### PR TITLE
feat LLMS-015: per-IP rate limiting on public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ public APIs must add an entry under `## [Unreleased]`.
 - `gocyclo` CI step now ignores `_test.go` files; table-driven tests
   legitimately exceed the 10-complexity threshold
 
+### Added (LLMS-015)
+- Per-IP fixed-window rate limiting on the public API (`internal/api/RateLimiter`)
+- `WithRateLimiter` functional option on `api.New()`; default 60 req/min configurable via `API_RATE_LIMIT` env var
+- Standard `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` response headers on every request
+- `Retry-After` header and `429 Too Many Requests` response when limit is exceeded
+- Client IP extracted from `X-Forwarded-For` (nginx first-entry) with fallback to TCP remote address
+
 ### Added (LLMS-002)
 - `internal/httpclient/` — shared HTTP client with default 30s timeout,
   `User-Agent: llmstatus.io/<version>`, per-request `X-Request-ID`, and

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -35,6 +36,7 @@ func main() {
 	influxToken := requireEnv("INFLUX_TOKEN")
 	influxDB := requireEnv("INFLUX_DATABASE")
 	addr := envOr("API_ADDR", ":8081")
+	rateLimit := envInt("API_RATE_LIMIT", 60)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
@@ -52,10 +54,14 @@ func main() {
 		Token:    influxToken,
 		Database: influxDB,
 	}, nil)
