### PR TITLE
feat LLMS-003: probe runner, ResultSink, and prober binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,20 @@ public APIs must add an entry under `## [Unreleased]`.
 - `docs/known-quirks.md` — first entries for OpenAI (HTTP 200 + error
   envelope, variable 401 codes)
 
+### Added (LLMS-003)
+- `internal/probes/runner.go` — `Runner` schedules `ProbeLightInference` for
+  every active (provider, model) pair at a configurable interval; bounded
+  concurrency via semaphore + `sync.WaitGroup`; per-probe context deadline;
+  functional options `WithInterval`, `WithProbeTimeout`, `WithConcurrency`
+- `ResultSink` interface decouples the runner from ingest; `LogSink` is the
+  default implementation (`slog.Info` per result)
+- `cmd/prober/main.go` — production binary: loads active providers and models
+  from Postgres via `pgstore`, matches each against the adapter registry,
+  then drives a `Runner`; config via `REGION_ID`, `DATABASE_URL`,
+  `PROBE_INTERVAL`, `PROBE_TIMEOUT`, `PROBE_CONCURRENCY` env vars
+- 5 unit tests with `goleak.VerifyTestMain`, bounded-concurrency tracking via
+  `atomic.Int64`, and a fake adapter + collect sink
+
 ### Added (LLMS-007)
 - `store/migrations/embed.go` — `//go:embed *.sql` bakes all migration
   files into the binary; no runtime path dependency

--- a/cmd/prober/main.go
+++ b/cmd/prober/main.go
@@ -1,10 +1,153 @@
-// Command prober schedules and runs probes against each registered provider.
+// Command prober loads active providers from Postgres, then schedules
+// ProbeLightInference calls for every active model at a fixed interval.
 //
-// Scaffolded by LLMS-001. Implementation lives in internal/probes.
+// Required environment variables:
+//
+//	DATABASE_URL  Postgres DSN (pgx5:// scheme not needed here — plain postgres:// works with pgx)
+//	REGION_ID     Identifier for this prober node, e.g. "us-west-2"
+//
+// Optional environment variables:
+//
+//	PROBE_INTERVAL    Duration between probe rounds (default: 60s)
+//	PROBE_TIMEOUT     Per-probe deadline (default: 30s)
+//	PROBE_CONCURRENCY Max simultaneous probes (default: 8)
 package main
 
-import "fmt"
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+	"github.com/llmstatus/llmstatus/internal/probes/adapters"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
 
 func main() {
-	fmt.Println("llmstatus prober (scaffold)")
+	regionID := requireEnv("REGION_ID")
+	dbURL := requireEnv("DATABASE_URL")
+
+	interval := envDuration("PROBE_INTERVAL", 60*time.Second)
+	timeout := envDuration("PROBE_TIMEOUT", 30*time.Second)
+	concurrency := envInt("PROBE_CONCURRENCY", 8)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		slog.Error("prober: cannot connect to postgres", "err", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	configs, err := loadProviderConfigs(ctx, pool)
+	if err != nil {
+		slog.Error("prober: cannot load providers", "err", err)
+		os.Exit(1)
+	}
+	if len(configs) == 0 {
+		slog.Warn("prober: no active providers with registered adapters — exiting")
+		os.Exit(0)
+	}
+
+	r := probes.New(
+		configs,
+		probes.LogSink{},
+		regionID,
+		probes.WithInterval(interval),
+		probes.WithProbeTimeout(timeout),
+		probes.WithConcurrency(concurrency),
+	)
+
+	slog.Info("prober: starting",
+		"region", regionID,
+		"providers", len(configs),
+		"interval", interval,
+		"concurrency", concurrency,
+	)
+
+	if err := r.Run(ctx); err != nil {
+		slog.Info("prober: stopped", "reason", err)
+	}
+}
+
+func loadProviderConfigs(ctx context.Context, pool *pgxpool.Pool) ([]probes.ProviderConfig, error) {
+	q := pgstore.New(pool)
+
+	providers, err := q.ListActiveProviders(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var configs []probes.ProviderConfig
+	for _, p := range providers {
+		adapter, ok := adapters.Get(p.ID)
+		if !ok {
+			slog.Warn("prober: no adapter registered, skipping", "provider", p.ID)
+			continue
+		}
+
+		models, err := q.ListModelsByProvider(ctx, p.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		modelIDs := make([]string, 0, len(models))
+		for _, m := range models {
+			modelIDs = append(modelIDs, m.ModelID)
+		}
+
+		if len(modelIDs) == 0 {
+			slog.Warn("prober: provider has no models, skipping", "provider", p.ID)
+			continue
+		}
+
+		configs = append(configs, probes.ProviderConfig{
+			Adapter: adapter,
+			Models:  modelIDs,
+		})
+	}
+	return configs, nil
+}
+
+func requireEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		slog.Error("prober: required environment variable not set", "key", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		slog.Warn("prober: invalid duration, using default", "key", key, "value", v, "default", def)
+		return def
+	}
+	return d
+}
+
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		slog.Warn("prober: invalid int, using default", "key", key, "value", v, "default", def)
+		return def
+	}
+	return n
 }

