### PR TITLE
feat LLMS-017: RSS 2.0 incident feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ public APIs must add an entry under `## [Unreleased]`.
 - `gocyclo` CI step now ignores `_test.go` files; table-driven tests
   legitimately exceed the 10-complexity threshold
 
+### Added (LLMS-017)
+- `GET /feed.xml` — global RSS 2.0 feed of all incidents (last 50, all providers)
+- `GET /v1/providers/{id}/feed.xml` — per-provider RSS 2.0 feed; returns HTTP 404 for unknown provider IDs
+- Feed items include provider name, severity, status, start time, and a permalink GUID
+- `Cache-Control: max-age=60`; `X-Forwarded-Proto` honoured for absolute link URLs
+
 ### Added (LLMS-016)
 - `GET /badge/{provider_id}.svg` — shields.io-compatible flat SVG badge showing provider status
 - Colors: operational → green (`#4CAF50`), degraded → amber (`#FF9800`), down → red (`#F44336`), unknown → gray (`#9E9E9E`)

--- a/internal/api/feed.go
+++ b/internal/api/feed.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/jackc/pgx/v5"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+const feedMaxItems = 50
+
+// ----- RSS 2.0 structures -------------------------------------------------------
+
+type rssFeed struct {
+	XMLName xml.Name   `xml:"rss"`
+	Version string     `xml:"version,attr"`
+	Channel rssChannel `xml:"channel"`
+}
+
+type rssChannel struct {
+	Title       string    `xml:"title"`
+	Link        string    `xml:"link"`
+	Description string    `xml:"description"`
+	Language    string    `xml:"language"`
+	TTL         int       `xml:"ttl"`
+	Items       []rssItem `xml:"item"`
+}
+
+type rssItem struct {
+	Title       string  `xml:"title"`
+	Link        string  `xml:"link"`
+	Description string  `xml:"description"`
+	PubDate     string  `xml:"pubDate"`
+	GUID        rssGUID `xml:"guid"`
+}
+
+// rssGUID marks the guid as a permalink when the value is a stable URL.
+type rssGUID struct {
+	Value       string `xml:",chardata"`
+	IsPermaLink string `xml:"isPermaLink,attr"`
+}
+
+// ----- handlers -----------------------------------------------------------------
+
+func (s *Server) getGlobalFeed(w http.ResponseWriter, r *http.Request) {
+	incidents, err := s.store.ListIncidents(r.Context(), pgstore.ListIncidentsParams{
+		Limit:  feedMaxItems,
+		Offset: 0,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load incidents")
+		return
+	}
+
+	providers, _ := s.store.ListActiveProviders(r.Context())
+	names := providerNameMap(providers)
+
+	base := siteBase(r)
+	writeFeed(w, rssChannel{
+		Title:       "llmstatus.io — All Incidents",
+		Link:        base,
+		Description: "Real-time incident feed for all AI API providers monitored by llmstatus.io",
+		Language:    "en",
+		TTL:         1,
+		Items:       incidentsToItems(incidents, names, base),
+	})
+}
+
+func (s *Server) getProviderFeed(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	p, err := s.store.GetProvider(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "provider not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to fetch provider")
+		return
+	}
+
+	incidents, err := s.store.ListIncidentsByProvider(r.Context(), pgstore.ListIncidentsByProviderParams{
+		ProviderID: id,
+		Limit:      feedMaxItems,
+		Offset:     0,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load incidents")
+		return
+	}
+
+	base := siteBase(r)
+	writeFeed(w, rssChannel{
+		Title:       p.Name + " — Incidents | llmstatus.io",
+		Link:        base + "/providers/" + p.ID,
+		Description: "Incident feed for " + p.Name + " — llmstatus.io",
+		Language:    "en",
+		TTL:         1,
+		Items:       incidentsToItems(incidents, map[string]string{p.ID: p.Name}, base),
+	})
+}
+
+// ----- helpers ------------------------------------------------------------------
+
+func writeFeed(w http.ResponseWriter, ch rssChannel) {
+	w.Header().Set("Content-Type", "application/rss+xml; charset=utf-8")
+	w.Header().Set("Cache-Control", "max-age=60, s-maxage=60")
+
+	_, _ = fmt.Fprint(w, xml.Header)
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	_ = enc.Encode(rssFeed{Version: "2.0", Channel: ch})
+}
+
+func incidentsToItems(incidents []pgstore.Incident, names map[string]string, base string) []rssItem {
+	items := make([]rssItem, 0, len(incidents))
+	for _, inc := range incidents {
+		name := inc.ProviderID
+		if n, ok := names[inc.ProviderID]; ok {
+			name = n
+		}
+		link := base + "/incidents/" + inc.Slug
+		desc := fmt.Sprintf("Provider: %s | Severity: %s | Status: %s | Started: %s",
+			name, inc.Severity, inc.Status,
+			mustTime(inc.StartedAt).Format("Mon, 02 Jan 2006 15:04:05 UTC"),
+		)
+		if inc.Description.Valid && inc.Description.String != "" {
+			desc += "\n\n" + inc.Description.String
+		}
+		items = append(items, rssItem{
+			Title:       fmt.Sprintf("[%s] %s: %s", name, inc.Severity, inc.Title),
+			Link:        link,
+			Description: desc,
+			PubDate:     mustTime(inc.StartedAt).UTC().Format("Mon, 02 Jan 2006 15:04:05 -0700"),
+			GUID:        rssGUID{Value: link, IsPermaLink: "true"},
+		})
+	}
+	return items
+}
+
+func providerNameMap(providers []pgstore.Provider) map[string]string {
+	m := make(map[string]string, len(providers))
+	for _, p := range providers {
+		m[p.ID] = p.Name
+	}
+	return m
+}
+
+// siteBase constructs the scheme+host base URL, honouring X-Forwarded-Proto
+// set by nginx in production.
+func siteBase(r *http.Request) string {
+	scheme := r.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	return scheme + "://" + r.Host
+}

--- a/internal/api/feed_test.go
+++ b/internal/api/feed_test.go
@@ -1,0 +1,231 @@
+package api_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/llmstatus/llmstatus/internal/api"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// xmlFeed mirrors rssFeed for decoding in tests — kept internal to test file.
+type xmlFeed struct {
+	XMLName xml.Name   `xml:"rss"`
+	Version string     `xml:"version,attr"`
+	Channel xmlChannel `xml:"channel"`
+}
+
+type xmlChannel struct {
+	Title       string    `xml:"title"`
+	Link        string    `xml:"link"`
+	Description string    `xml:"description"`
+	Language    string    `xml:"language"`
+	Items       []xmlItem `xml:"item"`
+}
+
+type xmlItem struct {
+	Title   string `xml:"title"`
+	Link    string `xml:"link"`
+	PubDate string `xml:"pubDate"`
+	GUID    string `xml:"guid"`
+}
+
+// ---- global feed ---------------------------------------------------------------
+
+func TestGetGlobalFeed_ContentType(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Host = "llmstatus.io"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200", rr.Code)
+	}
+	ct := rr.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/rss+xml") {
+		t.Fatalf("Content-Type=%q want application/rss+xml", ct)
+	}
+	cc := rr.Header().Get("Cache-Control")
+	if !strings.Contains(cc, "max-age=60") {
+		t.Fatalf("Cache-Control=%q want max-age=60", cc)
+	}
+}
+
+func TestGetGlobalFeed_XMLDeclaration(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Host = "llmstatus.io"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if !strings.HasPrefix(rr.Body.String(), "<?xml") {
+		t.Error("response does not start with XML declaration")
+	}
+}
+
+func TestGetGlobalFeed_ValidRSS(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+		incidents: []pgstore.Incident{
+			fixtureIncident("openai", "openai-outage-001", "ongoing", "critical"),
+			fixtureIncident("openai", "openai-latency-002", "resolved", "minor"),
+		},
+	}
+	srv := api.New(store)
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Host = "llmstatus.io"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	var feed xmlFeed
+	if err := xml.NewDecoder(rr.Body).Decode(&feed); err != nil {
+		t.Fatalf("XML decode error: %v", err)
+	}
+	if feed.Version != "2.0" {
+		t.Errorf("RSS version=%q want 2.0", feed.Version)
+	}
+	if feed.Channel.Language != "en" {
+		t.Errorf("language=%q want en", feed.Channel.Language)
+	}
+	if len(feed.Channel.Items) != 2 {
+		t.Fatalf("items=%d want 2", len(feed.Channel.Items))
+	}
+}
+
+func TestGetGlobalFeed_ItemFields(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+		incidents: []pgstore.Incident{fixtureIncident("openai", "openai-outage-001", "ongoing", "critical")},
+	}
+	srv := api.New(store)
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	var feed xmlFeed
+	if err := xml.NewDecoder(rr.Body).Decode(&feed); err != nil {
+		t.Fatalf("XML decode: %v", err)
+	}
+	item := feed.Channel.Items[0]
+
+	if !strings.Contains(item.Title, "OpenAI") {
+		t.Errorf("item title %q missing provider name", item.Title)
+	}
+	if !strings.Contains(item.Title, "critical") {
+		t.Errorf("item title %q missing severity", item.Title)
+	}
+	if !strings.Contains(item.Link, "example.com") {
+		t.Errorf("item link %q should contain host", item.Link)
+	}
+	if !strings.Contains(item.Link, "openai-outage-001") {
+		t.Errorf("item link %q should contain slug", item.Link)
+	}
+	if item.PubDate == "" {
+		t.Error("item pubDate is empty")
+	}
+	if item.GUID == "" {
+		t.Error("item guid is empty")
+	}
+}
+
+func TestGetGlobalFeed_ProviderIDFallback(t *testing.T) {
+	// Incident references a provider not in ListActiveProviders — falls back to ID.
+	store := &fakeStore{
+		providers: []pgstore.Provider{},
+		incidents: []pgstore.Incident{fixtureIncident("deepseek", "ds-001", "ongoing", "major")},
+	}
+	srv := api.New(store)
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Host = "llmstatus.io"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "deepseek") {
+		t.Error("feed should fall back to provider ID when name unavailable")
+	}
+}
+
+func TestGetGlobalFeed_EmptyIncidents(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Host = "llmstatus.io"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	var feed xmlFeed
+	if err := xml.NewDecoder(rr.Body).Decode(&feed); err != nil {
+		t.Fatalf("XML decode: %v", err)
+	}
+	if len(feed.Channel.Items) != 0 {
+		t.Errorf("items=%d want 0 for empty store", len(feed.Channel.Items))
+	}
+}
+
+// ---- per-provider feed ---------------------------------------------------------
+
+func TestGetProviderFeed_Success(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("anthropic", "Anthropic")},
+		incidents: []pgstore.Incident{fixtureIncident("anthropic", "ant-001", "resolved", "minor")},
+	}
+	srv := api.New(store)
+	req := httptest.NewRequest(http.MethodGet, "/v1/providers/anthropic/feed.xml", nil)
+	req.Host = "llmstatus.io"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200", rr.Code)
+	}
+	var feed xmlFeed
+	if err := xml.NewDecoder(rr.Body).Decode(&feed); err != nil {
+		t.Fatalf("XML decode: %v", err)
+	}
+	if !strings.Contains(feed.Channel.Title, "Anthropic") {
+		t.Errorf("channel title %q missing provider name", feed.Channel.Title)
+	}
+	if len(feed.Channel.Items) != 1 {
+		t.Fatalf("items=%d want 1", len(feed.Channel.Items))
+	}
+}
+
+func TestGetProviderFeed_NotFound(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	req := httptest.NewRequest(http.MethodGet, "/v1/providers/nonexistent/feed.xml", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", rr.Code)
+	}
+}
+
+func TestGetProviderFeed_XForwardedProto(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	srv := api.New(store)
+	req := httptest.NewRequest(http.MethodGet, "/v1/providers/openai/feed.xml", nil)
+	req.Host = "llmstatus.io"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "https://llmstatus.io") {
+		t.Errorf("feed links should use https from X-Forwarded-Proto, got: %s", body[:min(len(body), 300)])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -55,6 +55,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /v1/incidents", s.listIncidents)
 	s.mux.HandleFunc("GET /v1/incidents/{id}", s.getIncident)
 	s.mux.HandleFunc("GET /badge/{id}", s.getBadge)
+	s.mux.HandleFunc("GET /feed.xml", s.getGlobalFeed)
+	s.mux.HandleFunc("GET /v1/providers/{id}/feed.xml", s.getProviderFeed)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary
- Adds `GET /feed.xml` (global, last 50 incidents across all providers) and `GET /v1/providers/{id}/feed.xml` (per-provider)
- Both return valid RSS 2.0 XML with `application/rss+xml` content type and `Cache-Control: max-age=60`
- Item titles: `[Provider Name] severity: Incident Title`; GUID is a permalink to the incident page
- `X-Forwarded-Proto` header honoured when constructing absolute item URLs (nginx proxy support)
- Per-provider feed returns JSON 404 for unknown provider IDs
- Go mux pattern `/v1/providers/{id}/feed.xml` works because `{id}` is a full path segment and `feed.xml` is a literal suffix

## Test plan
- [x] `TestGetGlobalFeed_ContentType` — `application/rss+xml`, `max-age=60`
- [x] `TestGetGlobalFeed_XMLDeclaration` — response starts with `<?xml`
- [x] `TestGetGlobalFeed_ValidRSS` — parses as RSS 2.0 with correct item count
- [x] `TestGetGlobalFeed_ItemFields` — title contains provider name + severity, link contains host + slug
- [x] `TestGetGlobalFeed_ProviderIDFallback` — falls back to provider ID when name unavailable
- [x] `TestGetGlobalFeed_EmptyIncidents` — empty item list on empty store
- [x] `TestGetProviderFeed_Success` — channel title contains provider name, one item returned
- [x] `TestGetProviderFeed_NotFound` — 404 for unknown provider
- [x] `TestGetProviderFeed_XForwardedProto` — links use `https://` from header

Closes #46