### PR TITLE
feat LLMS-016: SVG badge endpoint GET /badge/{provider_id}.svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ public APIs must add an entry under `## [Unreleased]`.
 - `gocyclo` CI step now ignores `_test.go` files; table-driven tests
   legitimately exceed the 10-complexity threshold
 
+### Added (LLMS-016)
+- `GET /badge/{provider_id}.svg` — shields.io-compatible flat SVG badge showing provider status
+- Colors: operational → green (`#4CAF50`), degraded → amber (`#FF9800`), down → red (`#F44336`), unknown → gray (`#9E9E9E`)
+- Unknown provider IDs return a gray "unknown" badge (not a JSON error) for badge-consumer friendliness
+- XSS-safe: provider names are HTML-escaped before embedding in SVG
+
 ### Added (LLMS-015)
 - Per-IP fixed-window rate limiting on the public API (`internal/api/RateLimiter`)
 - `WithRateLimiter` functional option on `api.New()`; default 60 req/min configurable via `API_RATE_LIMIT` env var

--- a/internal/api/badge.go
+++ b/internal/api/badge.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"strings"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+func (s *Server) getBadge(w http.ResponseWriter, r *http.Request) {
+	// Strip optional .svg extension — Go mux does not support mid-segment wildcards.
+	id := strings.TrimSuffix(r.PathValue("id"), ".svg")
+
+	p, err := s.store.GetProvider(r.Context(), id)
+	if err != nil {
+		writeBadge(w, "llmstatus", "unknown", "#9E9E9E")
+		return
+	}
+
+	activeIncs, err := s.store.ListIncidentsByProvider(r.Context(), pgstore.ListIncidentsByProviderParams{
+		ProviderID: id,
+		Limit:      5,
+		Offset:     0,
+	})
+	if err != nil {
+		activeIncs = nil
+	}
+
+	incMap := map[string]pgstore.Incident{}
+	for _, inc := range activeIncs {
+		if inc.Status == "ongoing" {
+			existing, seen := incMap[inc.ProviderID]
+			if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
+				incMap[inc.ProviderID] = inc
+			}
+		}
+	}
+
+	status, _ := deriveStatus(p.ID, incMap)
+	writeBadge(w, p.Name, status, statusColor(status))
+}
+
+func writeBadge(w http.ResponseWriter, label, message, color string) {
+	w.Header().Set("Content-Type", "image/svg+xml; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, max-age=30")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, _ = fmt.Fprint(w, renderBadge(label, message, color))
+}
+
+func statusColor(status string) string {
+	switch status {
+	case "operational":
+		return "#4CAF50"
+	case "degraded":
+		return "#FF9800"
+	case "down":
+		return "#F44336"
+	default:
+		return "#9E9E9E"
+	}
+}
+
+// renderBadge returns a shields.io-style flat SVG badge.
+//
+// Coordinate space: SVG uses font-size="110" with transform="scale(.1)" so all
+// x/y/width values here are in 10× units (1 SVG unit = 10 displayed pixels).
+func renderBadge(label, message, color string) string {
+	const (
+		hPx  = 20  // badge height in display pixels
+		padU = 50  // horizontal padding in 10× units (= 5px each side)
+	)
+
+	labelU := badgeTextWidth(label) + padU*2
+	msgU := badgeTextWidth(message) + padU*2
+	totalU := labelU + msgU
+
+	// Total width in display pixels (round up).
+	totalPx := (totalU + 9) / 10
+
+	// Text x-centres in 10× units.
+	labelCX := labelU/2 + 10
+	msgCX := labelU + msgU/2
+
+	esc := html.EscapeString
+	l, m := esc(label), esc(message)
+
+	return fmt.Sprintf(
+		`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" role="img" aria-label="%s: %s">`+
+			`<title>%s: %s</title>`+
+			`<g shape-rendering="crispEdges">`+
+			`<rect width="%d" height="%d" fill="#555"/>`+
+			`<rect x="%d" width="%d" height="%d" fill="%s"/>`+
+			`</g>`+
+			`<g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="110">`+
+			`<text x="%d" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="%d" lengthAdjust="spacing">%s</text>`+
+			`<text x="%d" y="140" transform="scale(.1)" textLength="%d" lengthAdjust="spacing">%s</text>`+
+			`<text x="%d" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="%d" lengthAdjust="spacing">%s</text>`+
+			`<text x="%d" y="140" transform="scale(.1)" textLength="%d" lengthAdjust="spacing">%s</text>`+
+			`</g>`+
+			`</svg>`,
+		totalPx, hPx,
+		l, m,
+		l, m,
+		totalPx, hPx,
+		(labelU)/10, (msgU)/10, hPx, color,
+		labelCX, labelU-padU*2, l,
+		labelCX, labelU-padU*2, l,
+		msgCX, msgU-padU*2, m,
+		msgCX, msgU-padU*2, m,
+	)
+}
+
+// badgeTextWidth returns the approximate text width in 10× SVG units for
+// Verdana 11px. Values are derived from measured Verdana advance widths.
+func badgeTextWidth(s string) int {
+	w := 0
+	for _, c := range s {
+		w += verdanaWidth(c)
+	}
+	return w
+}
+
+func verdanaWidth(c rune) int {
+	switch c {
+	case ' ':
+		return 33
+	case 'f', 'i', 'j', 'l', 'r', 't':
+		return 45
+	case 'I':
+		return 40
+	case 'm', 'w':
+		return 90
+	case 'M', 'W':
+		return 100
+	case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'X', 'Y', 'Z':
+		return 80
+	default:
+		// Covers a-z (except narrow ones above) and 0-9.
+		return 65
+	}
+}

