### PR TITLE
feat LLMS-023: LatencyBar component + p95 in HistoryBucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-023)
+- `HistoryBucket.P95Ms` field — InfluxDB SQL now selects `approx_percentile_cont(0.95)` for successful probes alongside existing uptime data
+- `LatencyBar` component — 30-day per-day p95 bar chart, color-coded by threshold (≤500ms green, ≤2000ms amber, >2000ms red), gray stubs for days with no probe data; shows median p95 summary
+- Provider detail page: `LatencyBar` section rendered below `UptimeSparkline` when latency data is available
+
 ### Added (LLMS-022)
 - `ProbeTimestamp` client component — relative "X ago" display, auto-refreshes every 10 s (brand spec §6.4); used on `IncidentCard` and incident detail page header
 - `IncidentCard` now shows `ProbeTimestamp` instead of static `formatDate` for started time

--- a/internal/store/influx/history_reader.go
+++ b/internal/store/influx/history_reader.go
@@ -11,12 +11,13 @@ import (
 	"time"
 )
 
-// HistoryBucket holds aggregated probe counts for one time bucket.
+// HistoryBucket holds aggregated probe stats for one time bucket.
 type HistoryBucket struct {
 	Timestamp time.Time `json:"timestamp"`
 	Total     int64     `json:"total"`
 	Errors    int64     `json:"errors"`
 	Uptime    float64   `json:"uptime"` // 1 - error_rate; 1.0 when Total == 0
+	P95Ms     float64   `json:"p95_ms"` // p95 duration of successful probes; 0 when no successful probes
 }
 
 // HistoryReader queries InfluxDB 3 for per-provider time-bucketed history.
@@ -57,7 +58,9 @@ func (r *influxHistoryReader) ProviderHistory(
 	sql := fmt.Sprintf(
 		`SELECT date_bin(INTERVAL '%d seconds', time, TIMESTAMP '1970-01-01 00:00:00') AS bucket,
 		        COUNT(*) AS total,
-		        COUNT(*) FILTER (WHERE success = false) AS errors
+		        COUNT(*) FILTER (WHERE success = false) AS errors,
+		        COALESCE(approx_percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms)
+		                 FILTER (WHERE success = true AND duration_ms IS NOT NULL), 0) AS p95_ms
 		 FROM probes
 		 WHERE time >= now() - INTERVAL '%d seconds'
 		   AND provider_id = '%s'
@@ -100,6 +103,7 @@ func (r *influxHistoryReader) ProviderHistory(
 		Bucket string  `json:"bucket"`
 		Total  float64 `json:"total"`
 		Errors float64 `json:"errors"`
+		P95Ms  float64 `json:"p95_ms"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
 		return nil, fmt.Errorf("influx history: decode: %w", err)
@@ -126,6 +130,7 @@ func (r *influxHistoryReader) ProviderHistory(
 			Total:     total,
 			Errors:    errors,
 			Uptime:    uptime,
+			P95Ms:     row.P95Ms,
 		})
 	}
 	return buckets, nil

--- a/internal/store/influx/history_reader_test.go
+++ b/internal/store/influx/history_reader_test.go
@@ -15,8 +15,8 @@ func TestHistoryReader_Success(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`[
-			{"bucket":"2026-04-17T00:00:00Z","total":1440,"errors":14},
-			{"bucket":"2026-04-18T00:00:00Z","total":720,"errors":0}
+			{"bucket":"2026-04-17T00:00:00Z","total":1440,"errors":14,"p95_ms":680.5},
+			{"bucket":"2026-04-18T00:00:00Z","total":720,"errors":0,"p95_ms":0}
 		]`))
 	}))
 	t.Cleanup(srv.Close)
@@ -41,10 +41,16 @@ func TestHistoryReader_Success(t *testing.T) {
 	if b0.Uptime < wantUptime-0.001 || b0.Uptime > wantUptime+0.001 {
 		t.Errorf("bucket 0 uptime: got %f, want ~%f", b0.Uptime, wantUptime)
 	}
+	if b0.P95Ms != 680.5 {
+		t.Errorf("bucket 0 P95Ms: got %f, want 680.5", b0.P95Ms)
+	}
 
 	b1 := buckets[1]
 	if b1.Uptime != 1.0 {
 		t.Errorf("bucket 1 uptime: got %f, want 1.0 (no errors)", b1.Uptime)
+	}
+	if b1.P95Ms != 0 {
+		t.Errorf("bucket 1 P95Ms: got %f, want 0 (no successful probes)", b1.P95Ms)
 	}
 }
 

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -7,6 +7,7 @@ import { StatusPill } from "@/components/StatusPill";
 import { IncidentCard } from "@/components/IncidentCard";
 import { ModelList } from "@/components/ModelList";
 import { UptimeSparkline } from "@/components/UptimeSparkline";
