### PR TITLE
feat LLMS-022: ProbeTimestamp component + StatusPill brand conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-022)
+- `ProbeTimestamp` client component — relative "X ago" display, auto-refreshes every 10 s (brand spec §6.4); used on `IncidentCard` and incident detail page header
+- `IncidentCard` now shows `ProbeTimestamp` instead of static `formatDate` for started time
+
+### Changed (LLMS-022)
+- `StatusPill` updated to match brand spec §6.1: removed background pill (`rounded-full` + bg color), now dot-only with all-caps 11px text at 0.05em tracking
+
 ### Added
 - Initial open-source repository scaffolding
 - Apache-2.0 License for source code, CC BY 4.0 for methodology and data

--- a/web/app/incidents/[slug]/page.tsx
+++ b/web/app/incidents/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import { getIncident, ApiNotFoundError, type IncidentDetail, type Severity } from "@/lib/api";
 import { formatDate } from "@/components/IncidentCard";
+import { ProbeTimestamp } from "@/components/ProbeTimestamp";
 
 export const revalidate = 60;
 
@@ -122,15 +123,19 @@ export default async function IncidentPage({ params }: Props) {
             </span>
           </div>
           <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">{inc.title}</h1>
-          <p className="text-sm text-[var(--ink-400)]">
-            Provider:{" "}
-            <Link
-              href={`/providers/${inc.provider_id}`}
-              className="text-[var(--ink-300)] hover:text-[var(--ink-200)] transition-colors"
-            >
-              {inc.provider_id}
-            </Link>
-          </p>
+          <div className="flex items-center gap-3 mt-1">
+            <p className="text-sm text-[var(--ink-400)]">
+              Provider:{" "}
+              <Link
+                href={`/providers/${inc.provider_id}`}
+                className="text-[var(--ink-300)] hover:text-[var(--ink-200)] transition-colors"
+              >
+                {inc.provider_id}
+              </Link>
+            </p>
+            <span className="text-[var(--ink-600)]">·</span>
+            <ProbeTimestamp iso={inc.started_at} prefix="Started" />
+          </div>
         </div>
 
         {/* Timeline */}

--- a/web/components/IncidentCard.tsx
+++ b/web/components/IncidentCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { IncidentRef, Severity } from "@/lib/api";
+import { ProbeTimestamp } from "./ProbeTimestamp";
 
 const SEVERITY_STYLE: Record<Severity, { label: string; color: string }> = {
   critical: { label: "Critical", color: "text-[var(--signal-down)]" },
@@ -7,6 +8,7 @@ const SEVERITY_STYLE: Record<Severity, { label: string; color: string }> = {
   minor:    { label: "Minor",    color: "text-[var(--ink-300)]" },
 };
 
+// Kept for incident detail page Row component which needs a static string.
 export function formatDate(iso: string): string {
   return new Date(iso).toLocaleString("en-US", {
     month: "short",
@@ -35,9 +37,9 @@ export function IncidentCard({ incident, href }: Props) {
           {label}
         </span>
       </div>
-      <p className="mt-1 text-xs text-[var(--ink-400)]">
-        Started {formatDate(incident.started_at)}
-      </p>
+      <div className="mt-1">
+        <ProbeTimestamp iso={incident.started_at} prefix="Started" />
+      </div>
     </>
   );
 

--- a/web/components/ProbeTimestamp.tsx
+++ b/web/components/ProbeTimestamp.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+function relativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const diffS = Math.floor(diffMs / 1000);
+
+  if (diffS < 60) return `${diffS}s ago`;
+  const diffM = Math.floor(diffS / 60);
+  if (diffM < 60) return `${diffM}m ago`;
+  const diffH = Math.floor(diffM / 60);
+  const remM = diffM % 60;
+  if (diffH < 24) return remM > 0 ? `${diffH}h ${remM}m ago` : `${diffH}h ago`;
+  const diffD = Math.floor(diffH / 24);
+  return `${diffD}d ago`;
+}
+
+interface Props {
+  /** ISO 8601 timestamp string */
+  iso: string;
+  /** Prefix shown before the relative time, e.g. "Started" */
+  prefix?: string;
+}
+
+// Brand spec §6.4: relative "X ago" display, auto-refreshes every 10 s.
+export function ProbeTimestamp({ iso, prefix }: Props) {
+  const [label, setLabel] = useState(() => relativeTime(iso));
+
+  useEffect(() => {
+    setLabel(relativeTime(iso));
+    const id = setInterval(() => setLabel(relativeTime(iso)), 10_000);
+    return () => clearInterval(id);
+  }, [iso]);
+
+  return (
+    <time
+      dateTime={iso}
+      title={new Date(iso).toUTCString()}
+      className="text-[11px] text-[var(--ink-400)]"
+    >
+      {prefix ? `${prefix} ${label}` : label}
+    </time>
+  );
+}

--- a/web/components/StatusPill.tsx
+++ b/web/components/StatusPill.tsx
@@ -1,34 +1,30 @@
 import type { ProviderStatus } from "@/lib/api";
 
-const CONFIG: Record<ProviderStatus, { label: string; dot: string; bg: string; text: string }> = {
+// Brand spec §6.1: dot-only, no background pill, all-caps text, color inherits from status.
+const CONFIG: Record<ProviderStatus, { label: string; dot: string; text: string }> = {
   operational: {
     label: "Operational",
     dot: "bg-[var(--signal-ok)]",
-    bg: "bg-[var(--signal-ok-bg)]",
     text: "text-[var(--signal-ok)]",
   },
   degraded: {
     label: "Degraded",
     dot: "bg-[var(--signal-warn)]",
-    bg: "bg-[var(--signal-warn-bg)]",
     text: "text-[var(--signal-warn)]",
   },
   down: {
     label: "Down",
     dot: "bg-[var(--signal-down)]",
-    bg: "bg-[var(--signal-down-bg)]",
     text: "text-[var(--signal-down)]",
   },
 };
 
 export function StatusPill({ status }: { status: ProviderStatus }) {
-  const { label, dot, bg, text } = CONFIG[status];
+  const { label, dot, text } = CONFIG[status];
   return (
-    <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${bg} ${text}`}
-    >
-      <span className={`h-1.5 w-1.5 rounded-full ${dot}`} aria-hidden="true" />
-      {label}
+    <span className={`inline-flex items-center gap-2 ${text}`}>
+      <span className={`h-2 w-2 rounded-full ${dot}`} aria-hidden="true" />
+      <span className="text-[11px] font-semibold uppercase tracking-[0.05em]">{label}</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- **`ProbeTimestamp`** (`'use client'`): relative "X ago" display per brand spec §6.4, auto-refreshes every 10 s via `setInterval`, uses `<time dateTime>` for accessibility; renders absolute UTC in tooltip
- **`StatusPill`** fixed to match brand spec §6.1: removed background pill (`rounded-full` + bg), now dot-only with all-caps 11px text at 0.05em tracking
- `IncidentCard` uses `ProbeTimestamp` instead of static `formatDate` for started time
- Incident detail page header shows `ProbeTimestamp` alongside provider link

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` succeeds (5/5 static pages)
- [x] No `any` types introduced

Closes #53