### PR TITLE
chore: auto-label dependabot PRs with no-changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     labels:
       - dependencies
       - go
+      - no-changelog
     commit-message:
       prefix: "deps(go)"
     groups:
@@ -26,6 +27,7 @@ updates:
     labels:
       - dependencies
       - javascript
+      - no-changelog
     commit-message:
       prefix: "deps(web)"
     groups:
@@ -41,6 +43,7 @@ updates:
     labels:
       - dependencies
       - ci
+      - no-changelog
     commit-message:
       prefix: "deps(ci)"
 
@@ -51,5 +54,6 @@ updates:
     labels:
       - dependencies
       - docker
+      - no-changelog
     commit-message:
       prefix: "deps(docker)"


### PR DESCRIPTION
Prevents the Changelog-updated CI check from failing on dependency-only PRs, which by convention do not update `CHANGELOG.md`.

## Change
Adds `no-changelog` to the `labels:` list of each dependabot ecosystem (gomod, npm, github-actions, docker).

## Why
The `changelog` job in `.github/workflows/ci.yml` skips verification if a PR carries the `no-changelog` label. Dependabot PRs otherwise have to be labelled by hand every week.

## Follow-up
None.