### PR TITLE
feat LLMS-012: provider detail page /providers/{id}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,21 @@ public APIs must add an entry under `## [Unreleased]`.
 - `docs/known-quirks.md` — first entries for OpenAI (HTTP 200 + error
   envelope, variable 401 codes)
 
+### Added (LLMS-012)
+- `web/app/providers/[id]/page.tsx` — provider detail page; server component,
+  ISR 60s; `generateMetadata` produces `Is {Provider} API down?` title + data-driven
+  description; calls `notFound()` on `ApiNotFoundError` (HTTP 404), re-throws
+  other errors so Next.js retries ISR
+- `web/components/IncidentCard.tsx` — card showing severity, title, and UTC
+  started_at timestamp for active incidents
+- `web/components/ModelList.tsx` — table of active monitored models with
+  model ID (monospace) and type
+- `web/lib/api.ts` — added `ApiNotFoundError` class, `ProviderDetail`,
+  `IncidentRef`, `ModelSummary` types; `getProvider(id)` function; `apiFetch`
+  now throws `ApiNotFoundError` on HTTP 404
+- `web/components/ProviderTable.tsx` — provider name cells now link to
+  `/providers/{id}`
+
 ### Added (LLMS-011)
 - `web/app/globals.css` — replaced scaffold with brand system CSS variables
   (`--canvas-*`, `--ink-*`, `--signal-*`, `--viz-*`) from BRAND_SYSTEM.md §4;

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -1,0 +1,126 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { getProvider, ApiNotFoundError } from "@/lib/api";
+import { StatusPill } from "@/components/StatusPill";
+import { IncidentCard } from "@/components/IncidentCard";
+import { ModelList } from "@/components/ModelList";
+
+export const revalidate = 60;
+
+type Props = { params: Promise<{ id: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  try {
+    const provider = await getProvider(id);
+    const statusLabel =
+      provider.current_status === "operational"
+        ? "operational"
+        : provider.current_status === "down"
+        ? "experiencing an outage"
+        : "degraded";
+    return {
+      title: `Is ${provider.name} API down?`,
+      description: `${provider.name} API is currently ${statusLabel}. Real-time uptime monitoring from llmstatus.io.`,
+    };
+  } catch {
+    return { title: "Provider not found" };
+  }
+}
+
+export default async function ProviderPage({ params }: Props) {
+  const { id } = await params;
+
+  let provider;
+  try {
+    provider = await getProvider(id);
+  } catch (e) {
+    if (e instanceof ApiNotFoundError) notFound();
+    throw e;
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <header className="border-b border-[var(--ink-600)] px-6 py-4">
+        <div className="mx-auto max-w-4xl flex items-center justify-between">
+          <Link
+            href="/"
+            className="font-mono text-sm font-semibold tracking-widest text-[var(--signal-amber)] uppercase hover:opacity-80 transition-opacity"
+          >
+            llmstatus.io
+          </Link>
+          <span className="text-xs text-[var(--ink-400)]">
+            Real-time AI API monitoring
+          </span>
+        </div>
+      </header>
+
+      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+        {/* Breadcrumb */}
+        <nav className="mb-6 text-xs text-[var(--ink-400)]">
+          <Link href="/" className="hover:text-[var(--ink-200)] transition-colors">
+            All providers
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-[var(--ink-300)]">{provider.name}</span>
+        </nav>
+
+        {/* Header */}
+        <div className="mb-8 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-[var(--ink-100)]">
+              {provider.name}
+            </h1>
+            <p className="mt-1 text-sm text-[var(--ink-400)]">
+              {provider.category} · {provider.region}
+              {provider.status_page_url && (
+                <>
+                  {" · "}
+                  <a
+                    href={provider.status_page_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:text-[var(--ink-200)] transition-colors"
+                  >
+                    Status page ↗
+                  </a>
+                </>
+              )}
+            </p>
+          </div>
+          <StatusPill status={provider.current_status} />
+        </div>
+
+        {/* Active incidents */}
+        {provider.active_incidents.length > 0 && (
+          <section className="mb-8">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+              Active Incidents
+            </h2>
+            <div className="flex flex-col gap-2">
+              {provider.active_incidents.map((inc) => (
+                <IncidentCard key={inc.id} incident={inc} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Models */}
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            Monitored Models
+          </h2>
+          <ModelList models={provider.models} />
+        </section>
+      </main>
+
+      <footer className="border-t border-[var(--ink-600)] px-6 py-4">
+        <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
+          Data sourced from real API calls, not status pages. Updated every 60 s.
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/web/components/IncidentCard.tsx
+++ b/web/components/IncidentCard.tsx
@@ -1,0 +1,37 @@
+import type { IncidentRef, Severity } from "@/lib/api";
+
+const SEVERITY_STYLE: Record<Severity, { label: string; color: string }> = {
+  critical: { label: "Critical", color: "text-[var(--signal-down)]" },
+  major:    { label: "Major",    color: "text-[var(--signal-warn)]" },
+  minor:    { label: "Minor",    color: "text-[var(--ink-300)]" },
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  });
+}
+
+export function IncidentCard({ incident }: { incident: IncidentRef }) {
+  const { label, color } = SEVERITY_STYLE[incident.severity] ?? SEVERITY_STYLE.minor;
+
+  return (
+    <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-3">
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-sm font-medium text-[var(--ink-100)]">{incident.title}</p>
+        <span className={`shrink-0 text-xs font-semibold uppercase tracking-wide ${color}`}>
+          {label}
+        </span>
+      </div>
+      <p className="mt-1 text-xs text-[var(--ink-400)]">
+        Started {formatDate(incident.started_at)}
+      </p>
+    </div>
+  );
+}

--- a/web/components/ModelList.tsx
+++ b/web/components/ModelList.tsx
@@ -1,0 +1,47 @@
+import type { ModelSummary } from "@/lib/api";
+
+const MODEL_TYPE_LABEL: Record<string, string> = {
+  chat:      "Chat",
+  embedding: "Embedding",
+  image:     "Image",
+};
+
+export function ModelList({ models }: { models: ModelSummary[] }) {
+  const active = models.filter((m) => m.active);
+
+  if (active.length === 0) {
+    return (
+      <p className="text-sm text-[var(--ink-400)]">No active models configured.</p>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[var(--ink-600)]">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-[var(--ink-600)] bg-[var(--canvas-sunken)]">
+            <th className="px-4 py-2 text-left font-medium text-[var(--ink-300)]">Model</th>
+            <th className="px-4 py-2 text-left font-medium text-[var(--ink-300)]">Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          {active.map((m, idx) => (
+            <tr
+              key={m.model_id}
+              className={`border-b border-[var(--ink-600)] last:border-0 ${
+                idx % 2 === 0 ? "bg-[var(--canvas-raised)]" : "bg-[var(--canvas-base)]"
+              }`}
+            >
+              <td className="px-4 py-2 font-mono text-xs text-[var(--ink-200)]">
+                {m.model_id}
+              </td>
+              <td className="px-4 py-2 text-[var(--ink-300)]">
+                {MODEL_TYPE_LABEL[m.model_type] ?? m.model_type}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/components/ProviderTable.tsx
+++ b/web/components/ProviderTable.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { ProviderSummary } from "@/lib/api";
 import { StatusPill } from "./StatusPill";
 
@@ -42,7 +43,14 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
                 idx % 2 === 0 ? "bg-[var(--canvas-raised)]" : "bg-[var(--canvas-base)]"
               }`}
             >
-              <td className="px-4 py-3 font-medium text-[var(--ink-100)]">{p.name}</td>
+              <td className="px-4 py-3 font-medium text-[var(--ink-100)]">
+                <Link
+                  href={`/providers/${p.id}`}
+                  className="hover:text-[var(--signal-ok)] transition-colors"
+                >
+                  {p.name}
+                </Link>
+              </td>
               <td className="px-4 py-3 text-[var(--ink-300)]">
                 {CATEGORY_LABEL[p.category] ?? p.category}
               </td>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -5,7 +5,15 @@ interface ApiEnvelope<T> {
   meta: { generated_at: string; cache_ttl_s: number };
 }
 
+export class ApiNotFoundError extends Error {
+  constructor(path: string) {
+    super(`Not found: ${path}`);
+    this.name = "ApiNotFoundError";
+  }
+}
+
 export type ProviderStatus = "operational" | "degraded" | "down";
+export type Severity = "minor" | "major" | "critical";
 
 export interface ProviderSummary {
   id: string;
@@ -16,11 +24,34 @@ export interface ProviderSummary {
   active_incident_id?: string;
 }
 
+export interface IncidentRef {
+  id: string;
+  slug: string;
+  severity: Severity;
+  title: string;
+  status: string;
+  started_at: string;
+}
+
+export interface ModelSummary {
+  model_id: string;
+  display_name: string;
+  model_type: string;
+  active: boolean;
+}
+
+export interface ProviderDetail extends ProviderSummary {
+  status_page_url?: string;
+  documentation_url?: string;
+  models: ModelSummary[];
+  active_incidents: IncidentRef[];
+}
+
 export interface IncidentSummary {
   id: string;
   slug: string;
   provider_id: string;
-  severity: "minor" | "major" | "critical";
+  severity: Severity;
   title: string;
   status: "ongoing" | "monitoring" | "resolved";
   started_at: string;
@@ -32,15 +63,18 @@ async function apiFetch<T>(path: string, revalidate: number): Promise<T> {
     next: { revalidate },
     headers: { Accept: "application/json" },
   });
-  if (!res.ok) {
-    throw new Error(`API ${path} returned ${res.status}`);
-  }
+  if (res.status === 404) throw new ApiNotFoundError(path);
+  if (!res.ok) throw new Error(`API ${path} returned ${res.status}`);
   const envelope: ApiEnvelope<T> = await res.json();
   return envelope.data;
 }
 
 export function listProviders(): Promise<ProviderSummary[]> {
   return apiFetch<ProviderSummary[]>("/v1/providers", 30);
+}
+
+export function getProvider(id: string): Promise<ProviderDetail> {
+  return apiFetch<ProviderDetail>(`/v1/providers/${encodeURIComponent(id)}`, 60);
 }
 
 export function listIncidents(status = "ongoing"): Promise<IncidentSummary[]> {


### PR DESCRIPTION
## Summary

- Adds `/providers/[id]` dynamic route (ISR 60s) — the per-provider status page
- `generateMetadata` produces `Is {Provider} API down?` title and a data-driven meta description matching BRAND_SYSTEM.md §8.3
- `ApiNotFoundError` added to `api.ts`; the page calls `notFound()` on 404, re-throws other errors so Next.js serves the stale cache on transient API failures
- `IncidentCard` shows severity label (brand signal colors), title, and UTC start time
- `ModelList` shows active model IDs (monospace font) with type column
- `ProviderTable` provider names are now `<Link>` tags to the detail page

## Test plan

- [x] `npx tsc --noEmit` zero errors
- [x] `next build` clean; route shows `ƒ (Dynamic)` with 60s revalidate
- [x] Unknown provider id → `notFound()` path confirmed in code
- [x] Active incidents section only rendered when `active_incidents.length > 0`
- [x] No external UI libraries; pure server components

Closes #35