### PR TITLE
feat LLMS-014+018: provider history endpoint + UptimeSparkline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,28 @@ public APIs must add an entry under `## [Unreleased]`.
 - `docs/known-quirks.md` — first entries for OpenAI (HTTP 200 + error
   envelope, variable 401 codes)
 
+### Added (LLMS-014 + LLMS-018)
+- `internal/store/influx/history_reader.go` — `HistoryReader` interface +
+  `influxHistoryReader` implementation; queries InfluxDB 3 via
+  `POST /api/v3/query_sql` using `date_bin()` for time-bucketed aggregation;
+  sanitises `provider_id` to prevent SQL injection; 5 unit tests
+- `internal/api/history.go` — `GET /v1/providers/{id}/history?window=24h|7d|30d`
+  handler; `WithHistoryReader` functional option keeps `api.New(store)` backward-
+  compatible; returns 503 when reader not configured; 4 handler tests
+- `internal/api/server.go` — added optional `history HistoryReader` field;
+  `New()` now accepts variadic `func(*Server)` options; new route registered
+- `cmd/api/main.go` — wires `influx.NewHistoryReader` via `WithHistoryReader`;
+  three new required env vars: `INFLUX_HOST`, `INFLUX_TOKEN`, `INFLUX_DATABASE`
+- `web/lib/api.ts` — `HistoryBucket` type; `getProviderHistory(id, window)` with
+  300s revalidate (history changes slowly)
+- `web/components/UptimeSparkline.tsx` — 30-bar daily uptime chart; CSS-only,
+  no animation library; bar color maps uptime: ≥99% → `--signal-ok`,
+  ≥95% → `--signal-warn`, else → `--signal-down`; empty slots shown as
+  `--ink-600` stubs; summary line shows mean uptime %
+- `web/app/providers/[id]/page.tsx` — fetches 30d history alongside provider
+  data (best-effort: sparkline hidden on fetch failure); renders `UptimeSparkline`
+  in an "Uptime History" section above the model list
+
 ### Added (LLMS-013)
 - `web/app/incidents/page.tsx` — incidents list (all statuses, limit 50); ISR 30s;
   graceful API-error fallback; empty-state message

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2,7 +2,10 @@
 //
 // Required environment variables:
 //
-//	DATABASE_URL  Postgres DSN (pgx connection string)
+//	DATABASE_URL      Postgres DSN (pgx connection string)
+//	INFLUX_HOST       InfluxDB 3 base URL
+//	INFLUX_TOKEN      InfluxDB auth token
+//	INFLUX_DATABASE   InfluxDB database / bucket name
 //
 // Optional:
 //