--- a/internal/probes/runner.go
+++ b/internal/probes/runner.go
@@ -1,0 +1,153 @@
+package probes
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	defaultInterval    = 60 * time.Second
+	defaultProbeTimeout = 30 * time.Second
+	defaultConcurrency = 8
+)
+
+// ResultSink receives probe results. Implementations include LogSink (default)
+// and an HTTP sink (added in LLMS-004 when the ingest API is ready).
+type ResultSink interface {
+	Receive(ctx context.Context, r ProbeResult) error
+}
+
+// ProviderConfig pairs an adapter with the models it should probe.
+// The caller (cmd/prober) builds this list from the DB and the adapter registry.
+type ProviderConfig struct {
+	Adapter Provider
+	Models  []string
+}
+
+// Runner schedules ProbeLightInference for each Provider+Model pair at a
+// fixed interval and emits results to a ResultSink.
+type Runner struct {
+	providers    []ProviderConfig
+	sink         ResultSink
+	regionID     string
+	interval     time.Duration
+	probeTimeout time.Duration
+	concurrency  int
+}
+
+// Option configures a Runner.
+type Option func(*Runner)
+
+// WithInterval sets the time between probe rounds (default 60s).
+func WithInterval(d time.Duration) Option {
+	return func(r *Runner) { r.interval = d }
+}
+
+// WithProbeTimeout sets the per-probe context deadline (default 30s).
+func WithProbeTimeout(d time.Duration) Option {
+	return func(r *Runner) { r.probeTimeout = d }
+}
+
+// WithConcurrency sets the maximum number of simultaneous probe goroutines
+// (default 8). Must be ≥ 1.
+func WithConcurrency(n int) Option {
+	return func(r *Runner) {
+		if n < 1 {
+			n = 1
+		}
+		r.concurrency = n
+	}
+}
+
+// New creates a Runner. providers must not be empty. sink must not be nil.
+func New(providers []ProviderConfig, sink ResultSink, regionID string, opts ...Option) *Runner {
+	r := &Runner{
+		providers:    providers,
+		sink:         sink,
+		regionID:     regionID,
+		interval:     defaultInterval,
+		probeTimeout: defaultProbeTimeout,
+		concurrency:  defaultConcurrency,
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// Run starts the probe loop. It fires one round immediately then repeats
+// every interval. Blocks until ctx is cancelled; returns ctx.Err().
+func (r *Runner) Run(ctx context.Context) error {
+	r.runOnce(ctx)
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			r.runOnce(ctx)
+		}
+	}
+}
+
+// runOnce fires one probe per (provider, model) pair concurrently within
+// the configured concurrency limit, then waits for all to complete.
+func (r *Runner) runOnce(ctx context.Context) {
+	sem := make(chan struct{}, r.concurrency)
+	var wg sync.WaitGroup
+
+	for i := range r.providers {
+		pc := r.providers[i]
+		for _, model := range pc.Models {
+			model := model
+			sem <- struct{}{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				r.dispatchProbe(ctx, pc, model)
+			}()
+		}
+	}
+	wg.Wait()
+}
+
+// dispatchProbe runs a single probe and forwards the result to the sink.
+func (r *Runner) dispatchProbe(ctx context.Context, pc ProviderConfig, model string) {
+	pCtx, cancel := context.WithTimeout(ctx, r.probeTimeout)
+	defer cancel()
+
+	result, _ := pc.Adapter.ProbeLightInference(pCtx, model)
+	result.RegionID = r.regionID
+
+	if err := r.sink.Receive(ctx, result); err != nil {
+		slog.Error("runner: sink error",
+			"provider", pc.Adapter.ID(),
+			"model", model,
+			"err", err,
+		)
+	}
+}
+
+// LogSink writes every ProbeResult to the structured logger. It is the
+// default sink used by cmd/prober when no ingest URL is configured.
+type LogSink struct{}
+
+// Receive logs the ProbeResult at Info level and returns nil.
+func (LogSink) Receive(_ context.Context, r ProbeResult) error {
+	slog.Info("probe",
+		"provider", r.ProviderID,
+		"model", r.Model,
+		"probe_type", r.ProbeType,
+		"success", r.Success,
+		"duration_ms", r.DurationMs,
+		"error_class", string(r.ErrorClass),
+		"region", r.RegionID,
+	)
+	return nil
+}

