### PR TITLE
fix: safe int32 conversion in parseIntParam (4× CodeQL high)

### DIFF
--- a/internal/api/incidents.go
+++ b/internal/api/incidents.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -41,7 +42,7 @@ func (s *Server) listIncidents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	limit := parseIntParam(q.Get("limit"), 20, 1, 100)
-	offset := parseIntParam(q.Get("offset"), 0, 0, 1<<31)
+	offset := parseIntParam(q.Get("offset"), 0, 0, math.MaxInt32)
 
 	var (
 		incidents []pgstore.Incident
@@ -51,13 +52,13 @@ func (s *Server) listIncidents(w http.ResponseWriter, r *http.Request) {
 	if status != "" {
 		incidents, err = s.store.ListIncidentsByStatus(r.Context(), pgstore.ListIncidentsByStatusParams{
 			Status: status,
-			Limit:  int32(limit),
-			Offset: int32(offset),
+			Limit:  limit,
+			Offset: offset,
 		})
 	} else {
 		incidents, err = s.store.ListIncidents(r.Context(), pgstore.ListIncidentsParams{
-			Limit:  int32(limit),
-			Offset: int32(offset),
+			Limit:  limit,
+			Offset: offset,
 		})
 	}
 	if err != nil {
@@ -123,16 +124,16 @@ func toIncidentResponses(incidents []pgstore.Incident) []incidentResponse {
 	return coalesceSlice(out)
 }
 
-func parseIntParam(v string, def, min, max int) int {
+func parseIntParam(v string, def, min, max int32) int32 {
 	if v == "" {
 		return def
 	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < min {
+	n, err := strconv.ParseInt(v, 10, 32)
+	if err != nil || n < int64(min) {
 		return min
 	}
-	if n > max {
+	if n > int64(max) {
 		return max
 	}
-	return n
+	return int32(n)
 }


### PR DESCRIPTION
## Summary
- Fixes 4 CodeQL `go/incorrect-integer-conversion` (security severity: **high**) alerts in `internal/api/incidents.go`
- Root cause: `strconv.Atoi` returns `int` (64-bit on amd64); callers cast directly to `int32` without verifying the value fits
- Real overflow: `offset` max was `1<<31 = 2147483648`, which exceeds `math.MaxInt32` — casting produced `-2147483648` in the worst case

## Changes
- `parseIntParam` now uses `strconv.ParseInt(v, 10, 32)` which parses directly into the int32 range; return type changed to `int32`
- Offset max changed from `1<<31` to `math.MaxInt32` (= `1<<31 - 1`)
- Call sites no longer need `int32(...)` casts — they now receive `int32` directly

## Test plan
- [x] `go build ./internal/api/...` clean
- [x] `go test -short -race ./internal/api/...` passes
- [x] CodeQL alerts will re-evaluate on CI scan