### PR TITLE
feat LLMS-010: public read API — providers and incidents endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,22 @@ public APIs must add an entry under `## [Unreleased]`.
 - `docs/known-quirks.md` — first entries for OpenAI (HTTP 200 + error
   envelope, variable 401 codes)
 
+### Added (LLMS-010)
+- `internal/api/` — public read API using Go 1.22+ `net/http.ServeMux`
+  with method+path patterns (no external router dependency)
+- Endpoints: `GET /v1/providers`, `GET /v1/providers/{id}`,
+  `GET /v1/incidents`, `GET /v1/incidents/{id}`, `GET /healthz`
+- Provider status derived from the incidents table: critical ongoing →
+  `down`, major/minor ongoing → `degraded`, no ongoing → `operational`
+- `GET /v1/incidents/{id}` accepts both UUID and slug
+- Response envelope: `{"data": ..., "meta": {"generated_at": "...", "cache_ttl_s": 30}}`
+- `coalesceSlice` ensures all array fields serialize as `[]`, never JSON `null`
+- `Store` interface (subset of `pgstore.Querier`) keeps handlers decoupled
+  from the DB layer and fully testable with a fake store
+- `cmd/api/main.go` — server with graceful 5s shutdown; config via
+  `DATABASE_URL`, `API_ADDR`
+- 14 unit tests covering list, filter, get-by-uuid/slug, not-found, 405
+
 ### Added (LLMS-004)
 - `internal/store/influx/writer.go` — `Writer` interface + `lineWriter` implementation
   using the InfluxDB v2 line-protocol HTTP write endpoint (compatible with InfluxDB 3);

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,10 +1,83 @@
 // Command api serves the public read API for llmstatus.io.
 //
-// Scaffolded by LLMS-001. Implementation lives in internal/api.
+// Required environment variables:
+//
+//	DATABASE_URL  Postgres DSN (pgx connection string)
+//
+// Optional:
+//
+//	API_ADDR  Listen address (default ":8081")
 package main
 