+	limiter := api.NewRateLimiter(rateLimit, time.Minute)
 
 	srv := &http.Server{
-		Addr:         addr,
-		Handler:      api.New(store, api.WithHistoryReader(historyReader)),
+		Addr: addr,
+		Handler: api.New(store,
+			api.WithHistoryReader(historyReader),
+			api.WithRateLimiter(limiter),
+		),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  60 * time.Second,
@@ -91,6 +97,16 @@ func requireEnv(key string) string {
 func envOr(key, def string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+		slog.Warn("api: invalid env var, using default", "key", key, "default", def)
 	}
 	return def
 }

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateLimiter enforces a fixed-window per-IP request limit.
+type RateLimiter struct {
+	mu     sync.Mutex
+	limit  int
+	window time.Duration
+	hits   map[string]*rlEntry
+}
+
+type rlEntry struct {
+	count int
+	reset time.Time
+}
+
+// NewRateLimiter creates a RateLimiter allowing limit requests per window.
+func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
+	return &RateLimiter{
+		limit:  limit,
+		window: window,
+		hits:   make(map[string]*rlEntry),
+	}
+}
+
+// Allow checks whether ip may make another request.
+// It returns (allowed, remaining, reset time).
+func (rl *RateLimiter) Allow(ip string) (bool, int, time.Time) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	e, ok := rl.hits[ip]
+	if !ok || now.After(e.reset) {
+		reset := now.Truncate(rl.window).Add(rl.window)
+		rl.hits[ip] = &rlEntry{count: 1, reset: reset}
+		return true, rl.limit - 1, reset
+	}
+
+	e.count++
+	remaining := rl.limit - e.count
+	if remaining < 0 {
+		remaining = 0
+	}
+	return e.count <= rl.limit, remaining, e.reset
+}
+
+// Middleware wraps next, enforcing rate limits and writing standard headers.
+func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := realIP(r)
+		allowed, remaining, reset := rl.Allow(ip)
+
+		w.Header().Set("X-RateLimit-Limit", fmt.Sprintf("%d", rl.limit))
+		w.Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", remaining))
+		w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", reset.Unix()))
+
+		if !allowed {
+			retryAfter := int(time.Until(reset).Seconds()) + 1
+			w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+			writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// WithRateLimiter wraps the server's handler with per-IP rate limiting.
+func WithRateLimiter(rl *RateLimiter) func(*Server) {
+	return func(s *Server) { s.limiter = rl }
+}
+
+// realIP extracts the client IP from X-Forwarded-For (first entry, set by nginx)
+// or falls back to the TCP remote address.
+func realIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first address; trim whitespace and strip port if present.
+		first := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
+		if ip := net.ParseIP(first); ip != nil {
+			return ip.String()
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,0 +1,183 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/api"
+)
+
+func TestRateLimiter_Allow_UnderLimit(t *testing.T) {
+	rl := api.NewRateLimiter(5, time.Minute)
+	for i := range 5 {
+		allowed, remaining, _ := rl.Allow("1.2.3.4")
+		if !allowed {
+			t.Fatalf("call %d: expected allowed", i+1)
+		}
+		if remaining != 5-1-i {
+			t.Fatalf("call %d: remaining=%d want %d", i+1, remaining, 5-1-i)
+		}
+	}
+}
+
+func TestRateLimiter_Allow_OverLimit(t *testing.T) {
+	rl := api.NewRateLimiter(3, time.Minute)
+	for range 3 {
+		rl.Allow("1.2.3.4") //nolint:errcheck
+	}
+	allowed, remaining, _ := rl.Allow("1.2.3.4")
+	if allowed {
+		t.Fatal("4th call should be denied")
+	}
+	if remaining != 0 {
+		t.Fatalf("remaining=%d want 0", remaining)
+	}
+}
+
+func TestRateLimiter_Allow_IsolatedIPs(t *testing.T) {
+	rl := api.NewRateLimiter(1, time.Minute)
+	allowed1, _, _ := rl.Allow("1.1.1.1")
+	allowed2, _, _ := rl.Allow("2.2.2.2")
+	if !allowed1 || !allowed2 {
+		t.Fatal("each IP should get its own quota")
+	}
+}
+
+func TestRateLimiter_Allow_WindowReset(t *testing.T) {
+	rl := api.NewRateLimiter(1, 50*time.Millisecond)
+	rl.Allow("1.2.3.4")
+	allowed, _, _ := rl.Allow("1.2.3.4")
+	if allowed {
+		t.Fatal("second call in same window should be denied")
+	}
+	time.Sleep(60 * time.Millisecond)
+	allowed, _, _ = rl.Allow("1.2.3.4")
+	if !allowed {
+		t.Fatal("first call after window reset should be allowed")
+	}
+}
+
+func TestRateLimiter_Middleware_Headers(t *testing.T) {
+	rl := api.NewRateLimiter(10, time.Minute)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := rl.Middleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "5.5.5.5:1234"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200", rr.Code)
+	}
+	if v := rr.Header().Get("X-RateLimit-Limit"); v != "10" {
+		t.Fatalf("X-RateLimit-Limit=%q want 10", v)
+	}
+	remaining, err := strconv.Atoi(rr.Header().Get("X-RateLimit-Remaining"))
+	if err != nil || remaining != 9 {
+		t.Fatalf("X-RateLimit-Remaining=%q want 9", rr.Header().Get("X-RateLimit-Remaining"))
+	}
+	if rr.Header().Get("X-RateLimit-Reset") == "" {
+		t.Fatal("X-RateLimit-Reset header missing")
+	}
+}
+
+func TestRateLimiter_Middleware_429(t *testing.T) {
+	rl := api.NewRateLimiter(2, time.Minute)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := rl.Middleware(next)
+
+	for i := range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "9.9.9.9:999"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if i < 2 && rr.Code != http.StatusOK {
+			t.Fatalf("call %d: status=%d want 200", i+1, rr.Code)
+		}
+		if i == 2 {
+			if rr.Code != http.StatusTooManyRequests {
+				t.Fatalf("3rd call: status=%d want 429", rr.Code)
+			}
+			if rr.Header().Get("Retry-After") == "" {
+				t.Fatal("Retry-After header missing on 429")
+			}
+		}
+	}
+}
+
+func TestRateLimiter_Middleware_XForwardedFor(t *testing.T) {
+	rl := api.NewRateLimiter(1, time.Minute)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := rl.Middleware(next)
+
+	make2Requests := func(xff string) (int, int) {
+		codes := [2]int{}
+		for i := range 2 {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("X-Forwarded-For", xff)
+			req.RemoteAddr = "10.0.0.1:0"
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			codes[i] = rr.Code
+		}
+		return codes[0], codes[1]
+	}
+
+	first, second := make2Requests("203.0.113.1")
+	if first != 200 || second != 429 {
+		t.Fatalf("XFF rate limit: got %d,%d want 200,429", first, second)
+	}
+
+	// Different XFF IP gets its own quota.
+	first2, _ := make2Requests("203.0.113.2")
+	if first2 != 200 {
+		t.Fatalf("separate IP should be allowed: got %d", first2)
+	}
+}
+
+func TestWithRateLimiter_Wired(t *testing.T) {
+	rl := api.NewRateLimiter(1, time.Minute)
+	srv := api.New(&fakeStore{}, api.WithRateLimiter(rl))
+
+	// First request allowed.
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.RemoteAddr = "7.7.7.7:0"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first request: status=%d want 200", rr.Code)
+	}
+
+	// Second request from same IP denied.
+	req2 := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req2.RemoteAddr = "7.7.7.7:0"
+	rr2 := httptest.NewRecorder()
+	srv.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request: status=%d want 429", rr2.Code)
+	}
+}
+
+func TestServer_NoLimiter_NoRateLimit(t *testing.T) {
+	srv := api.New(&fakeStore{}) // no WithRateLimiter
+	for i := range 5 {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		req.RemoteAddr = fmt.Sprintf("8.8.8.8:%d", i)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: status=%d want 200", i+1, rr.Code)
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -22,22 +22,29 @@ var _ Store = (*pgstore.Queries)(nil)
 type Server struct {
 	store   Store
 	history HistoryReader // optional; nil → GET /history returns 503
+	limiter *RateLimiter  // optional; nil → no rate limiting
 	mux     *http.ServeMux
+	handler http.Handler // mux optionally wrapped with limiter middleware
 }
 
 // New creates a Server and registers all routes. Pass functional options
-// (e.g. WithHistoryReader) to enable optional capabilities.
+// (e.g. WithHistoryReader, WithRateLimiter) to enable optional capabilities.
 func New(store Store, opts ...func(*Server)) *Server {
 	s := &Server{store: store, mux: http.NewServeMux()}
 	for _, o := range opts {
 		o(s)
 	}
 	s.registerRoutes()
+	if s.limiter != nil {
+		s.handler = s.limiter.Middleware(s.mux)
+	} else {
+		s.handler = s.mux
+	}
 	return s
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.mux.ServeHTTP(w, r)
+	s.handler.ServeHTTP(w, r)
 }
 
 func (s *Server) registerRoutes() {


### PR DESCRIPTION
## Summary
- Adds `RateLimiter` (fixed-window, per-IP) in `internal/api/ratelimit.go`
- Wires it into `api.New()` via `WithRateLimiter` functional option
- Sets standard `X-RateLimit-*` headers on every response; returns `429 + Retry-After` when exceeded
- Default 60 req/min, configurable via `API_RATE_LIMIT` env var
- Client IP resolved from `X-Forwarded-For` first entry (nginx) with fallback to TCP `RemoteAddr`

## Test plan
- [x] `TestRateLimiter_Allow_UnderLimit` — 5 sequential calls all allowed with correct remaining counts
- [x] `TestRateLimiter_Allow_OverLimit` — 4th call denied, remaining=0
- [x] `TestRateLimiter_Allow_IsolatedIPs` — separate IPs have independent quotas
- [x] `TestRateLimiter_Allow_WindowReset` — counter resets after window expires
- [x] `TestRateLimiter_Middleware_Headers` — X-RateLimit-* headers set correctly
- [x] `TestRateLimiter_Middleware_429` — 429 + Retry-After on 3rd call with limit=2
- [x] `TestRateLimiter_Middleware_XForwardedFor` — rate-limits by XFF IP
- [x] `TestWithRateLimiter_Wired` — end-to-end through `api.New()` with limiter
- [x] `TestServer_NoLimiter_NoRateLimit` — server without limiter passes all requests

Closes #42