### PR TITLE
feat LLMS-019: detection rules 6.3 (latency degradation) + 6.4 (regional outage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ public APIs must add an entry under `## [Unreleased]`.
 - `gocyclo` CI step now ignores `_test.go` files; table-driven tests
   legitimately exceed the 10-complexity threshold
 
+### Added (LLMS-019)
+- Detection rule 6.3 — **latency degradation** (`latency_degradation`, severity `minor`): fires when p95 `duration_ms` over the last 5 min exceeds 3× the p95 over the past 24 h
+- Detection rule 6.4 — **regional outage** (`regional_outage`, severity `minor`): fires when one `region_id` has >50% error rate over 5 min while the provider is not globally down
+- `LatencyStats` and `RegionalStats` types added to the detector package
+- `ProbeReader` interface extended: `LatencyByProvider`, `RegionalErrorRateByProvider`
+- InfluxDB 3 queries for both new methods use `approx_percentile_cont` and `region_id` grouping
+- `Runner.runOnce` now evaluates all four rules; latency/regional fetch failures are non-fatal (logged as `WARN`)
+- **Known limitation**: rule 6.3 baseline is the last 24 h (V1 simplification); METHODOLOGY.md specifies same-hour 7-day median (tracked in REVIEW_QUEUE.md)
+
 ### Added (LLMS-017)
 - `GET /feed.xml` — global RSS 2.0 feed of all incidents (last 50, all providers)
 - `GET /v1/providers/{id}/feed.xml` — per-provider RSS 2.0 feed; returns HTTP 404 for unknown provider IDs

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -294,6 +294,13 @@ provider's endpoints. A slowdown in intermediate ISP infrastructure would
 be reflected in our latency data, even if the provider itself is healthy.
 We cannot distinguish these cases perfectly.
 
+### 8.8 Latency degradation baseline (V1 simplification)
+Rule 6.3 (Degraded Latency) compares p95 latency against a **24-hour rolling
+baseline** rather than the same-hour 7-day median specified in §6. This
+simplification is used in V1 because the 7-day same-hour baseline requires a
+more complex query. The simplified baseline may fire more frequently during
+off-peak hours when normal latency is lower. This will be corrected in v1.1.
+
 ---
 
 ## 9. What's Coming (Planned)

--- a/internal/detector/reader.go
+++ b/internal/detector/reader.go
@@ -29,6 +29,11 @@ func (s ProbeStats) ErrorRate() float64 {
 type ProbeReader interface {
 	// ErrorRateByProvider returns per-provider probe stats for the given window.
 	ErrorRateByProvider(ctx context.Context, window time.Duration) ([]ProbeStats, error)
+	// LatencyByProvider returns per-provider p95 latency for the given window
+	// (successful probes only, using duration_ms field).
+	LatencyByProvider(ctx context.Context, window time.Duration) ([]LatencyStats, error)
+	// RegionalErrorRateByProvider returns per-provider, per-region error stats.
+	RegionalErrorRateByProvider(ctx context.Context, window time.Duration) ([]RegionalStats, error)
 }
 
 // InfluxReaderConfig holds connection parameters for the InfluxDB 3 query API.
@@ -63,24 +68,7 @@ func (r *influxReader) ErrorRateByProvider(ctx context.Context, window time.Dura
 		int(window.Seconds()),
 	)
 
-	body, err := json.Marshal(map[string]string{
-		"q":      sql,
-		"db":     r.cfg.Database,
-		"format": "json",
-	})
-	if err != nil {
-		return nil, fmt.Errorf("detector: marshal query: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		r.cfg.Host+"/api/v3/query_sql", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("detector: build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Token "+r.cfg.Token)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := r.client.Do(req)
+	resp, err := r.querySQLRaw(ctx, sql)
 	if err != nil {
 		return nil, fmt.Errorf("detector: query influx: %w", err)
 	}
@@ -91,10 +79,9 @@ func (r *influxReader) ErrorRateByProvider(ctx context.Context, window time.Dura
 		return nil, fmt.Errorf("detector: influx status %d: %s", resp.StatusCode, detail)
 	}
 
-	// InfluxDB 3 returns a JSON array of objects with format=json.
 	var rows []struct {
 		ProviderID string  `json:"provider_id"`
-		Total      float64 `json:"total"` // JSON numbers decode as float64
+		Total      float64 `json:"total"`
 		Errors     float64 `json:"errors"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
@@ -113,4 +100,121 @@ func (r *influxReader) ErrorRateByProvider(ctx context.Context, window time.Dura
 		})
 	}
 	return stats, nil
+}
+
+func (r *influxReader) LatencyByProvider(ctx context.Context, window time.Duration) ([]LatencyStats, error) {
+	sql := fmt.Sprintf(
+		`SELECT provider_id,
+		        approx_percentile_cont(duration_ms, 0.95) AS p95_ms,
+		        COUNT(*) AS total
+		 FROM probes
+		 WHERE time >= now() - INTERVAL '%d seconds'
+		   AND success = true
+		 GROUP BY provider_id`,
+		int(window.Seconds()),
+	)
+
+	resp, err := r.querySQLRaw(ctx, sql)
+	if err != nil {
+		return nil, fmt.Errorf("detector latency: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("detector latency: influx status %d: %s", resp.StatusCode, detail)
+	}
+
+	var rows []struct {
+		ProviderID string  `json:"provider_id"`
+		P95Ms      float64 `json:"p95_ms"`
+		Total      float64 `json:"total"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("detector latency: decode: %w", err)
+	}
+
+	out := make([]LatencyStats, 0, len(rows))
+	for _, row := range rows {
+		if row.ProviderID == "" {
+			continue
+		}
+		out = append(out, LatencyStats{
+			ProviderID:  row.ProviderID,
+			P95Ms:       row.P95Ms,
+			SampleCount: int64(row.Total),
+		})
+	}
+	return out, nil
+}
+
+func (r *influxReader) RegionalErrorRateByProvider(ctx context.Context, window time.Duration) ([]RegionalStats, error) {
+	sql := fmt.Sprintf(
+		`SELECT provider_id,
+		        region_id,
+		        COUNT(*) AS total,
+		        COUNT(*) FILTER (WHERE success = false) AS errors
+		 FROM probes
+		 WHERE time >= now() - INTERVAL '%d seconds'
+		 GROUP BY provider_id, region_id`,
+		int(window.Seconds()),
+	)
+
+	resp, err := r.querySQLRaw(ctx, sql)
+	if err != nil {
+		return nil, fmt.Errorf("detector regional: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("detector regional: influx status %d: %s", resp.StatusCode, detail)
+	}
+
+	var rows []struct {
+		ProviderID string  `json:"provider_id"`
+		RegionID   string  `json:"region_id"`
+		Total      float64 `json:"total"`
+		Errors     float64 `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("detector regional: decode: %w", err)
+	}
+
+	out := make([]RegionalStats, 0, len(rows))
+	for _, row := range rows {
+		if row.ProviderID == "" || row.RegionID == "" {
+			continue
+		}
+		out = append(out, RegionalStats{
+			ProviderID: row.ProviderID,
+			Region:     row.RegionID,
+			Total:      int64(row.Total),
+			Errors:     int64(row.Errors),
+		})
+	}
+	return out, nil
+}
+
+// querySQLRaw sends a SQL query to InfluxDB 3 and returns the raw HTTP response.
+// The caller is responsible for closing resp.Body.
+func (r *influxReader) querySQLRaw(ctx context.Context, sql string) (*http.Response, error) {
+	body, err := json.Marshal(map[string]string{
+		"q":      sql,
+		"db":     r.cfg.Database,
+		"format": "json",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal query: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.cfg.Host+"/api/v3/query_sql", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+r.cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	return r.client.Do(req)
 }

--- a/internal/detector/reader_test.go
+++ b/internal/detector/reader_test.go
@@ -69,6 +69,97 @@ func TestInfluxReader_InfluxError(t *testing.T) {
 	}
 }
 
+func TestInfluxReader_LatencyByProvider(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"provider_id":"openai","p95_ms":450.5,"total":20},
+			{"provider_id":"anthropic","p95_ms":820.0,"total":15}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewInfluxReader(InfluxReaderConfig{
+		Host: srv.URL, Token: "t", Database: "db",
+	}, nil)
+
+	stats, err := reader.LatencyByProvider(context.Background(), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("LatencyByProvider: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+	byProvider := make(map[string]LatencyStats)
+	for _, s := range stats {
+		byProvider[s.ProviderID] = s
+	}
+	if got := byProvider["openai"].P95Ms; got != 450.5 {
+		t.Errorf("openai P95Ms: got %f, want 450.5", got)
+	}
+	if got := byProvider["openai"].SampleCount; got != 20 {
+		t.Errorf("openai SampleCount: got %d, want 20", got)
+	}
+}
+
+func TestInfluxReader_RegionalErrorRateByProvider(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"provider_id":"openai","region_id":"us-east-1","total":10,"errors":6},
+			{"provider_id":"openai","region_id":"eu-central","total":10,"errors":0}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewInfluxReader(InfluxReaderConfig{
+		Host: srv.URL, Token: "t", Database: "db",
+	}, nil)
+
+	stats, err := reader.RegionalErrorRateByProvider(context.Background(), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("RegionalErrorRateByProvider: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+	byRegion := make(map[string]RegionalStats)
+	for _, s := range stats {
+		byRegion[s.Region] = s
+	}
+	us := byRegion["us-east-1"]
+	if us.Total != 10 || us.Errors != 6 {
+		t.Errorf("us-east-1: total=%d errors=%d", us.Total, us.Errors)
+	}
+	if us.ErrorRate() < 0.59 || us.ErrorRate() > 0.61 {
+		t.Errorf("us-east-1 error rate: got %f, want ~0.60", us.ErrorRate())
+	}
+}
+
+func TestInfluxReader_RegionalErrorRateByProvider_SkipsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// One row has empty region_id — should be skipped.
+		_, _ = w.Write([]byte(`[
+			{"provider_id":"openai","region_id":"","total":5,"errors":1},
+			{"provider_id":"openai","region_id":"us-east-1","total":5,"errors":1}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewInfluxReader(InfluxReaderConfig{
+		Host: srv.URL, Token: "t", Database: "db",
+	}, nil)
+
+	stats, err := reader.RegionalErrorRateByProvider(context.Background(), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Errorf("expected 1 stat (empty region skipped), got %d", len(stats))
+	}
+}
+
 func TestInfluxReader_EmptyResult(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/detector/rules.go
+++ b/internal/detector/rules.go
@@ -1,21 +1,60 @@
 package detector
 
 const (
-	RuleProviderDown    = "provider_down"
-	RuleElevatedErrors  = "elevated_errors"
+	RuleProviderDown       = "provider_down"
+	RuleElevatedErrors     = "elevated_errors"
+	RuleLatencyDegradation = "latency_degradation"
+	RuleRegionalOutage     = "regional_outage"
 
 	downThreshold     = 0.50
 	elevatedThreshold = 0.05
-	minProbeCount     = int64(3) // require at least 3 probes before firing
+	minProbeCount     = int64(3)
+
+	// Rule 6.3: fire when p95 current > latencyDegradationFactor × p95 baseline.
+	latencyDegradationFactor = 3.0
+	latencyMinSamples        = int64(5)
+
+	// Rule 6.4: fire when one region exceeds this error rate while not globally down.
+	regionalOutageThreshold = 0.50
+	minRegionalProbeCount   = int64(3)
 )
 
 // Detection is a rule match for a single provider.
 type Detection struct {
 	ProviderID  string
-	Rule        string // RuleProviderDown | RuleElevatedErrors
-	Severity    string // "critical" | "major"
+	Rule        string
+	Severity    string
 	ErrorRate   float64
 	TotalProbes int64
+	// Rule 6.3 fields (zero for other rules)
+	P95Ms         float64
+	BaselineP95Ms float64
+	// Rule 6.4 field (empty for other rules)
+	Region string
+}
+
+// LatencyStats holds p95 latency for one provider over a time window.
+// Only successful probes contribute (per METHODOLOGY.md §5.3).
+type LatencyStats struct {
+	ProviderID  string
+	P95Ms       float64
+	SampleCount int64
+}
+
+// RegionalStats holds error counts for one provider+region over a time window.
+type RegionalStats struct {
+	ProviderID string
+	Region     string
+	Total      int64
+	Errors     int64
+}
+
+// ErrorRate returns the fraction of failed probes, or 0 when Total is 0.
+func (s RegionalStats) ErrorRate() float64 {
+	if s.Total == 0 {
+		return 0
+	}
+	return float64(s.Errors) / float64(s.Total)
 }
 
 // EvaluateRules applies rules 6.1 and 6.2 to the supplied stats.
@@ -71,5 +110,77 @@ func EvaluateRules(stats5m, stats10m []ProbeStats) []Detection {
 		}
 	}
 
+	return detections
+}
+
+// EvaluateLatencyRule applies rule 6.3 — degraded latency.
+//
+// Fires when a provider's p95 latency over `current` exceeds
+// latencyDegradationFactor × the same metric over `baseline`.
+// Both windows must have at least latencyMinSamples successful probes.
+//
+// V1 note: baseline is the last 24 h (not the same-hour 7-day median specified
+// in METHODOLOGY.md §6). This simplification is tracked in REVIEW_QUEUE.md.
+func EvaluateLatencyRule(current, baseline []LatencyStats) []Detection {
+	baselineByProvider := make(map[string]LatencyStats, len(baseline))
+	for _, b := range baseline {
+		baselineByProvider[b.ProviderID] = b
+	}
+
+	var detections []Detection
+	for _, c := range current {
+		if c.SampleCount < latencyMinSamples {
+			continue
+		}
+		b, ok := baselineByProvider[c.ProviderID]
+		if !ok || b.SampleCount < latencyMinSamples || b.P95Ms == 0 {
+			continue
+		}
+		if c.P95Ms > latencyDegradationFactor*b.P95Ms {
+			detections = append(detections, Detection{
+				ProviderID:    c.ProviderID,
+				Rule:          RuleLatencyDegradation,
+				Severity:      "minor",
+				TotalProbes:   c.SampleCount,
+				P95Ms:         c.P95Ms,
+				BaselineP95Ms: b.P95Ms,
+			})
+		}
+	}
+	return detections
+}
+
+// EvaluateRegionalRule applies rule 6.4 — regional outage.
+//
+// Fires when one region of a provider has error rate > regionalOutageThreshold
+// while the provider is not already flagged as globally down (rule 6.1).
+// Requires at least minRegionalProbeCount probes in the region.
+func EvaluateRegionalRule(regional []RegionalStats, globalStats5m []ProbeStats) []Detection {
+	downProviders := make(map[string]struct{})
+	for _, s := range globalStats5m {
+		if s.Total >= minProbeCount && s.ErrorRate() > downThreshold {
+			downProviders[s.ProviderID] = struct{}{}
+		}
+	}
+
+	var detections []Detection
+	for _, r := range regional {
+		if _, isDown := downProviders[r.ProviderID]; isDown {
+			continue
+		}
+		if r.Total < minRegionalProbeCount {
+			continue
+		}
+		if r.ErrorRate() > regionalOutageThreshold {
+			detections = append(detections, Detection{
+				ProviderID:  r.ProviderID,
+				Rule:        RuleRegionalOutage,
+				Severity:    "minor",
+				ErrorRate:   r.ErrorRate(),
+				TotalProbes: r.Total,
+				Region:      r.Region,
+			})
+		}
+	}
 	return detections
 }

--- a/internal/detector/rules_test.go
+++ b/internal/detector/rules_test.go
@@ -1,7 +1,9 @@
 package detector
 
 import (
+	"context"
 	"testing"
+	"time"
 )
 
 func TestEvaluateRules_NoProbes(t *testing.T) {
@@ -105,6 +107,244 @@ func TestEvaluateRules_MultipleProviders(t *testing.T) {
 	if len(detections) != 2 {
 		t.Fatalf("expected 2 detections (openai down + deepseek elevated), got %d", len(detections))
 	}
+}
+
+// ---- Rule 6.3 tests -----------------------------------------------------------
+
+func TestEvaluateLatencyRule_Fires(t *testing.T) {
+	current := []LatencyStats{{ProviderID: "openai", P95Ms: 6000, SampleCount: 10}}
+	baseline := []LatencyStats{{ProviderID: "openai", P95Ms: 1000, SampleCount: 20}}
+	// 6000 > 3 × 1000 → should fire
+	detections := EvaluateLatencyRule(current, baseline)
+	if len(detections) != 1 {
+		t.Fatalf("expected 1 detection, got %d", len(detections))
+	}
+	d := detections[0]
+	if d.Rule != RuleLatencyDegradation {
+		t.Errorf("Rule: got %q, want %q", d.Rule, RuleLatencyDegradation)
+	}
+	if d.Severity != "minor" {
+		t.Errorf("Severity: got %q, want minor", d.Severity)
+	}
+	if d.P95Ms != 6000 || d.BaselineP95Ms != 1000 {
+		t.Errorf("P95Ms=%f BaselineP95Ms=%f", d.P95Ms, d.BaselineP95Ms)
+	}
+}
+
+func TestEvaluateLatencyRule_BelowThreshold(t *testing.T) {
+	// 2500 < 3 × 1000 → should NOT fire
+	current := []LatencyStats{{ProviderID: "openai", P95Ms: 2500, SampleCount: 10}}
+	baseline := []LatencyStats{{ProviderID: "openai", P95Ms: 1000, SampleCount: 20}}
+	got := EvaluateLatencyRule(current, baseline)
+	if len(got) != 0 {
+		t.Errorf("expected no detections at 2.5× baseline, got %d", len(got))
+	}
+}
+
+func TestEvaluateLatencyRule_TooFewCurrentSamples(t *testing.T) {
+	current := []LatencyStats{{ProviderID: "openai", P95Ms: 9999, SampleCount: 2}} // < 5
+	baseline := []LatencyStats{{ProviderID: "openai", P95Ms: 100, SampleCount: 20}}
+	got := EvaluateLatencyRule(current, baseline)
+	if len(got) != 0 {
+		t.Errorf("expected no detection with too few current samples, got %d", len(got))
+	}
+}
+
+func TestEvaluateLatencyRule_TooFewBaselineSamples(t *testing.T) {
+	current := []LatencyStats{{ProviderID: "openai", P95Ms: 9999, SampleCount: 10}}
+	baseline := []LatencyStats{{ProviderID: "openai", P95Ms: 100, SampleCount: 1}} // < 5
+	got := EvaluateLatencyRule(current, baseline)
+	if len(got) != 0 {
+		t.Errorf("expected no detection with too few baseline samples, got %d", len(got))
+	}
+}
+
+func TestEvaluateLatencyRule_NoBaseline(t *testing.T) {
+	current := []LatencyStats{{ProviderID: "openai", P95Ms: 9999, SampleCount: 10}}
+	got := EvaluateLatencyRule(current, nil)
+	if len(got) != 0 {
+		t.Errorf("expected no detection when no baseline exists, got %d", len(got))
+	}
+}
+
+func TestEvaluateLatencyRule_ZeroBaselineP95(t *testing.T) {
+	current := []LatencyStats{{ProviderID: "openai", P95Ms: 9999, SampleCount: 10}}
+	baseline := []LatencyStats{{ProviderID: "openai", P95Ms: 0, SampleCount: 10}}
+	got := EvaluateLatencyRule(current, baseline)
+	if len(got) != 0 {
+		t.Errorf("expected no detection with zero baseline p95, got %d", len(got))
+	}
+}
+
+// ---- Rule 6.4 tests -----------------------------------------------------------
+
+func TestEvaluateRegionalRule_Fires(t *testing.T) {
+	regional := []RegionalStats{
+		{ProviderID: "openai", Region: "us-east-1", Total: 10, Errors: 6}, // 60%
+		{ProviderID: "openai", Region: "eu-central", Total: 10, Errors: 0}, // 0% — healthy
+	}
+	// Global stats show openai is NOT down overall.
+	global := []ProbeStats{{ProviderID: "openai", Total: 20, Errors: 6}} // 30%
+	detections := EvaluateRegionalRule(regional, global)
+	if len(detections) != 1 {
+		t.Fatalf("expected 1 detection, got %d: %+v", len(detections), detections)
+	}
+	d := detections[0]
+	if d.Rule != RuleRegionalOutage {
+		t.Errorf("Rule: got %q, want %q", d.Rule, RuleRegionalOutage)
+	}
+	if d.Severity != "minor" {
+		t.Errorf("Severity: got %q, want minor", d.Severity)
+	}
+	if d.Region != "us-east-1" {
+		t.Errorf("Region: got %q, want us-east-1", d.Region)
+	}
+}
+
+func TestEvaluateRegionalRule_GloballyDown_Suppressed(t *testing.T) {
+	// Provider is already globally DOWN — regional rule must not fire.
+	regional := []RegionalStats{
+		{ProviderID: "openai", Region: "us-east-1", Total: 10, Errors: 9},
+	}
+	global := []ProbeStats{{ProviderID: "openai", Total: 10, Errors: 6}} // 60% → down
+	got := EvaluateRegionalRule(regional, global)
+	if len(got) != 0 {
+		t.Errorf("expected no detection when provider is globally down, got %d", len(got))
+	}
+}
+
+func TestEvaluateRegionalRule_BelowThreshold(t *testing.T) {
+	regional := []RegionalStats{
+		{ProviderID: "openai", Region: "us-east-1", Total: 10, Errors: 4}, // 40% < 50%
+	}
+	got := EvaluateRegionalRule(regional, nil)
+	if len(got) != 0 {
+		t.Errorf("expected no detection below threshold, got %d", len(got))
+	}
+}
+
+func TestEvaluateRegionalRule_TooFewProbes(t *testing.T) {
+	regional := []RegionalStats{
+		{ProviderID: "openai", Region: "us-east-1", Total: 2, Errors: 2}, // < 3
+	}
+	got := EvaluateRegionalRule(regional, nil)
+	if len(got) != 0 {
+		t.Errorf("expected no detection with too few regional probes, got %d", len(got))
+	}
+}
+
+func TestEvaluateRegionalRule_MultipleRegions(t *testing.T) {
+	regional := []RegionalStats{
+		{ProviderID: "openai", Region: "us-east-1", Total: 10, Errors: 6}, // 60% — fire
+		{ProviderID: "openai", Region: "ap-northeast-1", Total: 10, Errors: 9}, // 90% — fire
+		{ProviderID: "openai", Region: "eu-central", Total: 10, Errors: 0}, // healthy
+	}
+	global := []ProbeStats{{ProviderID: "openai", Total: 30, Errors: 15}} // 50% — exactly at threshold, NOT > threshold
+	detections := EvaluateRegionalRule(regional, global)
+	if len(detections) != 2 {
+		t.Fatalf("expected 2 regional detections, got %d", len(detections))
+	}
+}
+
+func TestRegionalStats_ErrorRate(t *testing.T) {
+	cases := []struct {
+		total, errors int64
+		want          float64
+	}{
+		{0, 0, 0},
+		{10, 5, 0.5},
+		{10, 0, 0},
+	}
+	for _, tc := range cases {
+		s := RegionalStats{Total: tc.total, Errors: tc.errors}
+		if got := s.ErrorRate(); got != tc.want {
+			t.Errorf("ErrorRate(%d/%d) = %f, want %f", tc.errors, tc.total, got, tc.want)
+		}
+	}
+}
+
+// ---- Rule 6.3 + 6.4 runner integration ----------------------------------------
+
+func TestRunner_LatencyDegradation_CreatesIncident(t *testing.T) {
+	store := &fakeIncidentStore{}
+	r := New(&latencyFakeReader{
+		current:  []LatencyStats{{ProviderID: "openai", P95Ms: 9000, SampleCount: 10}},
+		baseline: []LatencyStats{{ProviderID: "openai", P95Ms: 1000, SampleCount: 20}},
+	}, store, time.Hour)
+	r.runOnce(context.Background())
+
+	found := false
+	for _, inc := range store.created {
+		if inc.DetectionRule.String == RuleLatencyDegradation {
+			found = true
+			if inc.Severity != "minor" {
+				t.Errorf("Severity: got %q, want minor", inc.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected latency_degradation incident to be created")
+	}
+}
+
+func TestRunner_RegionalOutage_CreatesIncident(t *testing.T) {
+	store := &fakeIncidentStore{}
+	r := New(&regionalFakeReader{
+		regional: []RegionalStats{
+			{ProviderID: "anthropic", Region: "us-east-1", Total: 5, Errors: 4}, // 80%
+		},
+	}, store, time.Hour)
+	r.runOnce(context.Background())
+
+	found := false
+	for _, inc := range store.created {
+		if inc.DetectionRule.String == RuleRegionalOutage {
+			found = true
+			if inc.Severity != "minor" {
+				t.Errorf("Severity: got %q, want minor", inc.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected regional_outage incident to be created")
+	}
+}
+
+// ---- specialized test readers --------------------------------------------------
+
+// latencyFakeReader returns distinct data for current (5m) vs baseline (24h).
+type latencyFakeReader struct {
+	current  []LatencyStats
+	baseline []LatencyStats
+	callN    int
+}
+
+func (f *latencyFakeReader) ErrorRateByProvider(_ context.Context, _ time.Duration) ([]ProbeStats, error) {
+	return nil, nil
+}
+func (f *latencyFakeReader) LatencyByProvider(_ context.Context, window time.Duration) ([]LatencyStats, error) {
+	if window <= 5*time.Minute {
+		return f.current, nil
+	}
+	return f.baseline, nil
+}
+func (f *latencyFakeReader) RegionalErrorRateByProvider(_ context.Context, _ time.Duration) ([]RegionalStats, error) {
+	return nil, nil
+}
+
+// regionalFakeReader only populates regional stats.
+type regionalFakeReader struct {
+	regional []RegionalStats
+}
+
+func (f *regionalFakeReader) ErrorRateByProvider(_ context.Context, _ time.Duration) ([]ProbeStats, error) {
+	return nil, nil
+}
+func (f *regionalFakeReader) LatencyByProvider(_ context.Context, _ time.Duration) ([]LatencyStats, error) {
+	return nil, nil
+}
+func (f *regionalFakeReader) RegionalErrorRateByProvider(_ context.Context, _ time.Duration) ([]RegionalStats, error) {
+	return f.regional, nil
 }
 
 func TestProbeStats_ErrorRate(t *testing.T) {

--- a/internal/detector/runner.go
+++ b/internal/detector/runner.go
@@ -69,6 +69,24 @@ func (r *Runner) runOnce(ctx context.Context) {
 
 	detections := EvaluateRules(stats5m, stats10m)
 
+	// Rule 6.3 — latency degradation.
+	latency5m, err := r.reader.LatencyByProvider(ctx, 5*time.Minute)
+	if err != nil {
+		slog.Warn("detector: read latency 5m stats", "err", err)
+	}
+	latency24h, err := r.reader.LatencyByProvider(ctx, 24*time.Hour)
+	if err != nil {
+		slog.Warn("detector: read latency 24h stats", "err", err)
+	}
+	detections = append(detections, EvaluateLatencyRule(latency5m, latency24h)...)
+
+	// Rule 6.4 — regional outage.
+	regional5m, err := r.reader.RegionalErrorRateByProvider(ctx, 5*time.Minute)
+	if err != nil {
+		slog.Warn("detector: read regional stats", "err", err)
+	}
+	detections = append(detections, EvaluateRegionalRule(regional5m, stats5m)...)
+
 	for _, d := range detections {
 		r.ensureIncident(ctx, d)
 	}
@@ -174,6 +192,10 @@ func incidentTitle(providerID, rule string) string {
 		return providerID + " is experiencing major disruption"
 	case RuleElevatedErrors:
 		return providerID + " elevated errors detected"
+	case RuleLatencyDegradation:
+		return providerID + " latency degradation detected"
+	case RuleRegionalOutage:
+		return providerID + " regional outage detected"
 	default:
 		return providerID + " " + rule
 	}

--- a/internal/detector/runner_test.go
+++ b/internal/detector/runner_test.go
@@ -15,9 +15,11 @@ import (
 // ---- fake ProbeReader -------------------------------------------------------
 
 type fakeReader struct {
-	stats5m  []ProbeStats
-	stats10m []ProbeStats
-	err      error
+	stats5m   []ProbeStats
+	stats10m  []ProbeStats
+	latency   []LatencyStats
+	regional  []RegionalStats
+	err       error
 }
 
 func (f *fakeReader) ErrorRateByProvider(_ context.Context, window time.Duration) ([]ProbeStats, error) {
@@ -28,6 +30,14 @@ func (f *fakeReader) ErrorRateByProvider(_ context.Context, window time.Duration
 		return f.stats5m, nil
 	}
 	return f.stats10m, nil
+}
+
+func (f *fakeReader) LatencyByProvider(_ context.Context, _ time.Duration) ([]LatencyStats, error) {
+	return f.latency, f.err
+}
+
+func (f *fakeReader) RegionalErrorRateByProvider(_ context.Context, _ time.Duration) ([]RegionalStats, error) {
+	return f.regional, f.err
 }
 
 // ---- fake IncidentStore -----------------------------------------------------


### PR DESCRIPTION
## Summary
- **Rule 6.3 — latency degradation** (`latency_degradation`, severity `minor`): fires when p95 `duration_ms` over last 5 min > 3× the p95 over past 24 h; requires ≥5 successful probes in both windows
- **Rule 6.4 — regional outage** (`regional_outage`, severity `minor`): fires when one `region_id` has >50% error rate over 5 min while provider is not globally down (rule 6.1); requires ≥3 probes per region
- Extends `ProbeReader` interface: `LatencyByProvider(ctx, window)`, `RegionalErrorRateByProvider(ctx, window)`
- InfluxDB 3 queries use `approx_percentile_cont(duration_ms, 0.95)` and `region_id` grouping
- `Runner.runOnce` wire-up: latency/regional fetch failures are non-fatal warnings (don't block 6.1/6.2)
- **Known limitation documented**: rule 6.3 uses 24h baseline (V1 simplification vs. 7-day same-hour median in METHODOLOGY.md); added §8.8 to METHODOLOGY.md and Q6 to REVIEW_QUEUE.md
- `incidentTitle` handles all four rule names

## Test plan
- [x] `TestEvaluateLatencyRule_Fires` — 6000ms vs 1000ms baseline → fires
- [x] `TestEvaluateLatencyRule_BelowThreshold` — 2.5× baseline → no fire
- [x] `TestEvaluateLatencyRule_TooFewCurrentSamples` — <5 current probes → no fire
- [x] `TestEvaluateLatencyRule_TooFewBaselineSamples` — <5 baseline probes → no fire
- [x] `TestEvaluateLatencyRule_NoBaseline` — missing baseline → no fire
- [x] `TestEvaluateLatencyRule_ZeroBaselineP95` — zero baseline p95 → no fire (div-by-zero guard)
- [x] `TestEvaluateRegionalRule_Fires` — one bad region, one healthy → fires
- [x] `TestEvaluateRegionalRule_GloballyDown_Suppressed` — globally down → suppressed
- [x] `TestEvaluateRegionalRule_BelowThreshold` — 40% < 50% → no fire
- [x] `TestEvaluateRegionalRule_TooFewProbes` — <3 regional probes → no fire
- [x] `TestEvaluateRegionalRule_MultipleRegions` — two bad regions → two detections
- [x] `TestRegionalStats_ErrorRate` — zero-total guard
- [x] `TestRunner_LatencyDegradation_CreatesIncident` — runner end-to-end
- [x] `TestRunner_RegionalOutage_CreatesIncident` — runner end-to-end
- [x] `TestInfluxReader_LatencyByProvider` — correct p95_ms + total parsed
- [x] `TestInfluxReader_RegionalErrorRateByProvider` — correct region/error parsing
- [x] `TestInfluxReader_RegionalErrorRateByProvider_SkipsEmpty` — empty region_id skipped

Closes #48