--- a/internal/api/badge_test.go
+++ b/internal/api/badge_test.go
@@ -1,0 +1,165 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/llmstatus/llmstatus/internal/api"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+func TestGetBadge_Operational(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/openai.svg", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200", rr.Code)
+	}
+	ct := rr.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "image/svg+xml") {
+		t.Fatalf("Content-Type=%q want image/svg+xml", ct)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "OpenAI") {
+		t.Error("badge SVG missing provider name")
+	}
+	if !strings.Contains(body, "operational") {
+		t.Error("badge SVG missing status")
+	}
+	if !strings.Contains(body, "#4CAF50") {
+		t.Error("badge SVG missing green color for operational status")
+	}
+}
+
+func TestGetBadge_Degraded(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("anthropic", "Anthropic")},
+		incidents: []pgstore.Incident{fixtureIncident("anthropic", "inc-001", "ongoing", "major")},
+	}
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/anthropic.svg", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "degraded") {
+		t.Error("badge SVG missing degraded status")
+	}
+	if !strings.Contains(body, "#FF9800") {
+		t.Error("badge SVG missing amber color for degraded status")
+	}
+}
+
+func TestGetBadge_Down(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+		incidents: []pgstore.Incident{fixtureIncident("openai", "inc-down", "ongoing", "critical")},
+	}
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/openai.svg", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "down") {
+		t.Error("badge SVG missing down status")
+	}
+	if !strings.Contains(body, "#F44336") {
+		t.Error("badge SVG missing red color for down status")
+	}
+}
+
+func TestGetBadge_UnknownProvider(t *testing.T) {
+	store := &fakeStore{}
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/nonexistent.svg", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	// Returns 200 with an "unknown" badge, not a JSON 404.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200 (unknown badge)", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "unknown") {
+		t.Error("badge SVG missing 'unknown' for missing provider")
+	}
+	if !strings.Contains(body, "#9E9E9E") {
+		t.Error("badge SVG missing gray color for unknown status")
+	}
+}
+
+func TestGetBadge_CacheHeaders(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/openai.svg", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	cc := rr.Header().Get("Cache-Control")
+	if !strings.Contains(cc, "max-age=30") {
+		t.Fatalf("Cache-Control=%q want max-age=30", cc)
+	}
+	if rr.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Error("X-Content-Type-Options header missing or wrong")
+	}
+}
+
+func TestGetBadge_SVGStructure(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/openai.svg", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	for _, want := range []string{
+		`<svg `, `xmlns="http://www.w3.org/2000/svg"`,
+		`<title>`, `</title>`,
+		`role="img"`, `aria-label=`,
+		`</svg>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("SVG missing %q", want)
+		}
+	}
+}
+
+func TestGetBadge_XSSEscaping(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("xss-test", `<script>alert(1)</script>`)},
+	}
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/xss-test.svg", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Error("SVG contains unescaped <script> tag — XSS vulnerability")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Error("expected HTML-escaped script tag in SVG")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -54,6 +54,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /v1/providers/{id}/history", s.getProviderHistory)
 	s.mux.HandleFunc("GET /v1/incidents", s.listIncidents)
 	s.mux.HandleFunc("GET /v1/incidents/{id}", s.getIncident)
+	s.mux.HandleFunc("GET /badge/{id}", s.getBadge)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary
- Adds `GET /badge/{provider_id}` (accepts `.svg` suffix) returning a shields.io-style flat SVG badge
- Badge shows provider name (left, dark) + status (right, colored): green=operational, amber=degraded, red=down, gray=unknown
- Unknown provider IDs return a gray "unknown" badge — not a JSON error — so badge consumers don't break
- Provider names are HTML-escaped before embedding; XSS test confirms safety
- Go `net/http` mux doesn't support mid-segment wildcards (`{id}.svg`), so the route is `/badge/{id}` with `.svg` stripped in the handler

## Test plan
- [x] `TestGetBadge_Operational` — green badge, correct provider name
- [x] `TestGetBadge_Degraded` — amber badge for ongoing major incident
- [x] `TestGetBadge_Down` — red badge for ongoing critical incident
- [x] `TestGetBadge_UnknownProvider` — gray unknown badge, HTTP 200
- [x] `TestGetBadge_CacheHeaders` — Cache-Control max-age=30, X-Content-Type-Options
- [x] `TestGetBadge_SVGStructure` — valid SVG with aria-label, title, role
- [x] `TestGetBadge_XSSEscaping` — `<script>` in provider name escaped to `&lt;script&gt;`

Closes #44