### PR TITLE
feat LLMS-013: incidents list and detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,21 @@ public APIs must add an entry under `## [Unreleased]`.
 - `docs/known-quirks.md` — first entries for OpenAI (HTTP 200 + error
   envelope, variable 401 codes)
 
+### Added (LLMS-013)
+- `web/app/incidents/page.tsx` — incidents list (all statuses, limit 50); ISR 30s;
+  graceful API-error fallback; empty-state message
+- `web/app/incidents/[slug]/page.tsx` — permanent incident detail page; ISR 60s;
+  `generateMetadata` with `{provider} incident on {date}: {title}` title format;
+  JSON-LD `Event` schema (`safeJsonLd` escapes `<` → `\u003c` to prevent
+  `</script>` injection from API data); breadcrumb navigation; timeline, description,
+  affected models/regions sections; `notFound()` on 404
+- `web/components/IncidentCard.tsx` — added optional `href` prop; when set the card
+  renders as a `<Link>` with hover border transition; `formatDate` exported for reuse
+- `web/lib/api.ts` — replaced `IncidentSummary` with fuller `IncidentDetail` (matches
+  Go `incidentResponse` exactly); added `getIncident(slug)` function; `listIncidents`
+  now accepts `status` and `limit` params
+- `web/app/providers/[id]/page.tsx` — incident cards now link to `/incidents/{slug}`
+
 ### Added (LLMS-012)
 - `web/app/providers/[id]/page.tsx` — provider detail page; server component,
   ISR 60s; `generateMetadata` produces `Is {Provider} API down?` title + data-driven