--- a/internal/probes/runner_test.go
+++ b/internal/probes/runner_test.go
@@ -1,0 +1,275 @@
+package probes_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+// ---- test doubles --------------------------------------------------------
+
+type fakeAdapter struct {
+	id     string
+	models []string
+	result probes.ProbeResult
+	delay  time.Duration
+	calls  atomic.Int64
+}
+
+func (a *fakeAdapter) ID() string       { return a.id }
+func (a *fakeAdapter) Models() []string { return a.models }
+
+func (a *fakeAdapter) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
+	a.calls.Add(1)
+	if a.delay > 0 {
+		select {
+		case <-time.After(a.delay):
+		case <-ctx.Done():
+			return probes.ProbeResult{}, ctx.Err()
+		}
+	}
+	r := a.result
+	r.ProviderID = a.id
+	r.Model = model
+	return r, nil
+}
+
+func (a *fakeAdapter) ProbeQuality(_ context.Context, model string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: a.id, ProbeType: "quality"}
+}
+func (a *fakeAdapter) ProbeEmbedding(_ context.Context, model string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: a.id, ProbeType: "embedding"}
+}
+func (a *fakeAdapter) ProbeStreaming(_ context.Context, model string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: a.id, ProbeType: "streaming"}
+}
+
+type collectSink struct {
+	mu      sync.Mutex
+	results []probes.ProbeResult
+}
+
+func (s *collectSink) Receive(_ context.Context, r probes.ProbeResult) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.results = append(s.results, r)
+	return nil
+}
+
+func (s *collectSink) snapshot() []probes.ProbeResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]probes.ProbeResult, len(s.results))
+	copy(out, s.results)
+	return out
+}
+
+// ---- tests ---------------------------------------------------------------
+
+func TestRunner_RunOnce_AllProbesDispatched(t *testing.T) {
+	adapter := &fakeAdapter{
+		id:     "test_provider",
+		models: []string{"model-a", "model-b", "model-c"},
+		result: probes.ProbeResult{Success: true, ProbeType: "light_inference"},
+	}
+	sink := &collectSink{}
+
+	r := probes.New(
+		[]probes.ProviderConfig{{Adapter: adapter, Models: adapter.Models()}},
+		sink,
+		"us-west-2",
+		probes.WithInterval(10*time.Second),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		_ = r.Run(ctx)
+	}()
+
+	// Wait until all 3 models have been probed at least once.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if int(adapter.calls.Load()) >= 3 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+
+	got := sink.snapshot()
+	if len(got) < 3 {
+		t.Errorf("expected ≥3 results, got %d", len(got))
+	}
+	for _, res := range got {
+		if res.RegionID != "us-west-2" {
+			t.Errorf("RegionID: got %q, want %q", res.RegionID, "us-west-2")
+		}
+		if res.ProviderID != "test_provider" {
+			t.Errorf("ProviderID: got %q, want %q", res.ProviderID, "test_provider")
+		}
+	}
+}
+
+func TestRunner_ContextCancellation_StopsCleanly(t *testing.T) {
+	adapter := &fakeAdapter{
+		id:     "slow_provider",
+		models: []string{"model-a"},
+		delay:  100 * time.Millisecond,
+		result: probes.ProbeResult{Success: true},
+	}
+	sink := &collectSink{}
+
+	r := probes.New(
+		[]probes.ProviderConfig{{Adapter: adapter, Models: adapter.Models()}},
+		sink,
+		"eu-west-1",
+		probes.WithInterval(500*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- r.Run(ctx)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+func TestRunner_BoundedConcurrency(t *testing.T) {
+	const numModels = 20
+	const maxConcurrency = 4
+
+	inFlight := atomic.Int64{}
+	maxSeen := atomic.Int64{}
+
+	slowAdapter := &fakeAdapter{
+		id:     "concurrent_provider",
+		models: make([]string, numModels),
+	}
+	for i := range slowAdapter.models {
+		slowAdapter.models[i] = "model"
+	}
+
+	// Override ProbeLightInference to track in-flight count.
+	trackingAdapter := &trackingConcurrencyAdapter{
+		fakeAdapter: slowAdapter,
+		inFlight:    &inFlight,
+		maxSeen:     &maxSeen,
+		holdFor:     20 * time.Millisecond,
+	}
+
+	sink := &collectSink{}
+	r := probes.New(
+		[]probes.ProviderConfig{{Adapter: trackingAdapter, Models: slowAdapter.Models()}},
+		sink,
+		"test",
+		probes.WithConcurrency(maxConcurrency),
+		probes.WithInterval(10*time.Second),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() { _ = r.Run(ctx) }()
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	if got := maxSeen.Load(); got > int64(maxConcurrency) {
+		t.Errorf("max concurrent probes = %d, want ≤ %d", got, maxConcurrency)
+	}
+}
+
+type trackingConcurrencyAdapter struct {
+	*fakeAdapter
+	inFlight *atomic.Int64
+	maxSeen  *atomic.Int64
+	holdFor  time.Duration
+}
+
+func (a *trackingConcurrencyAdapter) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
+	cur := a.inFlight.Add(1)
+	defer a.inFlight.Add(-1)
+
+	for {
+		seen := a.maxSeen.Load()
+		if cur <= seen || a.maxSeen.CompareAndSwap(seen, cur) {
+			break
+		}
+	}
+
+	select {
+	case <-time.After(a.holdFor):
+	case <-ctx.Done():
+	}
+	return probes.ProbeResult{Success: true, ProviderID: a.id, Model: model}, nil
+}
+
+func TestRunner_ProbeTimeout_Respected(t *testing.T) {
+	// Adapter that takes longer than the probe timeout.
+	adapter := &fakeAdapter{
+		id:     "tardy_provider",
+		models: []string{"slow-model"},
+		delay:  500 * time.Millisecond,
+		result: probes.ProbeResult{Success: true},
+	}
+	sink := &collectSink{}
+
+	r := probes.New(
+		[]probes.ProviderConfig{{Adapter: adapter, Models: adapter.Models()}},
+		sink,
+		"ap-northeast-1",
+		probes.WithProbeTimeout(50*time.Millisecond), // shorter than adapter delay
+		probes.WithInterval(10*time.Second),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() { _ = r.Run(ctx) }()
+
+	// Give the first runOnce time to fire and time out.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+
+	// The probe was called (even though it timed out).
+	if adapter.calls.Load() == 0 {
+		t.Error("expected probe to be called at least once")
+	}
+}
+
+func TestLogSink_Receive_NoError(t *testing.T) {
+	sink := probes.LogSink{}
+	err := sink.Receive(context.Background(), probes.ProbeResult{
+		ProviderID: "openai",
+		Model:      "gpt-4o-mini",
+		Success:    true,
+		DurationMs: 312,
+		RegionID:   "us-west-2",
+	})
+	if err != nil {
+		t.Errorf("LogSink.Receive returned unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/probes/runner.go`: `Runner` schedules `ProbeLightInference` per provider+model pair with bounded concurrency (semaphore + `sync.WaitGroup`) and per-probe context deadlines; functional options `WithInterval`, `WithProbeTimeout`, `WithConcurrency`
- `ResultSink` interface decouples runner from ingest; `LogSink` default writes via `slog.Info`
- `cmd/prober/main.go`: production binary that loads active providers/models from Postgres via `pgstore`, matches against the adapter registry, then drives a `Runner`; config via `REGION_ID`, `DATABASE_URL`, `PROBE_INTERVAL`, `PROBE_TIMEOUT`, `PROBE_CONCURRENCY` env vars

## Test plan
- [x] 5 unit tests: dispatch (all models hit), context cancellation (clean stop), bounded concurrency (≤ `maxConcurrency` in-flight), probe timeout (adapter delay > deadline), `LogSink` no-error
- [x] `goleak.VerifyTestMain` goroutine-leak guard
- [x] `go test -short -race ./internal/probes/...` — all pass
- [x] `go build ./...` — clean
- [x] `go vet ./cmd/prober/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)