### PR TITLE
feat LLMS-009: event detector (rules 6.1 + 6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,25 @@ public APIs must add an entry under `## [Unreleased]`.
 - `docs/known-quirks.md` — first entries for OpenAI (HTTP 200 + error
   envelope, variable 401 codes)
 
+### Added (LLMS-009)
+- `internal/detector/` — event-detection subsystem with three layers:
+  - `reader.go` — `ProbeReader` interface + `InfluxReader` that queries
+    InfluxDB 3 via `POST /api/v3/query_sql`; no gRPC dependency
+  - `rules.go` — `EvaluateRules` applies Rule 6.1 (≥50% error rate in 5m →
+    `provider_down`, critical) and Rule 6.2 (>5% in 10m → `elevated_errors`,
+    major); Rule 6.1 suppresses Rule 6.2 for the same provider;
+    minimum 3 probes required before any rule fires
+  - `runner.go` — `Runner` fetches stats, evaluates rules, deduplicates via
+    `GetOngoingByProviderAndRule`, creates incidents, and auto-resolves
+    stale auto-detected incidents; manual incidents are never auto-resolved
+- `cmd/detector/main.go` — production binary with graceful shutdown via
+  `signal.NotifyContext`; config via `DATABASE_URL`, `INFLUX_HOST`,
+  `INFLUX_TOKEN`, `INFLUX_DATABASE`, `DETECTOR_INTERVAL` (default 60s)
+- Incident slug format: `YYYY-MM-DD-{provider_id}-{rule-with-dashes}`
+  (e.g. `2026-04-18-openai-provider-down`)
+- 17 unit tests: 8 rule-evaluation cases, 3 InfluxReader cases (httptest),
+  6 runner cases with `fakeReader` + `fakeIncidentStore`
+
 ### Added (LLMS-010)
 - `internal/api/` — public read API using Go 1.22+ `net/http.ServeMux`
   with method+path patterns (no external router dependency)

--- a/cmd/detector/main.go
+++ b/cmd/detector/main.go
@@ -1,10 +1,85 @@
-// Command detector runs the event-detection rules over stored probe data.
+// Command detector evaluates detection rules every interval and manages
+// incidents in Postgres automatically.
 //
-// Scaffolded by LLMS-001. Implementation lives in internal/detector.
+// Required environment variables:
+//
+//	DATABASE_URL      Postgres DSN (pgx connection string)
+//	INFLUX_HOST       InfluxDB 3 base URL (e.g. "https://us-east-1-1.aws.cloud2.influxdata.com")
+//	INFLUX_TOKEN      InfluxDB auth token
+//	INFLUX_DATABASE   InfluxDB database / bucket name
+//
+// Optional:
+//
+//	DETECTOR_INTERVAL  Evaluation interval (default "60s")
 package main
 
-import "fmt"
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/llmstatus/llmstatus/internal/detector"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
 
 func main() {
-	fmt.Println("llmstatus detector (scaffold)")
+	dbURL := requireEnv("DATABASE_URL")
+	influxHost := requireEnv("INFLUX_HOST")
+	influxToken := requireEnv("INFLUX_TOKEN")
+	influxDB := requireEnv("INFLUX_DATABASE")
+	interval := parseDuration(envOr("DETECTOR_INTERVAL", "60s"))
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		slog.Error("detector: cannot connect to postgres", "err", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	reader := detector.NewInfluxReader(detector.InfluxReaderConfig{
+		Host:     influxHost,
+		Token:    influxToken,
+		Database: influxDB,
+	}, nil)
+
+	store := pgstore.New(pool)
+	runner := detector.New(reader, store, interval)
+
+	slog.Info("detector: starting", "interval", interval)
+	if err := runner.Run(ctx); err != nil {
+		slog.Info("detector: stopped", "reason", err)
+	}
+}
+
+func requireEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		slog.Error("detector: required environment variable not set", "key", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func parseDuration(s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		slog.Error("detector: invalid DETECTOR_INTERVAL", "value", s, "err", err)
+		os.Exit(1)
+	}
+	return d
 }

--- a/internal/detector/reader.go
+++ b/internal/detector/reader.go
@@ -1,0 +1,116 @@
+package detector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ProbeStats holds aggregated probe counts for one provider over a time window.
+type ProbeStats struct {
+	ProviderID string
+	Total      int64
+	Errors     int64
+}
+
+// ErrorRate returns the fraction of failed probes, or 0 when Total is 0.
+func (s ProbeStats) ErrorRate() float64 {
+	if s.Total == 0 {
+		return 0
+	}
+	return float64(s.Errors) / float64(s.Total)
+}
+
+// ProbeReader fetches aggregated probe statistics from the time-series store.
+type ProbeReader interface {
+	// ErrorRateByProvider returns per-provider probe stats for the given window.
+	ErrorRateByProvider(ctx context.Context, window time.Duration) ([]ProbeStats, error)
+}
+
+// InfluxReaderConfig holds connection parameters for the InfluxDB 3 query API.
+type InfluxReaderConfig struct {
+	Host     string // e.g. "https://us-east-1-1.aws.cloud2.influxdata.com"
+	Token    string
+	Database string
+}
+
+// NewInfluxReader returns a ProbeReader that queries InfluxDB 3 via the
+// HTTP SQL endpoint (POST /api/v3/query_sql), which requires no gRPC dep.
+func NewInfluxReader(cfg InfluxReaderConfig, client *http.Client) ProbeReader {
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &influxReader{cfg: cfg, client: client}
+}
+
+type influxReader struct {
+	cfg    InfluxReaderConfig
+	client *http.Client
+}
+
+func (r *influxReader) ErrorRateByProvider(ctx context.Context, window time.Duration) ([]ProbeStats, error) {
+	sql := fmt.Sprintf(
+		`SELECT provider_id,
+		        COUNT(*) AS total,
+		        COUNT(*) FILTER (WHERE success = false) AS errors
+		 FROM probes
+		 WHERE time >= now() - INTERVAL '%d seconds'
+		 GROUP BY provider_id`,
+		int(window.Seconds()),
+	)
+
+	body, err := json.Marshal(map[string]string{
+		"q":      sql,
+		"db":     r.cfg.Database,
+		"format": "json",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("detector: marshal query: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.cfg.Host+"/api/v3/query_sql", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("detector: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+r.cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("detector: query influx: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("detector: influx status %d: %s", resp.StatusCode, detail)
+	}
+
+	// InfluxDB 3 returns a JSON array of objects with format=json.
+	var rows []struct {
+		ProviderID string  `json:"provider_id"`
+		Total      float64 `json:"total"` // JSON numbers decode as float64
+		Errors     float64 `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("detector: decode response: %w", err)
+	}
+
+	stats := make([]ProbeStats, 0, len(rows))
+	for _, row := range rows {
+		if row.ProviderID == "" {
+			continue
+		}
+		stats = append(stats, ProbeStats{
+			ProviderID: row.ProviderID,
+			Total:      int64(row.Total),
+			Errors:     int64(row.Errors),
+		})
+	}
+	return stats, nil
+}

--- a/internal/detector/reader_test.go
+++ b/internal/detector/reader_test.go
@@ -1,0 +1,90 @@
+package detector
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestInfluxReader_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v3/query_sql" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Token testtoken" {
+			t.Errorf("Authorization: got %q", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"provider_id":"openai","total":10,"errors":3},
+			{"provider_id":"anthropic","total":5,"errors":0}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewInfluxReader(InfluxReaderConfig{
+		Host:     srv.URL,
+		Token:    "testtoken",
+		Database: "llmstatus",
+	}, nil)
+
+	stats, err := reader.ErrorRateByProvider(context.Background(), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("ErrorRateByProvider: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+
+	byProvider := make(map[string]ProbeStats)
+	for _, s := range stats {
+		byProvider[s.ProviderID] = s
+	}
+
+	openai := byProvider["openai"]
+	if openai.Total != 10 || openai.Errors != 3 {
+		t.Errorf("openai stats: got total=%d errors=%d", openai.Total, openai.Errors)
+	}
+	if openai.ErrorRate() < 0.29 || openai.ErrorRate() > 0.31 {
+		t.Errorf("openai error rate: got %f, want ~0.30", openai.ErrorRate())
+	}
+}
+
+func TestInfluxReader_InfluxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code":"unauthorized"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewInfluxReader(InfluxReaderConfig{
+		Host: srv.URL, Token: "bad", Database: "db",
+	}, nil)
+
+	_, err := reader.ErrorRateByProvider(context.Background(), 5*time.Minute)
+	if err == nil {
+		t.Error("expected error on 401, got nil")
+	}
+}
+
+func TestInfluxReader_EmptyResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewInfluxReader(InfluxReaderConfig{
+		Host: srv.URL, Token: "t", Database: "db",
+	}, nil)
+
+	stats, err := reader.ErrorRateByProvider(context.Background(), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected 0 stats, got %d", len(stats))
+	}
+}

--- a/internal/detector/rules.go
+++ b/internal/detector/rules.go
@@ -1,0 +1,75 @@
+package detector
+
+const (
+	RuleProviderDown    = "provider_down"
+	RuleElevatedErrors  = "elevated_errors"
+
+	downThreshold     = 0.50
+	elevatedThreshold = 0.05
+	minProbeCount     = int64(3) // require at least 3 probes before firing
+)
+
+// Detection is a rule match for a single provider.
+type Detection struct {
+	ProviderID  string
+	Rule        string // RuleProviderDown | RuleElevatedErrors
+	Severity    string // "critical" | "major"
+	ErrorRate   float64
+	TotalProbes int64
+}
+
+// EvaluateRules applies rules 6.1 and 6.2 to the supplied stats.
+//
+// stats5m  — probe stats over the last 5 minutes  (rule 6.1 window)
+// stats10m — probe stats over the last 10 minutes (rule 6.2 window)
+//
+// Rule 6.1 (DOWN) takes precedence: a provider that is "down" will not also
+// appear as "elevated_errors".
+func EvaluateRules(stats5m, stats10m []ProbeStats) []Detection {
+	// Index 5-minute stats by provider for O(1) lookup.
+	byProvider5m := make(map[string]ProbeStats, len(stats5m))
+	for _, s := range stats5m {
+		byProvider5m[s.ProviderID] = s
+	}
+
+	var detections []Detection
+	downProviders := make(map[string]struct{})
+
+	// Rule 6.1 — provider is DOWN.
+	for _, s := range stats5m {
+		if s.Total < minProbeCount {
+			continue
+		}
+		if s.ErrorRate() > downThreshold {
+			detections = append(detections, Detection{
+				ProviderID:  s.ProviderID,
+				Rule:        RuleProviderDown,
+				Severity:    "critical",
+				ErrorRate:   s.ErrorRate(),
+				TotalProbes: s.Total,
+			})
+			downProviders[s.ProviderID] = struct{}{}
+		}
+	}
+
+	// Rule 6.2 — elevated errors (skip providers already flagged as down).
+	for _, s := range stats10m {
+		if _, isDown := downProviders[s.ProviderID]; isDown {
+			continue
+		}
+		if s.Total < minProbeCount {
+			continue
+		}
+		if s.ErrorRate() > elevatedThreshold {
+			detections = append(detections, Detection{
+				ProviderID:  s.ProviderID,
+				Rule:        RuleElevatedErrors,
+				Severity:    "major",
+				ErrorRate:   s.ErrorRate(),
+				TotalProbes: s.Total,
+			})
+		}
+	}
+
+	return detections
+}

--- a/internal/detector/rules_test.go
+++ b/internal/detector/rules_test.go
@@ -1,0 +1,126 @@
+package detector
+
+import (
+	"testing"
+)
+
+func TestEvaluateRules_NoProbes(t *testing.T) {
+	got := EvaluateRules(nil, nil)
+	if len(got) != 0 {
+		t.Errorf("expected 0 detections on empty stats, got %d", len(got))
+	}
+}
+
+func TestEvaluateRules_Down(t *testing.T) {
+	stats5m := []ProbeStats{
+		{ProviderID: "openai", Total: 10, Errors: 6}, // 60% error rate
+	}
+	detections := EvaluateRules(stats5m, nil)
+
+	if len(detections) != 1 {
+		t.Fatalf("expected 1 detection, got %d", len(detections))
+	}
+	d := detections[0]
+	if d.ProviderID != "openai" {
+		t.Errorf("ProviderID: got %q, want openai", d.ProviderID)
+	}
+	if d.Rule != RuleProviderDown {
+		t.Errorf("Rule: got %q, want %q", d.Rule, RuleProviderDown)
+	}
+	if d.Severity != "critical" {
+		t.Errorf("Severity: got %q, want critical", d.Severity)
+	}
+}
+
+func TestEvaluateRules_Down_TooFewProbes(t *testing.T) {
+	// Below minProbeCount — should not fire even with 100% error rate.
+	stats5m := []ProbeStats{
+		{ProviderID: "openai", Total: 2, Errors: 2},
+	}
+	got := EvaluateRules(stats5m, nil)
+	if len(got) != 0 {
+		t.Errorf("expected 0 detections with only 2 probes, got %d", len(got))
+	}
+}
+
+func TestEvaluateRules_ElevatedErrors(t *testing.T) {
+	stats10m := []ProbeStats{
+		{ProviderID: "anthropic", Total: 20, Errors: 2}, // 10% error rate
+	}
+	detections := EvaluateRules(nil, stats10m)
+
+	if len(detections) != 1 {
+		t.Fatalf("expected 1 detection, got %d", len(detections))
+	}
+	d := detections[0]
+	if d.Rule != RuleElevatedErrors {
+		t.Errorf("Rule: got %q, want %q", d.Rule, RuleElevatedErrors)
+	}
+	if d.Severity != "major" {
+		t.Errorf("Severity: got %q, want major", d.Severity)
+	}
+}
+
+func TestEvaluateRules_Down_SuppressesElevated(t *testing.T) {
+	// Provider appears in both 5m and 10m stats — down rule wins.
+	stats5m := []ProbeStats{
+		{ProviderID: "openai", Total: 10, Errors: 6}, // 60% — DOWN
+	}
+	stats10m := []ProbeStats{
+		{ProviderID: "openai", Total: 20, Errors: 4}, // 20% — would be elevated
+	}
+	detections := EvaluateRules(stats5m, stats10m)
+
+	if len(detections) != 1 {
+		t.Fatalf("expected exactly 1 detection (down, not both), got %d", len(detections))
+	}
+	if detections[0].Rule != RuleProviderDown {
+		t.Errorf("expected provider_down rule, got %q", detections[0].Rule)
+	}
+}
+
+func TestEvaluateRules_Operational(t *testing.T) {
+	stats5m := []ProbeStats{
+		{ProviderID: "openai", Total: 10, Errors: 0},
+	}
+	stats10m := []ProbeStats{
+		{ProviderID: "openai", Total: 20, Errors: 1}, // 5% — at threshold, not above
+	}
+	got := EvaluateRules(stats5m, stats10m)
+	if len(got) != 0 {
+		t.Errorf("expected 0 detections at 5%% error rate, got %d", len(got))
+	}
+}
+
+func TestEvaluateRules_MultipleProviders(t *testing.T) {
+	stats5m := []ProbeStats{
+		{ProviderID: "openai", Total: 10, Errors: 6},    // DOWN
+		{ProviderID: "anthropic", Total: 10, Errors: 0}, // OK
+	}
+	stats10m := []ProbeStats{
+		{ProviderID: "deepseek", Total: 10, Errors: 2}, // elevated (20%)
+	}
+	detections := EvaluateRules(stats5m, stats10m)
+
+	if len(detections) != 2 {
+		t.Fatalf("expected 2 detections (openai down + deepseek elevated), got %d", len(detections))
+	}
+}
+
+func TestProbeStats_ErrorRate(t *testing.T) {
+	cases := []struct {
+		total, errors int64
+		want          float64
+	}{
+		{0, 0, 0},
+		{10, 5, 0.5},
+		{10, 0, 0},
+		{10, 10, 1.0},
+	}
+	for _, tc := range cases {
+		s := ProbeStats{Total: tc.total, Errors: tc.errors}
+		if got := s.ErrorRate(); got != tc.want {
+			t.Errorf("ErrorRate(%d/%d) = %f, want %f", tc.errors, tc.total, got, tc.want)
+		}
+	}
+}

--- a/internal/detector/runner.go
+++ b/internal/detector/runner.go
@@ -1,0 +1,184 @@
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// IncidentStore is the subset of pgstore.Querier used by the detector.
+type IncidentStore interface {
+	GetOngoingByProviderAndRule(ctx context.Context, arg pgstore.GetOngoingByProviderAndRuleParams) (pgstore.Incident, error)
+	CreateIncident(ctx context.Context, arg pgstore.CreateIncidentParams) (pgstore.Incident, error)
+	ResolveIncident(ctx context.Context, arg pgstore.ResolveIncidentParams) error
+	ListIncidentsByStatus(ctx context.Context, arg pgstore.ListIncidentsByStatusParams) ([]pgstore.Incident, error)
+}
+
+// compile-time check: pgstore.Queries satisfies IncidentStore.
+var _ IncidentStore = (*pgstore.Queries)(nil)
+
+// Runner periodically evaluates detection rules and manages incidents.
+type Runner struct {
+	reader   ProbeReader
+	store    IncidentStore
+	interval time.Duration
+}
+
+// New creates a Runner with the given reader, store, and tick interval.
+func New(reader ProbeReader, store IncidentStore, interval time.Duration) *Runner {
+	return &Runner{reader: reader, store: store, interval: interval}
+}
+
+// Run evaluates rules immediately, then repeats every interval.
+// Blocks until ctx is cancelled; returns ctx.Err().
+func (r *Runner) Run(ctx context.Context) error {
+	r.runOnce(ctx)
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			r.runOnce(ctx)
+		}
+	}
+}
+
+func (r *Runner) runOnce(ctx context.Context) {
+	stats5m, err := r.reader.ErrorRateByProvider(ctx, 5*time.Minute)
+	if err != nil {
+		slog.Error("detector: read 5m stats", "err", err)
+		return
+	}
+	stats10m, err := r.reader.ErrorRateByProvider(ctx, 10*time.Minute)
+	if err != nil {
+		slog.Error("detector: read 10m stats", "err", err)
+		return
+	}
+
+	detections := EvaluateRules(stats5m, stats10m)
+
+	for _, d := range detections {
+		r.ensureIncident(ctx, d)
+	}
+
+	r.resolveStale(ctx, detections)
+}
+
+// ensureIncident creates a new incident for the detection if none is already
+// ongoing for the same provider+rule pair (deduplication).
+func (r *Runner) ensureIncident(ctx context.Context, d Detection) {
+	_, err := r.store.GetOngoingByProviderAndRule(ctx, pgstore.GetOngoingByProviderAndRuleParams{
+		ProviderID:    d.ProviderID,
+		DetectionRule: pgtype.Text{String: d.Rule, Valid: true},
+	})
+	if err == nil {
+		return // already ongoing — do nothing
+	}
+	if !isNotFound(err) {
+		slog.Error("detector: check ongoing incident", "provider", d.ProviderID, "rule", d.Rule, "err", err)
+		return
+	}
+
+	now := time.Now().UTC()
+	snapshot, _ := json.Marshal(map[string]any{
+		"error_rate":   fmt.Sprintf("%.4f", d.ErrorRate),
+		"total_probes": d.TotalProbes,
+		"detected_at":  now.Format(time.RFC3339),
+	})
+
+	if _, err := r.store.CreateIncident(ctx, pgstore.CreateIncidentParams{
+		Slug:            incidentSlug(d.ProviderID, d.Rule, now),
+		ProviderID:      d.ProviderID,
+		Severity:        d.Severity,
+		Title:           incidentTitle(d.ProviderID, d.Rule),
+		Status:          "ongoing",
+		AffectedModels:  []string{},
+		AffectedRegions: []string{},
+		StartedAt:       pgtype.Timestamptz{Time: now, Valid: true},
+		DetectionMethod: "auto",
+		DetectionRule:   pgtype.Text{String: d.Rule, Valid: true},
+		MetricsSnapshot: json.RawMessage(snapshot),
+	}); err != nil {
+		slog.Error("detector: create incident", "provider", d.ProviderID, "rule", d.Rule, "err", err)
+		return
+	}
+
+	slog.Info("detector: incident created",
+		"provider", d.ProviderID,
+		"rule", d.Rule,
+		"severity", d.Severity,
+		"error_rate", fmt.Sprintf("%.1f%%", d.ErrorRate*100),
+	)
+}
+
+// resolveStale resolves auto-detected ongoing incidents whose rule is no
+// longer firing.
+func (r *Runner) resolveStale(ctx context.Context, active []Detection) {
+	ongoing, err := r.store.ListIncidentsByStatus(ctx, pgstore.ListIncidentsByStatusParams{
+		Status: "ongoing",
+		Limit:  200,
+		Offset: 0,
+	})
+	if err != nil {
+		slog.Error("detector: list ongoing incidents", "err", err)
+		return
+	}
+
+	activeSet := make(map[string]struct{}, len(active))
+	for _, d := range active {
+		activeSet[d.ProviderID+"|"+d.Rule] = struct{}{}
+	}
+
+	now := time.Now().UTC()
+	for _, inc := range ongoing {
+		if inc.DetectionMethod != "auto" || !inc.DetectionRule.Valid {
+			continue
+		}
+		key := inc.ProviderID + "|" + inc.DetectionRule.String
+		if _, firing := activeSet[key]; firing {
+			continue
+		}
+		if err := r.store.ResolveIncident(ctx, pgstore.ResolveIncidentParams{
+			ID:         inc.ID,
+			ResolvedAt: pgtype.Timestamptz{Time: now, Valid: true},
+		}); err != nil {
+			slog.Error("detector: resolve incident", "id", inc.ID, "err", err)
+			continue
+		}
+		slog.Info("detector: incident resolved", "provider", inc.ProviderID, "rule", inc.DetectionRule.String)
+	}
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func incidentSlug(providerID, rule string, t time.Time) string {
+	suffix := strings.ReplaceAll(rule, "_", "-")
+	return t.Format("2006-01-02") + "-" + providerID + "-" + suffix
+}
+
+func incidentTitle(providerID, rule string) string {
+	switch rule {
+	case RuleProviderDown:
+		return providerID + " is experiencing major disruption"
+	case RuleElevatedErrors:
+		return providerID + " elevated errors detected"
+	default:
+		return providerID + " " + rule
+	}
+}
+
+func isNotFound(err error) bool {
+	return err == pgx.ErrNoRows
+}

--- a/internal/detector/runner_test.go
+++ b/internal/detector/runner_test.go
@@ -1,0 +1,201 @@
+package detector
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// ---- fake ProbeReader -------------------------------------------------------
+
+type fakeReader struct {
+	stats5m  []ProbeStats
+	stats10m []ProbeStats
+	err      error
+}
+
+func (f *fakeReader) ErrorRateByProvider(_ context.Context, window time.Duration) ([]ProbeStats, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if window <= 5*time.Minute {
+		return f.stats5m, nil
+	}
+	return f.stats10m, nil
+}
+
+// ---- fake IncidentStore -----------------------------------------------------
+
+type fakeIncidentStore struct {
+	incidents []pgstore.Incident
+	created   []pgstore.CreateIncidentParams
+	resolved  []pgstore.ResolveIncidentParams
+}
+
+func (f *fakeIncidentStore) GetOngoingByProviderAndRule(_ context.Context, arg pgstore.GetOngoingByProviderAndRuleParams) (pgstore.Incident, error) {
+	for _, inc := range f.incidents {
+		if inc.ProviderID == arg.ProviderID &&
+			inc.DetectionRule.Valid &&
+			inc.DetectionRule.String == arg.DetectionRule.String &&
+			inc.Status == "ongoing" {
+			return inc, nil
+		}
+	}
+	return pgstore.Incident{}, pgx.ErrNoRows
+}
+
+func (f *fakeIncidentStore) CreateIncident(_ context.Context, arg pgstore.CreateIncidentParams) (pgstore.Incident, error) {
+	f.created = append(f.created, arg)
+	inc := pgstore.Incident{
+		ID:              uuid.New(),
+		Slug:            arg.Slug,
+		ProviderID:      arg.ProviderID,
+		Severity:        arg.Severity,
+		Title:           arg.Title,
+		Status:          arg.Status,
+		DetectionMethod: arg.DetectionMethod,
+		DetectionRule:   arg.DetectionRule,
+	}
+	f.incidents = append(f.incidents, inc)
+	return inc, nil
+}
+
+func (f *fakeIncidentStore) ResolveIncident(_ context.Context, arg pgstore.ResolveIncidentParams) error {
+	f.resolved = append(f.resolved, arg)
+	for i, inc := range f.incidents {
+		if inc.ID == arg.ID {
+			f.incidents[i].Status = "resolved"
+		}
+	}
+	return nil
+}
+
+func (f *fakeIncidentStore) ListIncidentsByStatus(_ context.Context, arg pgstore.ListIncidentsByStatusParams) ([]pgstore.Incident, error) {
+	var out []pgstore.Incident
+	for _, inc := range f.incidents {
+		if inc.Status == arg.Status {
+			out = append(out, inc)
+		}
+	}
+	return out, nil
+}
+
+// ---- tests ------------------------------------------------------------------
+
+func TestRunner_CreatesIncident_WhenDown(t *testing.T) {
+	reader := &fakeReader{
+		stats5m: []ProbeStats{{ProviderID: "openai", Total: 10, Errors: 6}},
+	}
+	store := &fakeIncidentStore{}
+	r := New(reader, store, time.Hour)
+	r.runOnce(context.Background())
+
+	if len(store.created) != 1 {
+		t.Fatalf("expected 1 incident created, got %d", len(store.created))
+	}
+	inc := store.created[0]
+	if inc.ProviderID != "openai" {
+		t.Errorf("ProviderID: got %q, want openai", inc.ProviderID)
+	}
+	if inc.Severity != "critical" {
+		t.Errorf("Severity: got %q, want critical", inc.Severity)
+	}
+	if inc.DetectionRule.String != RuleProviderDown {
+		t.Errorf("DetectionRule: got %q, want %q", inc.DetectionRule.String, RuleProviderDown)
+	}
+	if inc.Status != "ongoing" {
+		t.Errorf("Status: got %q, want ongoing", inc.Status)
+	}
+}
+
+func TestRunner_Deduplication(t *testing.T) {
+	// Pre-seed an existing ongoing incident.
+	existing := pgstore.Incident{
+		ID:              uuid.New(),
+		ProviderID:      "openai",
+		Status:          "ongoing",
+		DetectionMethod: "auto",
+		DetectionRule:   pgtype.Text{String: RuleProviderDown, Valid: true},
+	}
+	reader := &fakeReader{
+		stats5m: []ProbeStats{{ProviderID: "openai", Total: 10, Errors: 6}},
+	}
+	store := &fakeIncidentStore{incidents: []pgstore.Incident{existing}}
+	r := New(reader, store, time.Hour)
+	r.runOnce(context.Background())
+
+	if len(store.created) != 0 {
+		t.Errorf("expected no new incidents (dedup), got %d", len(store.created))
+	}
+}
+
+func TestRunner_ResolvesStaleIncident(t *testing.T) {
+	// Ongoing incident for a rule that is no longer firing.
+	stale := pgstore.Incident{
+		ID:              uuid.New(),
+		ProviderID:      "openai",
+		Status:          "ongoing",
+		DetectionMethod: "auto",
+		DetectionRule:   pgtype.Text{String: RuleProviderDown, Valid: true},
+	}
+	reader := &fakeReader{} // no detections — all clear
+	store := &fakeIncidentStore{incidents: []pgstore.Incident{stale}}
+	r := New(reader, store, time.Hour)
+	r.runOnce(context.Background())
+
+	if len(store.resolved) != 1 {
+		t.Fatalf("expected 1 resolution, got %d", len(store.resolved))
+	}
+	if store.resolved[0].ID != stale.ID {
+		t.Errorf("resolved wrong incident")
+	}
+}
+
+func TestRunner_DoesNotResolveManualIncidents(t *testing.T) {
+	manual := pgstore.Incident{
+		ID:              uuid.New(),
+		ProviderID:      "openai",
+		Status:          "ongoing",
+		DetectionMethod: "manual",
+		DetectionRule:   pgtype.Text{String: RuleProviderDown, Valid: true},
+	}
+	reader := &fakeReader{}
+	store := &fakeIncidentStore{incidents: []pgstore.Incident{manual}}
+	r := New(reader, store, time.Hour)
+	r.runOnce(context.Background())
+
+	if len(store.resolved) != 0 {
+		t.Error("manual incident should not be auto-resolved")
+	}
+}
+
+func TestRunner_ElevatedErrors_CreatesIncident(t *testing.T) {
+	reader := &fakeReader{
+		stats10m: []ProbeStats{{ProviderID: "anthropic", Total: 20, Errors: 2}}, // 10%
+	}
+	store := &fakeIncidentStore{}
+	r := New(reader, store, time.Hour)
+	r.runOnce(context.Background())
+
+	if len(store.created) != 1 {
+		t.Fatalf("expected 1 incident, got %d", len(store.created))
+	}
+	if store.created[0].Severity != "major" {
+		t.Errorf("severity: got %q, want major", store.created[0].Severity)
+	}
+}
+
+func TestIncidentSlug(t *testing.T) {
+	t1 := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	got := incidentSlug("openai", RuleProviderDown, t1)
+	want := "2026-04-18-openai-provider-down"
+	if got != want {
+		t.Errorf("slug: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/detector/` with three layers: `InfluxReader` (probe stats via HTTP SQL), `EvaluateRules` (Rule 6.1 provider_down / Rule 6.2 elevated_errors), and `Runner` (dedup + create + auto-resolve)
- Rule 6.1: ≥50% error rate in 5-minute window → critical incident; Rule 6.2: >5% error rate in 10-minute window → major incident; Rule 6.1 suppresses Rule 6.2 for the same provider
- Minimum 3 probes required before any rule fires (prevents noise on sparse data)
- Manual incidents are never auto-resolved — only incidents created by the detector with `detection_method = "auto"` are eligible
- `cmd/detector/main.go` implemented with graceful shutdown via `signal.NotifyContext`; reads `DATABASE_URL`, `INFLUX_HOST`, `INFLUX_TOKEN`, `INFLUX_DATABASE`, `DETECTOR_INTERVAL`

## Test plan

- [x] 17 unit tests all pass (`go test -short -race ./internal/detector/...`)
- [x] `go build ./cmd/detector/...` succeeds
- [x] Rule evaluation: down, elevated, suppression, deduplication, stale resolution, manual skip
- [x] InfluxReader: success parse, 401 error, empty result
- [x] Slug format verified: `2026-04-18-openai-provider-down`

Closes #31