--- a/web/app/incidents/[slug]/page.tsx
+++ b/web/app/incidents/[slug]/page.tsx
@@ -1,0 +1,211 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { getIncident, ApiNotFoundError, type IncidentDetail, type Severity } from "@/lib/api";
+import { formatDate } from "@/components/IncidentCard";
+
+export const revalidate = 60;
+
+type Props = { params: Promise<{ slug: string }> };
+
+function incidentTitle(inc: IncidentDetail): string {
+  const date = new Date(inc.started_at).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+  return `${inc.provider_id} incident on ${date}: ${inc.title}`;
+}
+
+// Escape < so that </script> can never appear inside a <script> tag.
+function safeJsonLd(obj: unknown): string {
+  return JSON.stringify(obj).replace(/</g, "\\u003c");
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  try {
+    const inc = await getIncident(slug);
+    return {
+      title: incidentTitle(inc),
+      description: inc.description ?? inc.title,
+    };
+  } catch {
+    return { title: "Incident not found" };
+  }
+}
+
+const SEVERITY_STYLE: Record<Severity, { label: string; color: string }> = {
+  critical: { label: "Critical", color: "text-[var(--signal-down)]" },
+  major:    { label: "Major",    color: "text-[var(--signal-warn)]" },
+  minor:    { label: "Minor",    color: "text-[var(--ink-300)]" },
+};
+
+const STATUS_STYLE: Record<string, string> = {
+  ongoing:    "text-[var(--signal-down)]",
+  monitoring: "text-[var(--signal-warn)]",
+  resolved:   "text-[var(--signal-ok)]",
+};
+
+export default async function IncidentPage({ params }: Props) {
+  const { slug } = await params;
+
+  let inc: IncidentDetail;
+  try {
+    inc = await getIncident(slug);
+  } catch (e) {
+    if (e instanceof ApiNotFoundError) notFound();
+    throw e;
+  }
+
+  const { label: severityLabel, color: severityColor } =
+    SEVERITY_STYLE[inc.severity] ?? SEVERITY_STYLE.minor;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: inc.title,
+    startDate: inc.started_at,
+    ...(inc.resolved_at ? { endDate: inc.resolved_at } : {}),
+    description: inc.description ?? inc.title,
+    eventStatus:
+      inc.status === "resolved"
+        ? "https://schema.org/EventCancelled"
+        : "https://schema.org/EventScheduled",
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      {/* eslint-disable-next-line react/no-danger -- safeJsonLd escapes </ to prevent script injection */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }}
+      />
+
+      <header className="border-b border-[var(--ink-600)] px-6 py-4">
+        <div className="mx-auto max-w-4xl flex items-center justify-between">
+          <Link
+            href="/"
+            className="font-mono text-sm font-semibold tracking-widest text-[var(--signal-amber)] uppercase hover:opacity-80 transition-opacity"
+          >
+            llmstatus.io
+          </Link>
+          <span className="text-xs text-[var(--ink-400)]">Real-time AI API monitoring</span>
+        </div>
+      </header>
+
+      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+        {/* Breadcrumb */}
+        <nav className="mb-6 text-xs text-[var(--ink-400)]">
+          <Link href="/" className="hover:text-[var(--ink-200)] transition-colors">
+            All providers
+          </Link>
+          <span className="mx-2">/</span>
+          <Link href="/incidents" className="hover:text-[var(--ink-200)] transition-colors">
+            Incidents
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-[var(--ink-300)]">{inc.slug}</span>
+        </nav>
+
+        {/* Header */}
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-2">
+            <span className={`text-xs font-semibold uppercase tracking-wide ${severityColor}`}>
+              {severityLabel}
+            </span>
+            <span className="text-[var(--ink-600)]">·</span>
+            <span className={`text-xs font-semibold uppercase tracking-wide ${STATUS_STYLE[inc.status] ?? ""}`}>
+              {inc.status}
+            </span>
+          </div>
+          <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">{inc.title}</h1>
+          <p className="text-sm text-[var(--ink-400)]">
+            Provider:{" "}
+            <Link
+              href={`/providers/${inc.provider_id}`}
+              className="text-[var(--ink-300)] hover:text-[var(--ink-200)] transition-colors"
+            >
+              {inc.provider_id}
+            </Link>
+          </p>
+        </div>
+
+        {/* Timeline */}
+        <section className="mb-8 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] divide-y divide-[var(--ink-600)]">
+          <Row label="Started" value={formatDate(inc.started_at)} />
+          {inc.resolved_at && (
+            <Row label="Resolved" value={formatDate(inc.resolved_at)} />
+          )}
+          <Row label="Detection" value={inc.detection_method} />
+          <Row label="Human reviewed" value={inc.human_reviewed ? "Yes" : "No"} />
+        </section>
+
+        {/* Description */}
+        {inc.description && (
+          <section className="mb-8">
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+              Description
+            </h2>
+            <p className="text-sm text-[var(--ink-200)] leading-6">{inc.description}</p>
+          </section>
+        )}
+
+        {/* Affected models */}
+        {inc.affected_models.length > 0 && (
+          <section className="mb-6">
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+              Affected Models
+            </h2>
+            <ul className="flex flex-wrap gap-2">
+              {inc.affected_models.map((m) => (
+                <li
+                  key={m}
+                  className="rounded px-2 py-0.5 font-mono text-xs bg-[var(--canvas-sunken)] text-[var(--ink-200)]"
+                >
+                  {m}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Affected regions */}
+        {inc.affected_regions.length > 0 && (
+          <section>
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+              Affected Regions
+            </h2>
+            <ul className="flex flex-wrap gap-2">
+              {inc.affected_regions.map((r) => (
+                <li
+                  key={r}
+                  className="rounded px-2 py-0.5 font-mono text-xs bg-[var(--canvas-sunken)] text-[var(--ink-200)]"
+                >
+                  {r}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </main>
+
+      <footer className="border-t border-[var(--ink-600)] px-6 py-4">
+        <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
+          This URL is permanent and will not change. Detection method: {inc.detection_method}.
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center px-4 py-3 gap-6">
+      <span className="w-36 shrink-0 text-xs text-[var(--ink-400)]">{label}</span>
+      <span className="text-sm text-[var(--ink-200)]">{value}</span>
+    </div>
+  );
+}

--- a/web/app/incidents/page.tsx
+++ b/web/app/incidents/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { listIncidents } from "@/lib/api";
+import { IncidentCard } from "@/components/IncidentCard";
+
+export const revalidate = 30;
+
+export const metadata: Metadata = {
+  title: "Incidents",
+  description: "All detected incidents across AI API providers, past and present.",
+};
+
+export default async function IncidentsPage() {
+  const incidents = await listIncidents("all", 50).catch(() => null);
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <header className="border-b border-[var(--ink-600)] px-6 py-4">
+        <div className="mx-auto max-w-4xl flex items-center justify-between">
+          <Link
+            href="/"
+            className="font-mono text-sm font-semibold tracking-widest text-[var(--signal-amber)] uppercase hover:opacity-80 transition-opacity"
+          >
+            llmstatus.io
+          </Link>
+          <span className="text-xs text-[var(--ink-400)]">Real-time AI API monitoring</span>
+        </div>
+      </header>
+
+      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+        <div className="mb-8">
+          <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">Incidents</h1>
+          <p className="text-sm text-[var(--ink-400)]">
+            All detected provider incidents, most recent first.
+          </p>
+        </div>
+
+        {incidents === null ? (
+          <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6 py-10 text-center">
+            <p className="text-sm text-[var(--ink-400)]">
+              Could not reach the API. Check that the backend is running.
+            </p>
+          </div>
+        ) : incidents.length === 0 ? (
+          <p className="py-12 text-center text-sm text-[var(--ink-400)]">
+            No incidents recorded yet.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {incidents.map((inc) => (
+              <IncidentCard
+                key={inc.id}
+                incident={inc}
+                href={`/incidents/${inc.slug}`}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+
+      <footer className="border-t border-[var(--ink-600)] px-6 py-4">
+        <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
+          Data sourced from real API calls, not status pages. Updated every 30 s.
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -101,7 +101,7 @@ export default async function ProviderPage({ params }: Props) {
             </h2>
             <div className="flex flex-col gap-2">
               {provider.active_incidents.map((inc) => (
-                <IncidentCard key={inc.id} incident={inc} />
+                <IncidentCard key={inc.id} incident={inc} href={`/incidents/${inc.slug}`} />
               ))}
             </div>
           </section>

--- a/web/components/IncidentCard.tsx
+++ b/web/components/IncidentCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { IncidentRef, Severity } from "@/lib/api";
 
 const SEVERITY_STYLE: Record<Severity, { label: string; color: string }> = {
@@ -6,7 +7,7 @@ const SEVERITY_STYLE: Record<Severity, { label: string; color: string }> = {
   minor:    { label: "Minor",    color: "text-[var(--ink-300)]" },
 };
 
-function formatDate(iso: string): string {
+export function formatDate(iso: string): string {
   return new Date(iso).toLocaleString("en-US", {
     month: "short",
     day: "numeric",
@@ -18,11 +19,16 @@ function formatDate(iso: string): string {
   });
 }
 
-export function IncidentCard({ incident }: { incident: IncidentRef }) {
+interface Props {
+  incident: IncidentRef;
+  href?: string;
+}
+
+export function IncidentCard({ incident, href }: Props) {
   const { label, color } = SEVERITY_STYLE[incident.severity] ?? SEVERITY_STYLE.minor;
 
-  return (
-    <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-3">
+  const inner = (
+    <>
       <div className="flex items-start justify-between gap-4">
         <p className="text-sm font-medium text-[var(--ink-100)]">{incident.title}</p>
         <span className={`shrink-0 text-xs font-semibold uppercase tracking-wide ${color}`}>
@@ -32,6 +38,18 @@ export function IncidentCard({ incident }: { incident: IncidentRef }) {
       <p className="mt-1 text-xs text-[var(--ink-400)]">
         Started {formatDate(incident.started_at)}
       </p>
-    </div>
+    </>
   );
+
+  const cls =
+    "block rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-3";
+
+  if (href) {
+    return (
+      <Link href={href} className={`${cls} hover:border-[var(--ink-500)] transition-colors`}>
+        {inner}
+      </Link>
+    );
+  }
+  return <div className={cls}>{inner}</div>;
 }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -47,15 +47,22 @@ export interface ProviderDetail extends ProviderSummary {
   active_incidents: IncidentRef[];
 }
 
-export interface IncidentSummary {
+export type IncidentStatus = "ongoing" | "monitoring" | "resolved";
+
+export interface IncidentDetail {
   id: string;
   slug: string;
   provider_id: string;
   severity: Severity;
   title: string;
-  status: "ongoing" | "monitoring" | "resolved";
+  description?: string;
+  status: IncidentStatus;
+  affected_models: string[];
+  affected_regions: string[];
   started_at: string;
   resolved_at?: string;
+  detection_method: string;
+  human_reviewed: boolean;
 }
 
 async function apiFetch<T>(path: string, revalidate: number): Promise<T> {
@@ -77,6 +84,10 @@ export function getProvider(id: string): Promise<ProviderDetail> {
   return apiFetch<ProviderDetail>(`/v1/providers/${encodeURIComponent(id)}`, 60);
 }
 
-export function listIncidents(status = "ongoing"): Promise<IncidentSummary[]> {
-  return apiFetch<IncidentSummary[]>(`/v1/incidents?status=${status}`, 30);
+export function listIncidents(status = "all", limit = 50): Promise<IncidentDetail[]> {
+  return apiFetch<IncidentDetail[]>(`/v1/incidents?status=${status}&limit=${limit}`, 30);
+}
+
+export function getIncident(slug: string): Promise<IncidentDetail> {
+  return apiFetch<IncidentDetail>(`/v1/incidents/${encodeURIComponent(slug)}`, 60);
 }


### PR DESCRIPTION
## Summary

- `/incidents` — list of all incidents (ISR 30s), graceful empty/error states
- `/incidents/[slug]` — permanent detail page (ISR 60s); JSON-LD \`Event\` schema; \`safeJsonLd()\` escapes \`<\` → \`\\u003c\` to prevent \`</script>\` injection from API-supplied strings
- \`generateMetadata\` follows ROADMAP §8.3 title template: \`{provider} incident on {date}: {title}\`
- \`IncidentCard\` upgraded with optional \`href\` — renders as \`<Link>\` when provided; \`formatDate\` exported for the detail page
- \`IncidentDetail\` type now mirrors the Go \`incidentResponse\` exactly (adds \`affected_models\`, \`affected_regions\`, \`detection_method\`, \`human_reviewed\`)
- Provider detail page incident cards now link to their permanent URLs

## Test plan

- [x] \`npx tsc --noEmit\` zero errors
- [x] \`next build\` clean — 5 routes, 2 dynamic with ISR
- [x] \`safeJsonLd\` replaces \`<\` so \`</script>\` cannot appear inside the ld+json block
- [x] \`notFound()\` on 404 confirmed in code path
- [x] Empty incidents state handled; API-error state handled

Closes #37