+import { LatencyBar } from "@/components/LatencyBar";
 
 export const revalidate = 60;
 
@@ -119,6 +120,17 @@ export default async function ProviderPage({ params }: Props) {
             </h2>
             <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
               <UptimeSparkline buckets={history} days={30} />
+            </div>
+          </section>
+        )}
+
+        {history !== null && history.some((b) => b.p95_ms > 0) && (
+          <section className="mb-8">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+              Latency (p95)
+            </h2>
+            <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
+              <LatencyBar buckets={history} days={30} />
             </div>
           </section>
         )}

--- a/web/components/LatencyBar.tsx
+++ b/web/components/LatencyBar.tsx
@@ -1,0 +1,96 @@
+import type { HistoryBucket } from "@/lib/api";
+
+interface Props {
+  buckets: HistoryBucket[];
+  days?: number;
+}
+
+// Reference ceiling for bar scaling. Bars at or above this value fill 100% height.
+const CEILING_MS = 3000;
+
+function latencyColor(p95Ms: number, hasData: boolean): string {
+  if (!hasData) return "bg-[var(--ink-600)]";
+  if (p95Ms <= 500) return "bg-[var(--signal-ok)]";
+  if (p95Ms <= 2000) return "bg-[var(--signal-warn)]";
+  return "bg-[var(--signal-down)]";
+}
+
+function formatMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function formatDay(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export function LatencyBar({ buckets, days = 30 }: Props) {
+  const byDay = new Map<string, HistoryBucket>();
+  for (const b of buckets) {
+    byDay.set(b.timestamp.slice(0, 10), b);
+  }
+
+  const slots: string[] = [];
+  const now = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    slots.push(d.toISOString().slice(0, 10));
+  }
+
+  // Summary: median p95 across all buckets that have data.
+  const withData = buckets.filter((b) => b.total > 0 && b.p95_ms > 0);
+  const medianP95 =
+    withData.length === 0
+      ? null
+      : withData
+          .map((b) => b.p95_ms)
+          .sort((a, b) => a - b)[Math.floor(withData.length / 2)];
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between text-xs text-[var(--ink-400)]">
+        <span>p95 latency — 30 days</span>
+        {medianP95 !== null && (
+          <span className="font-medium text-[var(--ink-200)]">
+            {formatMs(medianP95)} median
+          </span>
+        )}
+      </div>
+
+      <div className="flex h-10 items-end gap-px" aria-label="30-day p95 latency chart">
+        {slots.map((day) => {
+          const b = byDay.get(day);
+          const hasData = b !== undefined && b.total > 0 && b.p95_ms > 0;
+          const p95 = b?.p95_ms ?? 0;
+          const color = latencyColor(p95, hasData);
+          const label = hasData
+            ? `${formatDay(day)}: ${formatMs(p95)} p95`
+            : `${formatDay(day)}: no data`;
+          const heightPct = hasData
+            ? Math.max(10, Math.min(100, Math.round((p95 / CEILING_MS) * 100)))
+            : 20;
+
+          return (
+            <div
+              key={day}
+              title={label}
+              className={`flex-1 rounded-sm ${color}`}
+              style={{ height: `${heightPct}%` }}
+              aria-label={label}
+            />
+          );
+        })}
+      </div>
+
+      <div className="mt-1 flex justify-between text-xs text-[var(--ink-500)]">
+        <span>{formatDay(slots[0])}</span>
+        <span>{formatDay(slots[slots.length - 1])}</span>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -88,7 +88,8 @@ export interface HistoryBucket {
   timestamp: string;
   total: number;
   errors: number;
-  uptime: number; // 0–1
+  uptime: number;  // 0–1
+  p95_ms: number;  // p95 duration of successful probes in ms; 0 when no successful probes
 }
 
 export type HistoryWindow = "24h" | "7d" | "30d";


### PR DESCRIPTION
## Summary
- **`HistoryBucket`** extended: Go struct and TS interface gain `p95_ms` / `P95Ms` — InfluxDB SQL now selects `approx_percentile_cont(0.95) WITHIN GROUP … FILTER (WHERE success = true)`, COALESCE'd to 0 when no successful probes
- **`LatencyBar`** component: 30-day per-day p95 bar chart, bars proportional to a 3000ms ceiling, color-coded (≤500ms green / ≤2000ms amber / >2000ms red), gray stubs for no-data days, median p95 summary in header
- Provider detail page: `LatencyBar` section rendered below `UptimeSparkline`, hidden when all p95 values are 0 (no probe data yet)

## Test plan
- [x] `go test -short -race ./internal/store/influx/...` — P95Ms field asserted in success test
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` succeeds (5/5 static pages)

Closes #55