@@ -22,11 +25,15 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/llmstatus/llmstatus/internal/api"
+	"github.com/llmstatus/llmstatus/internal/store/influx"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 
 func main() {
 	dbURL := requireEnv("DATABASE_URL")
+	influxHost := requireEnv("INFLUX_HOST")
+	influxToken := requireEnv("INFLUX_TOKEN")
+	influxDB := requireEnv("INFLUX_DATABASE")
 	addr := envOr("API_ADDR", ":8081")
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
@@ -40,9 +47,15 @@ func main() {
 	defer pool.Close()
 
 	store := pgstore.New(pool)
+	historyReader := influx.NewHistoryReader(influx.HistoryReaderConfig{
+		Host:     influxHost,
+		Token:    influxToken,
+		Database: influxDB,
+	}, nil)
+
 	srv := &http.Server{
 		Addr:         addr,
-		Handler:      api.New(store),
+		Handler:      api.New(store, api.WithHistoryReader(historyReader)),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/store/influx"
+)
+
+// HistoryReader is the subset of influx.HistoryReader used by the API.
+type HistoryReader interface {
+	ProviderHistory(ctx context.Context, providerID string, window, bucketSize time.Duration) ([]influx.HistoryBucket, error)
+}
+
+// compile-time check: influx.influxHistoryReader satisfies HistoryReader via
+// the exported NewHistoryReader constructor.
+var _ HistoryReader = (influx.HistoryReader)(nil)
+
+// WithHistoryReader wires an InfluxDB history reader into the Server.
+func WithHistoryReader(r HistoryReader) func(*Server) {
+	return func(s *Server) { s.history = r }
+}
+
+func (s *Server) getProviderHistory(w http.ResponseWriter, r *http.Request) {
+	if s.history == nil {
+		writeError(w, http.StatusServiceUnavailable, "history not available")
+		return
+	}
+
+	id := r.PathValue("id")
+	window, bucketSize := parseWindowParam(r.URL.Query().Get("window"))
+
+	buckets, err := s.history.ProviderHistory(r.Context(), id, window, bucketSize)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to query history")
+		return
+	}
+
+	writeEnvelope(w, coalesceSlice(buckets))
+}
+
+// parseWindowParam maps the ?window= query string to (total window, bucket size).
+// Defaults to 30d with daily buckets.
+func parseWindowParam(window string) (time.Duration, time.Duration) {
+	switch window {
+	case "24h":
+		return 24 * time.Hour, time.Hour
+	case "7d":
+		return 7 * 24 * time.Hour, 24 * time.Hour
+	default: // "30d" and anything else
+		return 30 * 24 * time.Hour, 24 * time.Hour
+	}
+}

--- a/internal/api/history_handler_test.go
+++ b/internal/api/history_handler_test.go
@@ -1,0 +1,85 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/api"
+	"github.com/llmstatus/llmstatus/internal/store/influx"
+)
+
+type fakeHistoryReader struct {
+	buckets []influx.HistoryBucket
+	err     error
+}
+
+func (f *fakeHistoryReader) ProviderHistory(_ context.Context, _ string, _, _ time.Duration) ([]influx.HistoryBucket, error) {
+	return f.buckets, f.err
+}
+
+func TestGetProviderHistory_Success(t *testing.T) {
+	now := time.Now().UTC().Truncate(24 * time.Hour)
+	fake := &fakeHistoryReader{
+		buckets: []influx.HistoryBucket{
+			{Timestamp: now.Add(-48 * time.Hour), Total: 1440, Errors: 14, Uptime: 0.9903},
+			{Timestamp: now.Add(-24 * time.Hour), Total: 1440, Errors: 0, Uptime: 1.0},
+		},
+	}
+
+	srv := api.New(&fakeStore{}, api.WithHistoryReader(fake))
+	req := httptest.NewRequest(http.MethodGet, "/v1/providers/openai/history?window=7d", nil)
+	req.SetPathValue("id", "openai")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var env struct {
+		Data []influx.HistoryBucket `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Data) != 2 {
+		t.Errorf("expected 2 buckets, got %d", len(env.Data))
+	}
+}
+
+func TestGetProviderHistory_NoReader(t *testing.T) {
+	srv := api.New(&fakeStore{}) // no WithHistoryReader
+	req := httptest.NewRequest(http.MethodGet, "/v1/providers/openai/history", nil)
+	req.SetPathValue("id", "openai")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status: got %d, want 503", w.Code)
+	}
+}
+
+func TestGetProviderHistory_EmptyCoalesced(t *testing.T) {
+	fake := &fakeHistoryReader{buckets: nil}
+	srv := api.New(&fakeStore{}, api.WithHistoryReader(fake))
+	req := httptest.NewRequest(http.MethodGet, "/v1/providers/openai/history", nil)
+	req.SetPathValue("id", "openai")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+	var env struct {
+		Data []influx.HistoryBucket `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Data == nil {
+		t.Error("data should be [] not null")
+	}
+}

--- a/internal/api/history_test.go
+++ b/internal/api/history_test.go
@@ -1,0 +1,28 @@
+// Internal tests for unexported functions in history.go.
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseWindowParam(t *testing.T) {
+	cases := []struct {
+		input          string
+		wantWindow     time.Duration
+		wantBucketSize time.Duration
+	}{
+		{"24h", 24 * time.Hour, time.Hour},
+		{"7d", 7 * 24 * time.Hour, 24 * time.Hour},
+		{"30d", 30 * 24 * time.Hour, 24 * time.Hour},
+		{"", 30 * 24 * time.Hour, 24 * time.Hour},
+		{"bad", 30 * 24 * time.Hour, 24 * time.Hour},
+	}
+	for _, tc := range cases {
+		w, b := parseWindowParam(tc.input)
+		if w != tc.wantWindow || b != tc.wantBucketSize {
+			t.Errorf("parseWindowParam(%q): got (%v,%v), want (%v,%v)",
+				tc.input, w, b, tc.wantWindow, tc.wantBucketSize)
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,13 +20,18 @@ var _ Store = (*pgstore.Queries)(nil)
 
 // Server wires handlers to a ServeMux and owns the store reference.
 type Server struct {
-	store Store
-	mux   *http.ServeMux
+	store   Store
+	history HistoryReader // optional; nil → GET /history returns 503
+	mux     *http.ServeMux
 }
 
-// New creates a Server and registers all routes.
-func New(store Store) *Server {
+// New creates a Server and registers all routes. Pass functional options
+// (e.g. WithHistoryReader) to enable optional capabilities.
+func New(store Store, opts ...func(*Server)) *Server {
 	s := &Server{store: store, mux: http.NewServeMux()}
+	for _, o := range opts {
+		o(s)
+	}
 	s.registerRoutes()
 	return s
 }
@@ -39,6 +44,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
 	s.mux.HandleFunc("GET /v1/providers", s.listProviders)
 	s.mux.HandleFunc("GET /v1/providers/{id}", s.getProvider)
+	s.mux.HandleFunc("GET /v1/providers/{id}/history", s.getProviderHistory)
 	s.mux.HandleFunc("GET /v1/incidents", s.listIncidents)
 	s.mux.HandleFunc("GET /v1/incidents/{id}", s.getIncident)
 }

--- a/internal/store/influx/history_reader.go
+++ b/internal/store/influx/history_reader.go
@@ -1,0 +1,132 @@
+package influx
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// HistoryBucket holds aggregated probe counts for one time bucket.
+type HistoryBucket struct {
+	Timestamp time.Time `json:"timestamp"`
+	Total     int64     `json:"total"`
+	Errors    int64     `json:"errors"`
+	Uptime    float64   `json:"uptime"` // 1 - error_rate; 1.0 when Total == 0
+}
+
+// HistoryReader queries InfluxDB 3 for per-provider time-bucketed history.
+type HistoryReader interface {
+	ProviderHistory(ctx context.Context, providerID string, window, bucketSize time.Duration) ([]HistoryBucket, error)
+}
+
+// HistoryReaderConfig holds connection parameters for InfluxDB 3.
+type HistoryReaderConfig struct {
+	Host     string
+	Token    string
+	Database string
+}
+
+// NewHistoryReader returns a HistoryReader that queries via POST /api/v3/query_sql.
+func NewHistoryReader(cfg HistoryReaderConfig, client *http.Client) HistoryReader {
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &influxHistoryReader{cfg: cfg, client: client}
+}
+
+type influxHistoryReader struct {
+	cfg    HistoryReaderConfig
+	client *http.Client
+}
+
+func (r *influxHistoryReader) ProviderHistory(
+	ctx context.Context,
+	providerID string,
+	window, bucketSize time.Duration,
+) ([]HistoryBucket, error) {
+	// Sanitise providerID: only [a-z0-9_-] are valid provider IDs.
+	if strings.ContainsAny(providerID, "'\";\\") {
+		return nil, fmt.Errorf("influx: invalid provider_id %q", providerID)
+	}
+
+	sql := fmt.Sprintf(
+		`SELECT date_bin(INTERVAL '%d seconds', time, TIMESTAMP '1970-01-01 00:00:00') AS bucket,
+		        COUNT(*) AS total,
+		        COUNT(*) FILTER (WHERE success = false) AS errors
+		 FROM probes
+		 WHERE time >= now() - INTERVAL '%d seconds'
+		   AND provider_id = '%s'
+		 GROUP BY bucket
+		 ORDER BY bucket`,
+		int(bucketSize.Seconds()),
+		int(window.Seconds()),
+		providerID,
+	)
+
+	body, err := json.Marshal(map[string]string{
+		"q":      sql,
+		"db":     r.cfg.Database,
+		"format": "json",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("influx history: marshal query: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.cfg.Host+"/api/v3/query_sql", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("influx history: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+r.cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("influx history: query: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("influx history: status %d: %s", resp.StatusCode, detail)
+	}
+
+	var rows []struct {
+		Bucket string  `json:"bucket"`
+		Total  float64 `json:"total"`
+		Errors float64 `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("influx history: decode: %w", err)
+	}
+
+	buckets := make([]HistoryBucket, 0, len(rows))
+	for _, row := range rows {
+		ts, err := time.Parse(time.RFC3339Nano, row.Bucket)
+		if err != nil {
+			// Try without nanoseconds.
+			ts, err = time.Parse("2006-01-02T15:04:05Z", row.Bucket)
+			if err != nil {
+				continue
+			}
+		}
+		total := int64(row.Total)
+		errors := int64(row.Errors)
+		uptime := 1.0
+		if total > 0 {
+			uptime = 1.0 - float64(errors)/float64(total)
+		}
+		buckets = append(buckets, HistoryBucket{
+			Timestamp: ts.UTC(),
+			Total:     total,
+			Errors:    errors,
+			Uptime:    uptime,
+		})
+	}
+	return buckets, nil
+}

--- a/internal/store/influx/history_reader_test.go
+++ b/internal/store/influx/history_reader_test.go
@@ -1,0 +1,108 @@
+package influx
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHistoryReader_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v3/query_sql" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"bucket":"2026-04-17T00:00:00Z","total":1440,"errors":14},
+			{"bucket":"2026-04-18T00:00:00Z","total":720,"errors":0}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewHistoryReader(HistoryReaderConfig{
+		Host: srv.URL, Token: "t", Database: "db",
+	}, nil)
+
+	buckets, err := reader.ProviderHistory(context.Background(), "openai", 30*24*time.Hour, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("ProviderHistory: %v", err)
+	}
+	if len(buckets) != 2 {
+		t.Fatalf("expected 2 buckets, got %d", len(buckets))
+	}
+
+	b0 := buckets[0]
+	if b0.Total != 1440 || b0.Errors != 14 {
+		t.Errorf("bucket 0: got total=%d errors=%d", b0.Total, b0.Errors)
+	}
+	wantUptime := 1.0 - 14.0/1440.0
+	if b0.Uptime < wantUptime-0.001 || b0.Uptime > wantUptime+0.001 {
+		t.Errorf("bucket 0 uptime: got %f, want ~%f", b0.Uptime, wantUptime)
+	}
+
+	b1 := buckets[1]
+	if b1.Uptime != 1.0 {
+		t.Errorf("bucket 1 uptime: got %f, want 1.0 (no errors)", b1.Uptime)
+	}
+}
+
+func TestHistoryReader_EmptyResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewHistoryReader(HistoryReaderConfig{Host: srv.URL, Token: "t", Database: "db"}, nil)
+	buckets, err := reader.ProviderHistory(context.Background(), "openai", 7*24*time.Hour, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(buckets) != 0 {
+		t.Errorf("expected 0 buckets, got %d", len(buckets))
+	}
+}
+
+func TestHistoryReader_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code":"unauthorized"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewHistoryReader(HistoryReaderConfig{Host: srv.URL, Token: "bad", Database: "db"}, nil)
+	_, err := reader.ProviderHistory(context.Background(), "openai", 24*time.Hour, time.Hour)
+	if err == nil {
+		t.Error("expected error on 401, got nil")
+	}
+}
+
+func TestHistoryReader_InvalidProviderID(t *testing.T) {
+	reader := NewHistoryReader(HistoryReaderConfig{Host: "http://x", Token: "t", Database: "db"}, nil)
+	_, err := reader.ProviderHistory(context.Background(), "'; DROP TABLE probes; --", time.Hour, time.Hour)
+	if err == nil {
+		t.Error("expected error for invalid provider_id")
+	}
+}
+
+func TestHistoryReader_UptimeZeroTotal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"bucket":"2026-04-18T00:00:00Z","total":0,"errors":0}]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewHistoryReader(HistoryReaderConfig{Host: srv.URL, Token: "t", Database: "db"}, nil)
+	buckets, err := reader.ProviderHistory(context.Background(), "openai", 24*time.Hour, time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(buckets) != 1 {
+		t.Fatalf("expected 1 bucket, got %d", len(buckets))
+	}
+	if buckets[0].Uptime != 1.0 {
+		t.Errorf("uptime with zero total: got %f, want 1.0", buckets[0].Uptime)
+	}
+}

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -2,10 +2,11 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 
-import { getProvider, ApiNotFoundError } from "@/lib/api";
+import { getProvider, getProviderHistory, ApiNotFoundError } from "@/lib/api";
 import { StatusPill } from "@/components/StatusPill";
 import { IncidentCard } from "@/components/IncidentCard";
 import { ModelList } from "@/components/ModelList";
+import { UptimeSparkline } from "@/components/UptimeSparkline";
 
 export const revalidate = 60;
 
@@ -40,6 +41,9 @@ export default async function ProviderPage({ params }: Props) {
     if (e instanceof ApiNotFoundError) notFound();
     throw e;
   }
+
+  // History fetch is best-effort — sparkline is hidden if unavailable.
+  const history = await getProviderHistory(id, "30d").catch(() => null);
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -103,6 +107,18 @@ export default async function ProviderPage({ params }: Props) {
               {provider.active_incidents.map((inc) => (
                 <IncidentCard key={inc.id} incident={inc} href={`/incidents/${inc.slug}`} />
               ))}
+            </div>
+          </section>
+        )}
+
+        {/* Uptime sparkline */}
+        {history !== null && (
+          <section className="mb-8">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+              Uptime History
+            </h2>
+            <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
+              <UptimeSparkline buckets={history} days={30} />
             </div>
           </section>
         )}

--- a/web/components/UptimeSparkline.tsx
+++ b/web/components/UptimeSparkline.tsx
@@ -1,0 +1,97 @@
+import type { HistoryBucket } from "@/lib/api";
+
+interface Props {
+  buckets: HistoryBucket[];
+  /** Number of days to show; padded with empty slots when data is sparse. */
+  days?: number;
+}
+
+function uptimeColor(uptime: number, hasData: boolean): string {
+  if (!hasData) return "bg-[var(--ink-600)]";
+  if (uptime >= 0.99) return "bg-[var(--signal-ok)]";
+  if (uptime >= 0.95) return "bg-[var(--signal-warn)]";
+  return "bg-[var(--signal-down)]";
+}
+
+function uptimeHeight(uptime: number, hasData: boolean): string {
+  if (!hasData) return "h-2"; // gray stub for missing data
+  // Map 0–1 uptime to 20–100% of container height (always at least a sliver)
+  const pct = Math.max(20, Math.round(uptime * 100));
+  // Tailwind can't interpolate arbitrary values at runtime, so use inline style.
+  return `h-[${pct}%]`;
+}
+
+function formatDay(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export function UptimeSparkline({ buckets, days = 30 }: Props) {
+  // Build a day-keyed map for O(1) lookup.
+  const byDay = new Map<string, HistoryBucket>();
+  for (const b of buckets) {
+    const key = b.timestamp.slice(0, 10); // "YYYY-MM-DD"
+    byDay.set(key, b);
+  }
+
+  // Generate the last `days` day keys in ascending order.
+  const slots: string[] = [];
+  const now = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    slots.push(d.toISOString().slice(0, 10));
+  }
+
+  const overall =
+    buckets.length === 0
+      ? null
+      : buckets.reduce((sum, b) => sum + b.uptime, 0) / buckets.length;
+
+  return (
+    <div>
+      {/* Summary line */}
+      <div className="mb-2 flex items-center justify-between text-xs text-[var(--ink-400)]">
+        <span>30-day uptime</span>
+        {overall !== null && (
+          <span className="font-medium text-[var(--ink-200)]">
+            {(overall * 100).toFixed(2)} %
+          </span>
+        )}
+      </div>
+
+      {/* Bars */}
+      <div className="flex h-10 items-end gap-px" aria-label="30-day uptime chart">
+        {slots.map((day) => {
+          const b = byDay.get(day);
+          const hasData = b !== undefined && b.total > 0;
+          const uptime = b?.uptime ?? 0;
+          const color = uptimeColor(uptime, hasData);
+          const label = hasData
+            ? `${formatDay(day)}: ${(uptime * 100).toFixed(1)}% uptime`
+            : `${formatDay(day)}: no data`;
+          const heightPct = hasData ? Math.max(20, Math.round(uptime * 100)) : 20;
+
+          return (
+            <div
+              key={day}
+              title={label}
+              className={`flex-1 rounded-sm ${color}`}
+              style={{ height: `${heightPct}%` }}
+              aria-label={label}
+            />
+          );
+        })}
+      </div>
+
+      {/* Axis labels */}
+      <div className="mt-1 flex justify-between text-xs text-[var(--ink-500)]">
+        <span>{formatDay(slots[0])}</span>
+        <span>{formatDay(slots[slots.length - 1])}</span>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -84,6 +84,22 @@ export function getProvider(id: string): Promise<ProviderDetail> {
   return apiFetch<ProviderDetail>(`/v1/providers/${encodeURIComponent(id)}`, 60);
 }
 
+export interface HistoryBucket {
+  timestamp: string;
+  total: number;
+  errors: number;
+  uptime: number; // 0–1
+}
+
+export type HistoryWindow = "24h" | "7d" | "30d";
+
+export function getProviderHistory(id: string, window: HistoryWindow = "30d"): Promise<HistoryBucket[]> {
+  return apiFetch<HistoryBucket[]>(
+    `/v1/providers/${encodeURIComponent(id)}/history?window=${window}`,
+    300, // 5-min revalidate — history data changes slowly
+  );
+}
+
 export function listIncidents(status = "all", limit = 50): Promise<IncidentDetail[]> {
   return apiFetch<IncidentDetail[]>(`/v1/incidents?status=${status}&limit=${limit}`, 30);
 }


### PR DESCRIPTION
## Summary

**LLMS-014 — Backend history API**
- `GET /v1/providers/{id}/history?window=24h|7d|30d` — queries InfluxDB 3 via `date_bin()` SQL for per-bucket uptime data
- `WithHistoryReader` functional option keeps `api.New(store)` backward-compatible; returns 503 when no reader configured
- Provider ID sanitised (rejects `'`, `"`, `;`, `\`) before SQL interpolation
- 9 new tests: 5 in `influx` package (httptest mock), 4 in `api` package

**LLMS-018 — Frontend sparkline**
- `UptimeSparkline` — 30 daily bars, height ∝ uptime, CSS-only (no animation library)
- Color thresholds: ≥99% → `--signal-ok` (cyan), ≥95% → `--signal-warn` (amber), below → `--signal-down` (coral); no-data slots → `--ink-600` (gray)
- Summary line shows mean uptime % across the window
- Provider detail page fetches 30d history as best-effort (sparkline hidden on failure, page still loads)

## Test plan

- [x] `go test -short -race ./cmd/... ./internal/... ./pkg/...` — all green
- [x] `npx tsc --noEmit` — zero errors
- [x] `next build` — clean
- [x] History API: success, empty result, 401 error, invalid provider ID, zero-total uptime
- [x] Handler: success, no reader → 503, nil coalesces to `[]`
- [x] `parseWindowParam`: 5 cases including defaults and unknown values

Closes #39
Closes #40