-import "fmt"
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/llmstatus/llmstatus/internal/api"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
 
 func main() {
-	fmt.Println("llmstatus api (scaffold)")
+	dbURL := requireEnv("DATABASE_URL")
+	addr := envOr("API_ADDR", ":8081")
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		slog.Error("api: cannot connect to postgres", "err", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	store := pgstore.New(pool)
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      api.New(store),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	go func() {
+		slog.Info("api: listening", "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("api: server error", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	slog.Info("api: shutting down")
+
+	shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutCtx); err != nil {
+		slog.Error("api: shutdown error", "err", err)
+	}
+}
+
+func requireEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		slog.Error("api: required environment variable not set", "key", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
 }

--- a/internal/api/incidents.go
+++ b/internal/api/incidents.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// ---- response types ---------------------------------------------------------
+
+type incidentResponse struct {
+	ID              string     `json:"id"`
+	Slug            string     `json:"slug"`
+	ProviderID      string     `json:"provider_id"`
+	Severity        string     `json:"severity"`
+	Title           string     `json:"title"`
+	Description     *string    `json:"description,omitempty"`
+	Status          string     `json:"status"`
+	AffectedModels  []string   `json:"affected_models"`
+	AffectedRegions []string   `json:"affected_regions"`
+	StartedAt       time.Time  `json:"started_at"`
+	ResolvedAt      *time.Time `json:"resolved_at,omitempty"`
+	DetectionMethod string     `json:"detection_method"`
+	HumanReviewed   bool       `json:"human_reviewed"`
+}
+
+// ---- handlers ---------------------------------------------------------------
+
+func (s *Server) listIncidents(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	status := q.Get("status")
+	if status == "" || status == "all" {
+		status = ""
+	}
+
+	limit := parseIntParam(q.Get("limit"), 20, 1, 100)
+	offset := parseIntParam(q.Get("offset"), 0, 0, 1<<31)
+
+	var (
+		incidents []pgstore.Incident
+		err       error
+	)
+
+	if status != "" {
+		incidents, err = s.store.ListIncidentsByStatus(r.Context(), pgstore.ListIncidentsByStatusParams{
+			Status: status,
+			Limit:  int32(limit),
+			Offset: int32(offset),
+		})
+	} else {
+		incidents, err = s.store.ListIncidents(r.Context(), pgstore.ListIncidentsParams{
+			Limit:  int32(limit),
+			Offset: int32(offset),
+		})
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list incidents")
+		return
+	}
+
+	writeEnvelope(w, toIncidentResponses(incidents))
+}
+
+func (s *Server) getIncident(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var (
+		inc pgstore.Incident
+		err error
+	)
+
+	// Try UUID first; fall back to slug lookup.
+	if uid, uErr := uuid.Parse(id); uErr == nil {
+		inc, err = s.store.GetIncidentByID(r.Context(), uid)
+	} else {
+		inc, err = s.store.GetIncidentBySlug(r.Context(), id)
+	}
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "incident not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to fetch incident")
+		return
+	}
+
+	writeEnvelope(w, toIncidentResponse(inc))
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func toIncidentResponse(inc pgstore.Incident) incidentResponse {
+	return incidentResponse{
+		ID:              inc.ID.String(),
+		Slug:            inc.Slug,
+		ProviderID:      inc.ProviderID,
+		Severity:        inc.Severity,
+		Title:           inc.Title,
+		Description:     textVal(inc.Description),
+		Status:          inc.Status,
+		AffectedModels:  coalesceSlice(inc.AffectedModels),
+		AffectedRegions: coalesceSlice(inc.AffectedRegions),
+		StartedAt:       mustTime(inc.StartedAt),
+		ResolvedAt:      timeVal(inc.ResolvedAt),
+		DetectionMethod: inc.DetectionMethod,
+		HumanReviewed:   inc.HumanReviewed,
+	}
+}
+
+func toIncidentResponses(incidents []pgstore.Incident) []incidentResponse {
+	out := make([]incidentResponse, 0, len(incidents))
+	for _, inc := range incidents {
+		out = append(out, toIncidentResponse(inc))
+	}
+	return coalesceSlice(out)
+}
+
+func parseIntParam(v string, def, min, max int) int {
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < min {
+		return min
+	}
+	if n > max {
+		return max
+	}
+	return n
+}

--- a/internal/api/incidents_test.go
+++ b/internal/api/incidents_test.go
@@ -1,0 +1,137 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/llmstatus/llmstatus/internal/api"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+func TestListIncidents_Empty(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	rec := doGet(t, srv, "/v1/incidents")
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
+	}
+	var resp map[string]json.RawMessage
+	mustDecode(t, rec.Body, &resp)
+	if string(resp["data"]) != "[]" {
+		t.Errorf("data: got %s, want []", resp["data"])
+	}
+}
+
+func TestListIncidents_All(t *testing.T) {
+	store := &fakeStore{
+		incidents: []pgstore.Incident{
+			fixtureIncident("openai", "slug-1", "ongoing", "major"),
+			fixtureIncident("anthropic", "slug-2", "resolved", "minor"),
+		},
+	}
+	srv := api.New(store)
+
+	var body struct {
+		Data []struct {
+			Slug   string `json:"slug"`
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	mustDecode(t, doGet(t, srv, "/v1/incidents").Body, &body)
+
+	if len(body.Data) != 2 {
+		t.Fatalf("data length: got %d, want 2", len(body.Data))
+	}
+}
+
+func TestListIncidents_FilterByStatus(t *testing.T) {
+	store := &fakeStore{
+		incidents: []pgstore.Incident{
+			fixtureIncident("openai", "slug-1", "ongoing", "major"),
+			fixtureIncident("anthropic", "slug-2", "resolved", "minor"),
+		},
+	}
+	srv := api.New(store)
+
+	var body struct {
+		Data []struct {
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	mustDecode(t, doGet(t, srv, "/v1/incidents?status=ongoing").Body, &body)
+
+	if len(body.Data) != 1 {
+		t.Fatalf("data length: got %d, want 1", len(body.Data))
+	}
+	if body.Data[0].Status != "ongoing" {
+		t.Errorf("status: got %q, want ongoing", body.Data[0].Status)
+	}
+}
+
+func TestGetIncident_BySlug(t *testing.T) {
+	inc := fixtureIncident("openai", "2026-04-18-openai-down", "ongoing", "critical")
+	store := &fakeStore{incidents: []pgstore.Incident{inc}}
+	srv := api.New(store)
+
+	var body struct {
+		Data struct {
+			Slug            string `json:"slug"`
+			ProviderID      string `json:"provider_id"`
+			AffectedModels  []any  `json:"affected_models"`
+			AffectedRegions []any  `json:"affected_regions"`
+		} `json:"data"`
+	}
+	mustDecode(t, doGet(t, srv, "/v1/incidents/2026-04-18-openai-down").Body, &body)
+
+	if body.Data.Slug != "2026-04-18-openai-down" {
+		t.Errorf("slug: got %q", body.Data.Slug)
+	}
+	if body.Data.ProviderID != "openai" {
+		t.Errorf("provider_id: got %q", body.Data.ProviderID)
+	}
+	// nil slices must come back as [], not null
+	if body.Data.AffectedModels == nil {
+		t.Error("affected_models must not be null")
+	}
+	if body.Data.AffectedRegions == nil {
+		t.Error("affected_regions must not be null")
+	}
+}
+
+func TestGetIncident_ByUUID(t *testing.T) {
+	inc := fixtureIncident("openai", "slug-uuid", "resolved", "minor")
+	store := &fakeStore{incidents: []pgstore.Incident{inc}}
+	srv := api.New(store)
+
+	rec := doGet(t, srv, "/v1/incidents/"+inc.ID.String())
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
+	}
+}
+
+func TestGetIncident_NotFound(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	rec := doGet(t, srv, "/v1/incidents/no-such-slug")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", rec.Code)
+	}
+}
+
+func TestListIncidents_LimitParam(t *testing.T) {
+	incs := make([]pgstore.Incident, 10)
+	for i := range incs {
+		incs[i] = fixtureIncident("openai", "slug-"+string(rune('a'+i)), "resolved", "minor")
+	}
+	store := &fakeStore{incidents: incs}
+	srv := api.New(store)
+
+	var body struct {
+		Data []any `json:"data"`
+	}
+	mustDecode(t, doGet(t, srv, "/v1/incidents?limit=3").Body, &body)
+
+	if len(body.Data) != 3 {
+		t.Errorf("data length: got %d, want 3", len(body.Data))
+	}
+}

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// ---- response types ---------------------------------------------------------
+
+type providerSummary struct {
+	ID               string  `json:"id"`
+	Name             string  `json:"name"`
+	Category         string  `json:"category"`
+	Region           string  `json:"region"`
+	CurrentStatus    string  `json:"current_status"`
+	ActiveIncidentID *string `json:"active_incident_id,omitempty"`
+}
+
+type modelSummary struct {
+	ModelID     string `json:"model_id"`
+	DisplayName string `json:"display_name"`
+	ModelType   string `json:"model_type"`
+	Active      bool   `json:"active"`
+}
+
+type incidentRef struct {
+	ID        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	Severity  string    `json:"severity"`
+	Title     string    `json:"title"`
+	Status    string    `json:"status"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+type providerDetail struct {
+	providerSummary
+	StatusPageURL    *string       `json:"status_page_url,omitempty"`
+	DocumentationURL *string       `json:"documentation_url,omitempty"`
+	Models           []modelSummary `json:"models"`
+	ActiveIncidents  []incidentRef  `json:"active_incidents"`
+}
+
+// ---- handlers ---------------------------------------------------------------
+
+func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
+	providers, err := s.store.ListActiveProviders(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list providers")
+		return
+	}
+
+	ongoing, err := s.store.ListIncidentsByStatus(r.Context(), pgstore.ListIncidentsByStatusParams{
+		Status: "ongoing",
+		Limit:  200,
+		Offset: 0,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load incidents")
+		return
+	}
+
+	// Build a map from provider_id → highest-severity ongoing incident.
+	incidentByProvider := make(map[string]pgstore.Incident)
+	for _, inc := range ongoing {
+		existing, seen := incidentByProvider[inc.ProviderID]
+		if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
+			incidentByProvider[inc.ProviderID] = inc
+		}
+	}
+
+	summaries := make([]providerSummary, 0, len(providers))
+	for _, p := range providers {
+		s := toProviderSummary(p, incidentByProvider)
+		summaries = append(summaries, s)
+	}
+
+	writeEnvelope(w, summaries)
+}
+
+func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	p, err := s.store.GetProvider(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "provider not found")
+		return
+	}
+
+	models, err := s.store.ListModelsByProvider(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load models")
+		return
+	}
+
+	activeIncs, err := s.store.ListIncidentsByProvider(r.Context(), pgstore.ListIncidentsByProviderParams{
+		ProviderID: id,
+		Limit:      20,
+		Offset:     0,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load incidents")
+		return
+	}
+
+	// Build incident map for status derivation.
+	incMap := map[string]pgstore.Incident{}
+	if len(activeIncs) > 0 {
+		for _, inc := range activeIncs {
+			if inc.Status == "ongoing" {
+				existing, seen := incMap[inc.ProviderID]
+				if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
+					incMap[inc.ProviderID] = inc
+				}
+			}
+		}
+	}
+
+	detail := providerDetail{
+		providerSummary:  toProviderSummary(p, incMap),
+		StatusPageURL:    textVal(p.StatusPageUrl),
+		DocumentationURL: textVal(p.DocumentationUrl),
+		Models:           toModelSummaries(models),
+		ActiveIncidents:  toIncidentRefs(activeIncs),
+	}
+
+	writeEnvelope(w, detail)
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func toProviderSummary(p pgstore.Provider, incMap map[string]pgstore.Incident) providerSummary {
+	status, activeID := deriveStatus(p.ID, incMap)
+	return providerSummary{
+		ID:               p.ID,
+		Name:             p.Name,
+		Category:         p.Category,
+		Region:           p.Region,
+		CurrentStatus:    status,
+		ActiveIncidentID: activeID,
+	}
+}
+
+func deriveStatus(providerID string, incMap map[string]pgstore.Incident) (string, *string) {
+	inc, ok := incMap[providerID]
+	if !ok {
+		return "operational", nil
+	}
+	id := inc.ID.String()
+	switch inc.Severity {
+	case "critical":
+		return "down", &id
+	case "major":
+		return "degraded", &id
+	default:
+		return "degraded", &id
+	}
+}
+
+func severityRank(s string) int {
+	switch s {
+	case "critical":
+		return 3
+	case "major":
+		return 2
+	case "minor":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func toModelSummaries(models []pgstore.Model) []modelSummary {
+	out := make([]modelSummary, 0, len(models))
+	for _, m := range models {
+		out = append(out, modelSummary{
+			ModelID:     m.ModelID,
+			DisplayName: m.DisplayName,
+			ModelType:   m.ModelType,
+			Active:      m.Active,
+		})
+	}
+	return coalesceSlice(out)
+}
+
+func toIncidentRefs(incidents []pgstore.Incident) []incidentRef {
+	// Filter to ongoing only for the "active_incidents" field.
+	out := make([]incidentRef, 0)
+	for _, inc := range incidents {
+		if inc.Status != "ongoing" {
+			continue
+		}
+		out = append(out, incidentRef{
+			ID:        inc.ID.String(),
+			Slug:      inc.Slug,
+			Severity:  inc.Severity,
+			Title:     inc.Title,
+			Status:    inc.Status,
+			StartedAt: mustTime(inc.StartedAt),
+		})
+	}
+	return coalesceSlice(out)
+}

--- a/internal/api/providers_test.go
+++ b/internal/api/providers_test.go
@@ -1,0 +1,169 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/llmstatus/llmstatus/internal/api"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+func TestListProviders_Empty(t *testing.T) {
+	store := &fakeStore{}
+	srv := api.New(store)
+
+	rec := doGet(t, srv, "/v1/providers")
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
+	}
+	var resp map[string]json.RawMessage
+	mustDecode(t, rec.Body, &resp)
+	// data must be [] not null
+	if string(resp["data"]) != "[]" {
+		t.Errorf("data: got %s, want []", resp["data"])
+	}
+}
+
+func TestListProviders_Operational(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	srv := api.New(store)
+
+	rec := doGet(t, srv, "/v1/providers")
+
+	var body struct {
+		Data []struct {
+			ID            string  `json:"id"`
+			CurrentStatus string  `json:"current_status"`
+			ActiveInc     *string `json:"active_incident_id"`
+		} `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+
+	if len(body.Data) != 1 {
+		t.Fatalf("data length: got %d, want 1", len(body.Data))
+	}
+	if body.Data[0].ID != "openai" {
+		t.Errorf("ID: got %q, want openai", body.Data[0].ID)
+	}
+	if body.Data[0].CurrentStatus != "operational" {
+		t.Errorf("status: got %q, want operational", body.Data[0].CurrentStatus)
+	}
+	if body.Data[0].ActiveInc != nil {
+		t.Error("expected no active incident")
+	}
+}
+
+func TestListProviders_WithOngoingIncident(t *testing.T) {
+	inc := fixtureIncident("openai", "2026-04-18-openai-down", "ongoing", "critical")
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+		incidents: []pgstore.Incident{inc},
+	}
+	srv := api.New(store)
+
+	rec := doGet(t, srv, "/v1/providers")
+
+	var body struct {
+		Data []struct {
+			CurrentStatus    string  `json:"current_status"`
+			ActiveIncidentID *string `json:"active_incident_id"`
+		} `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+
+	if body.Data[0].CurrentStatus != "down" {
+		t.Errorf("status: got %q, want down", body.Data[0].CurrentStatus)
+	}
+	if body.Data[0].ActiveIncidentID == nil {
+		t.Error("expected active_incident_id to be set")
+	}
+}
+
+func TestGetProvider_Found(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("anthropic", "Anthropic")},
+		models:    []pgstore.Model{fixtureModel("anthropic", "claude-haiku-4-5-20251001")},
+	}
+	srv := api.New(store)
+
+	rec := doGet(t, srv, "/v1/providers/anthropic")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var body struct {
+		Data struct {
+			ID     string `json:"id"`
+			Models []struct {
+				ModelID string `json:"model_id"`
+			} `json:"models"`
+			ActiveIncidents []any `json:"active_incidents"`
+		} `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+
+	if body.Data.ID != "anthropic" {
+		t.Errorf("ID: got %q, want anthropic", body.Data.ID)
+	}
+	if len(body.Data.Models) != 1 {
+		t.Fatalf("models: got %d, want 1", len(body.Data.Models))
+	}
+	if body.Data.Models[0].ModelID != "claude-haiku-4-5-20251001" {
+		t.Errorf("model_id: got %q", body.Data.Models[0].ModelID)
+	}
+	if body.Data.ActiveIncidents == nil {
+		t.Error("active_incidents must not be null")
+	}
+}
+
+func TestGetProvider_NotFound(t *testing.T) {
+	store := &fakeStore{}
+	srv := api.New(store)
+
+	rec := doGet(t, srv, "/v1/providers/nonexistent")
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", rec.Code)
+	}
+}
+
+func TestHealthz(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	rec := doGet(t, srv, "/healthz")
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	// Go 1.22 ServeMux returns 405 for wrong method on a known path.
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want 405", rec.Code)
+	}
+}
+
+// ---- shared test helpers ----------------------------------------------------
+
+func doGet(t *testing.T, h http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func mustDecode(t *testing.T, body interface{ Read([]byte) (int, error) }, v any) {
+	t.Helper()
+	if err := json.NewDecoder(body).Decode(v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,105 @@
+// Package api implements the public read API for llmstatus.io.
+//
+// All endpoints are GET, unauthenticated, and return JSON wrapped in a
+// standard envelope:
+//
+//	{"data": ..., "meta": {"generated_at": "...", "cache_ttl_s": 30}}
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// compile-time check: pgstore.Queries satisfies Store.
+var _ Store = (*pgstore.Queries)(nil)
+
+// Server wires handlers to a ServeMux and owns the store reference.
+type Server struct {
+	store Store
+	mux   *http.ServeMux
+}
+
+// New creates a Server and registers all routes.
+func New(store Store) *Server {
+	s := &Server{store: store, mux: http.NewServeMux()}
+	s.registerRoutes()
+	return s
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *Server) registerRoutes() {
+	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
+	s.mux.HandleFunc("GET /v1/providers", s.listProviders)
+	s.mux.HandleFunc("GET /v1/providers/{id}", s.getProvider)
+	s.mux.HandleFunc("GET /v1/incidents", s.listIncidents)
+	s.mux.HandleFunc("GET /v1/incidents/{id}", s.getIncident)
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// ---- response helpers -------------------------------------------------------
+
+const cacheTTL = 30
+
+type meta struct {
+	GeneratedAt time.Time `json:"generated_at"`
+	CacheTTLS   int       `json:"cache_ttl_s"`
+}
+
+func writeMeta() meta { return meta{GeneratedAt: time.Now().UTC(), CacheTTLS: cacheTTL} }
+
+func writeJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+func writeEnvelope(w http.ResponseWriter, data any) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": data,
+		"meta": writeMeta(),
+	})
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// coalesceSlice ensures nil slices become [] in JSON (never null).
+func coalesceSlice[T any](s []T) []T {
+	if s == nil {
+		return []T{}
+	}
+	return s
+}
+
+// ---- pgtype converters ------------------------------------------------------
+
+func textVal(t pgtype.Text) *string {
+	if !t.Valid {
+		return nil
+	}
+	return &t.String
+}
+
+func timeVal(t pgtype.Timestamptz) *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	tm := t.Time.UTC()
+	return &tm
+}
+
+func mustTime(t pgtype.Timestamptz) time.Time {
+	return t.Time.UTC()
+}

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// Store is the subset of pgstore.Querier used by the read API.
+// pgstore.Queries satisfies this interface at compile time (see server.go).
+type Store interface {
+	ListActiveProviders(ctx context.Context) ([]pgstore.Provider, error)
+	GetProvider(ctx context.Context, id string) (pgstore.Provider, error)
+	ListModelsByProvider(ctx context.Context, providerID string) ([]pgstore.Model, error)
+	ListIncidents(ctx context.Context, arg pgstore.ListIncidentsParams) ([]pgstore.Incident, error)
+	ListIncidentsByProvider(ctx context.Context, arg pgstore.ListIncidentsByProviderParams) ([]pgstore.Incident, error)
+	ListIncidentsByStatus(ctx context.Context, arg pgstore.ListIncidentsByStatusParams) ([]pgstore.Incident, error)
+	GetIncidentByID(ctx context.Context, id uuid.UUID) (pgstore.Incident, error)
+	GetIncidentBySlug(ctx context.Context, slug string) (pgstore.Incident, error)
+}

--- a/internal/api/testhelpers_test.go
+++ b/internal/api/testhelpers_test.go
@@ -1,0 +1,131 @@
+package api_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// fakeStore implements api.Store for unit tests.
+type fakeStore struct {
+	providers []pgstore.Provider
+	models    []pgstore.Model
+	incidents []pgstore.Incident
+	err       error
+}
+
+func (f *fakeStore) ListActiveProviders(_ context.Context) ([]pgstore.Provider, error) {
+	return f.providers, f.err
+}
+
+func (f *fakeStore) GetProvider(_ context.Context, id string) (pgstore.Provider, error) {
+	for _, p := range f.providers {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return pgstore.Provider{}, pgx.ErrNoRows
+}
+
+func (f *fakeStore) ListModelsByProvider(_ context.Context, providerID string) ([]pgstore.Model, error) {
+	var out []pgstore.Model
+	for _, m := range f.models {
+		if m.ProviderID == providerID {
+			out = append(out, m)
+		}
+	}
+	return out, f.err
+}
+
+func (f *fakeStore) ListIncidents(_ context.Context, arg pgstore.ListIncidentsParams) ([]pgstore.Incident, error) {
+	end := int(arg.Offset) + int(arg.Limit)
+	if end > len(f.incidents) {
+		end = len(f.incidents)
+	}
+	if int(arg.Offset) >= len(f.incidents) {
+		return []pgstore.Incident{}, f.err
+	}
+	return f.incidents[arg.Offset:end], f.err
+}
+
+func (f *fakeStore) ListIncidentsByProvider(_ context.Context, arg pgstore.ListIncidentsByProviderParams) ([]pgstore.Incident, error) {
+	var out []pgstore.Incident
+	for _, inc := range f.incidents {
+		if inc.ProviderID == arg.ProviderID {
+			out = append(out, inc)
+		}
+	}
+	return out, f.err
+}
+
+func (f *fakeStore) ListIncidentsByStatus(_ context.Context, arg pgstore.ListIncidentsByStatusParams) ([]pgstore.Incident, error) {
+	var out []pgstore.Incident
+	for _, inc := range f.incidents {
+		if inc.Status == arg.Status {
+			out = append(out, inc)
+		}
+	}
+	return out, f.err
+}
+
+func (f *fakeStore) GetIncidentByID(_ context.Context, id uuid.UUID) (pgstore.Incident, error) {
+	for _, inc := range f.incidents {
+		if inc.ID == id {
+			return inc, nil
+		}
+	}
+	return pgstore.Incident{}, pgx.ErrNoRows
+}
+
+func (f *fakeStore) GetIncidentBySlug(_ context.Context, slug string) (pgstore.Incident, error) {
+	for _, inc := range f.incidents {
+		if inc.Slug == slug {
+			return inc, nil
+		}
+	}
+	return pgstore.Incident{}, pgx.ErrNoRows
+}
+
+// ---- fixtures ---------------------------------------------------------------
+
+func fixtureProvider(id, name string) pgstore.Provider {
+	return pgstore.Provider{
+		ID:       id,
+		Name:     name,
+		Category: "official",
+		Region:   "global",
+		Active:   true,
+	}
+}
+
+func fixtureModel(providerID, modelID string) pgstore.Model {
+	return pgstore.Model{
+		ID:          1,
+		ProviderID:  providerID,
+		ModelID:     modelID,
+		DisplayName: modelID,
+		ModelType:   "chat",
+		Active:      true,
+	}
+}
+
+func fixtureIncident(providerID, slug, status, severity string) pgstore.Incident {
+	return pgstore.Incident{
+		ID:         uuid.New(),
+		Slug:       slug,
+		ProviderID: providerID,
+		Severity:   severity,
+		Title:      "Test incident",
+		Status:     status,
+		StartedAt: pgtype.Timestamptz{
+			Time:  time.Now().UTC(),
+			Valid: true,
+		},
+		DetectionMethod: "auto",
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/api/` — Go 1.22+ `net/http.ServeMux` with method+path patterns, no external router
- `GET /v1/providers` — list active providers; status derived from incidents table (operational/degraded/down)
- `GET /v1/providers/{id}` — provider detail with models + active incidents
- `GET /v1/incidents` — list incidents; `?status=ongoing|resolved|all`, `?limit`, `?offset`
- `GET /v1/incidents/{id}` — get by UUID or slug
- `GET /healthz` — load-balancer probe
- `Store` interface decouples handlers from `pgstore.Queries` — fully testable without DB
- `coalesceSlice` ensures array fields are always `[]`, never `null`
- `cmd/api/main.go` wired up with graceful shutdown

## Test plan
- [x] 14 unit tests: list/get for providers and incidents, status derivation, UUID/slug routing, null-coalescing, 405
- [x] `go test -short -race ./...` — full suite green
- [x] `go build ./...` — clean

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)