### PR TITLE
feat LLMS-024: shared SiteHeader/SiteFooter + nav links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-024)
+- `SiteHeader` server component: logo link + nav (`Providers` / `Incidents`) with active-page highlighting via `NavLink` client component (`usePathname`)
+- `SiteFooter` server component: standard footer copy, rendered once in root `layout.tsx`
+- `NavLink` client component: highlights the active route using `usePathname()`
+
+### Changed (LLMS-024)
+- Root `layout.tsx` now renders `SiteHeader` and `SiteFooter` — all 4 pages stripped of duplicated header/footer markup
+- `ProviderTable` rows now have `hover:bg-[var(--canvas-overlay)]` per brand spec §6.2
+
 ### Added (LLMS-023)
 - `HistoryBucket.P95Ms` field — InfluxDB SQL now selects `approx_percentile_cont(0.95)` for successful probes alongside existing uptime data
 - `LatencyBar` component — 30-day per-day p95 bar chart, color-coded by threshold (≤500ms green, ≤2000ms amber, >2000ms red), gray stubs for days with no probe data; shows median p95 summary

--- a/web/app/incidents/[slug]/page.tsx
+++ b/web/app/incidents/[slug]/page.tsx
@@ -78,131 +78,115 @@ export default async function IncidentPage({ params }: Props) {
   };
 
   return (
-    <div className="flex flex-col min-h-screen">
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
       {/* eslint-disable-next-line react/no-danger -- safeJsonLd escapes </ to prevent script injection */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }}
       />
 
-      <header className="border-b border-[var(--ink-600)] px-6 py-4">
-        <div className="mx-auto max-w-4xl flex items-center justify-between">
-          <Link
-            href="/"
-            className="font-mono text-sm font-semibold tracking-widest text-[var(--signal-amber)] uppercase hover:opacity-80 transition-opacity"
-          >
-            llmstatus.io
-          </Link>
-          <span className="text-xs text-[var(--ink-400)]">Real-time AI API monitoring</span>
+      {/* Breadcrumb */}
+      <nav className="mb-6 text-xs text-[var(--ink-400)]">
+        <Link href="/" className="hover:text-[var(--ink-200)] transition-colors">
+          All providers
+        </Link>
+        <span className="mx-2">/</span>
+        <Link href="/incidents" className="hover:text-[var(--ink-200)] transition-colors">
+          Incidents
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-[var(--ink-300)]">{inc.slug}</span>
+      </nav>
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <span className={`text-xs font-semibold uppercase tracking-wide ${severityColor}`}>
+            {severityLabel}
+          </span>
+          <span className="text-[var(--ink-600)]">·</span>
+          <span className={`text-xs font-semibold uppercase tracking-wide ${STATUS_STYLE[inc.status] ?? ""}`}>
+            {inc.status}
+          </span>
         </div>
-      </header>
-
-      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
-        {/* Breadcrumb */}
-        <nav className="mb-6 text-xs text-[var(--ink-400)]">
-          <Link href="/" className="hover:text-[var(--ink-200)] transition-colors">
-            All providers
-          </Link>
-          <span className="mx-2">/</span>
-          <Link href="/incidents" className="hover:text-[var(--ink-200)] transition-colors">
-            Incidents
-          </Link>
-          <span className="mx-2">/</span>
-          <span className="text-[var(--ink-300)]">{inc.slug}</span>
-        </nav>
-
-        {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center gap-3 mb-2">
-            <span className={`text-xs font-semibold uppercase tracking-wide ${severityColor}`}>
-              {severityLabel}
-            </span>
-            <span className="text-[var(--ink-600)]">·</span>
-            <span className={`text-xs font-semibold uppercase tracking-wide ${STATUS_STYLE[inc.status] ?? ""}`}>
-              {inc.status}
-            </span>
-          </div>
-          <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">{inc.title}</h1>
-          <div className="flex items-center gap-3 mt-1">
-            <p className="text-sm text-[var(--ink-400)]">
-              Provider:{" "}
-              <Link
-                href={`/providers/${inc.provider_id}`}
-                className="text-[var(--ink-300)] hover:text-[var(--ink-200)] transition-colors"
-              >
-                {inc.provider_id}
-              </Link>
-            </p>
-            <span className="text-[var(--ink-600)]">·</span>
-            <ProbeTimestamp iso={inc.started_at} prefix="Started" />
-          </div>
+        <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">{inc.title}</h1>
+        <div className="flex items-center gap-3 mt-1">
+          <p className="text-sm text-[var(--ink-400)]">
+            Provider:{" "}
+            <Link
+              href={`/providers/${inc.provider_id}`}
+              className="text-[var(--ink-300)] hover:text-[var(--ink-200)] transition-colors"
+            >
+              {inc.provider_id}
+            </Link>
+          </p>
+          <span className="text-[var(--ink-600)]">·</span>
+          <ProbeTimestamp iso={inc.started_at} prefix="Started" />
         </div>
+      </div>
 
-        {/* Timeline */}
-        <section className="mb-8 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] divide-y divide-[var(--ink-600)]">
-          <Row label="Started" value={formatDate(inc.started_at)} />
-          {inc.resolved_at && (
-            <Row label="Resolved" value={formatDate(inc.resolved_at)} />
-          )}
-          <Row label="Detection" value={inc.detection_method} />
-          <Row label="Human reviewed" value={inc.human_reviewed ? "Yes" : "No"} />
+      {/* Timeline */}
+      <section className="mb-8 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] divide-y divide-[var(--ink-600)]">
+        <Row label="Started" value={formatDate(inc.started_at)} />
+        {inc.resolved_at && (
+          <Row label="Resolved" value={formatDate(inc.resolved_at)} />
+        )}
+        <Row label="Detection" value={inc.detection_method} />
+        <Row label="Human reviewed" value={inc.human_reviewed ? "Yes" : "No"} />
+      </section>
+
+      {/* Description */}
+      {inc.description && (
+        <section className="mb-8">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            Description
+          </h2>
+          <p className="text-sm text-[var(--ink-200)] leading-6">{inc.description}</p>
         </section>
+      )}
 
-        {/* Description */}
-        {inc.description && (
-          <section className="mb-8">
-            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-              Description
-            </h2>
-            <p className="text-sm text-[var(--ink-200)] leading-6">{inc.description}</p>
-          </section>
-        )}
+      {/* Affected models */}
+      {inc.affected_models.length > 0 && (
+        <section className="mb-6">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            Affected Models
+          </h2>
+          <ul className="flex flex-wrap gap-2">
+            {inc.affected_models.map((m) => (
+              <li
+                key={m}
+                className="rounded px-2 py-0.5 font-mono text-xs bg-[var(--canvas-sunken)] text-[var(--ink-200)]"
+              >
+                {m}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
-        {/* Affected models */}
-        {inc.affected_models.length > 0 && (
-          <section className="mb-6">
-            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-              Affected Models
-            </h2>
-            <ul className="flex flex-wrap gap-2">
-              {inc.affected_models.map((m) => (
-                <li
-                  key={m}
-                  className="rounded px-2 py-0.5 font-mono text-xs bg-[var(--canvas-sunken)] text-[var(--ink-200)]"
-                >
-                  {m}
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
+      {/* Affected regions */}
+      {inc.affected_regions.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            Affected Regions
+          </h2>
+          <ul className="flex flex-wrap gap-2">
+            {inc.affected_regions.map((r) => (
+              <li
+                key={r}
+                className="rounded px-2 py-0.5 font-mono text-xs bg-[var(--canvas-sunken)] text-[var(--ink-200)]"
+              >
+                {r}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
-        {/* Affected regions */}
-        {inc.affected_regions.length > 0 && (
-          <section>
-            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-              Affected Regions
-            </h2>
-            <ul className="flex flex-wrap gap-2">
-              {inc.affected_regions.map((r) => (
-                <li
-                  key={r}
-                  className="rounded px-2 py-0.5 font-mono text-xs bg-[var(--canvas-sunken)] text-[var(--ink-200)]"
-                >
-                  {r}
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-      </main>
-
-      <footer className="border-t border-[var(--ink-600)] px-6 py-4">
-        <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
-          This URL is permanent and will not change. Detection method: {inc.detection_method}.
-        </div>
-      </footer>
-    </div>
+      <p className="text-xs text-[var(--ink-500)]">
+        This URL is permanent. Detection method: {inc.detection_method}.
+      </p>
+    </main>
   );
 }
 

--- a/web/app/incidents/page.tsx
+++ b/web/app/incidents/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 
 import { listIncidents } from "@/lib/api";
 import { IncidentCard } from "@/components/IncidentCard";
@@ -15,55 +14,35 @@ export default async function IncidentsPage() {
   const incidents = await listIncidents("all", 50).catch(() => null);
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <header className="border-b border-[var(--ink-600)] px-6 py-4">
-        <div className="mx-auto max-w-4xl flex items-center justify-between">
-          <Link
-            href="/"
-            className="font-mono text-sm font-semibold tracking-widest text-[var(--signal-amber)] uppercase hover:opacity-80 transition-opacity"
-          >
-            llmstatus.io
-          </Link>
-          <span className="text-xs text-[var(--ink-400)]">Real-time AI API monitoring</span>
-        </div>
-      </header>
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">Incidents</h1>
+        <p className="text-sm text-[var(--ink-400)]">
+          All detected provider incidents, most recent first.
+        </p>
+      </div>
 
-      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
-        <div className="mb-8">
-          <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">Incidents</h1>
+      {incidents === null ? (
+        <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6 py-10 text-center">
           <p className="text-sm text-[var(--ink-400)]">
-            All detected provider incidents, most recent first.
+            Could not reach the API. Check that the backend is running.
           </p>
         </div>
-
-        {incidents === null ? (
-          <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6 py-10 text-center">
-            <p className="text-sm text-[var(--ink-400)]">
-              Could not reach the API. Check that the backend is running.
-            </p>
-          </div>
-        ) : incidents.length === 0 ? (
-          <p className="py-12 text-center text-sm text-[var(--ink-400)]">
-            No incidents recorded yet.
-          </p>
-        ) : (
-          <div className="flex flex-col gap-2">
-            {incidents.map((inc) => (
-              <IncidentCard
-                key={inc.id}
-                incident={inc}
-                href={`/incidents/${inc.slug}`}
-              />
-            ))}
-          </div>
-        )}
-      </main>
-
-      <footer className="border-t border-[var(--ink-600)] px-6 py-4">
-        <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
-          Data sourced from real API calls, not status pages. Updated every 30 s.
+      ) : incidents.length === 0 ? (
+        <p className="py-12 text-center text-sm text-[var(--ink-400)]">
+          No incidents recorded yet.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {incidents.map((inc) => (
+            <IncidentCard
+              key={inc.id}
+              incident={inc}
+              href={`/incidents/${inc.slug}`}
+            />
+          ))}
         </div>
-      </footer>
-    </div>
+      )}
+    </main>
   );
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { SiteHeader } from "@/components/SiteHeader";
+import { SiteFooter } from "@/components/SiteFooter";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -18,7 +20,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
       <body className="min-h-full flex flex-col bg-[var(--canvas-base)] text-[var(--ink-100)]">
-        {children}
+        <SiteHeader />
+        <div className="flex-1 flex flex-col">
+          {children}
+        </div>
+        <SiteFooter />
       </body>
     </html>
   );

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,7 +4,7 @@ import { ProviderTable } from "@/components/ProviderTable";
 export const revalidate = 30;
 
 export default async function HomePage() {
-  let providers = await listProviders().catch(() => null);
+  const providers = await listProviders().catch(() => null);
 
   const allOk =
     providers !== null &&
@@ -14,57 +14,40 @@ export default async function HomePage() {
   const hasOutage =
     providers !== null && providers.some((p) => p.current_status === "down");
 
-  const summaryText = providers === null
-    ? "Unable to load provider data."
-    : allOk
-    ? "All systems operational."
-    : hasOutage
-    ? "One or more providers are experiencing issues."
-    : "Some providers are degraded.";
+  const summaryText =
+    providers === null
+      ? "Unable to load provider data."
+      : allOk
+      ? "All systems operational."
+      : hasOutage
+      ? "One or more providers are experiencing issues."
+      : "Some providers are degraded.";
 
-  const summaryColor = providers === null || hasOutage
-    ? "text-[var(--signal-down)]"
-    : allOk
-    ? "text-[var(--signal-ok)]"
-    : "text-[var(--signal-warn)]";
+  const summaryColor =
+    providers === null || hasOutage
+      ? "text-[var(--signal-down)]"
+      : allOk
+      ? "text-[var(--signal-ok)]"
+      : "text-[var(--signal-warn)]";
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <header className="border-b border-[var(--ink-600)] px-6 py-4">
-        <div className="mx-auto max-w-4xl flex items-center justify-between">
-          <span className="font-mono text-sm font-semibold tracking-widest text-[var(--signal-amber)] uppercase">
-            llmstatus.io
-          </span>
-          <span className="text-xs text-[var(--ink-400)]">
-            Real-time AI API monitoring
-          </span>
-        </div>
-      </header>
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">
+          AI API Status
+        </h1>
+        <p className={`text-sm font-medium ${summaryColor}`}>{summaryText}</p>
+      </div>
 
-      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
-        <div className="mb-8">
-          <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">
-            AI API Status
-          </h1>
-          <p className={`text-sm font-medium ${summaryColor}`}>{summaryText}</p>
+      {providers !== null ? (
+        <ProviderTable providers={providers} />
+      ) : (
+        <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6 py-10 text-center">
+          <p className="text-sm text-[var(--ink-400)]">
+            Could not reach the API. Check that the backend is running.
+          </p>
         </div>
-
-        {providers !== null ? (
-          <ProviderTable providers={providers} />
-        ) : (
-          <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6 py-10 text-center">
-            <p className="text-sm text-[var(--ink-400)]">
-              Could not reach the API. Check that the backend is running.
-            </p>
-          </div>
-        )}
-      </main>
-
-      <footer className="border-t border-[var(--ink-600)] px-6 py-4">
-        <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
-          Data sourced from real API calls, not status pages. Updated every 30 s.
-        </div>
-      </footer>
-    </div>
+      )}
+    </main>
   );
 }

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -43,112 +43,91 @@ export default async function ProviderPage({ params }: Props) {
     throw e;
   }
 
-  // History fetch is best-effort — sparkline is hidden if unavailable.
+  // History fetch is best-effort — charts are hidden if unavailable.
   const history = await getProviderHistory(id, "30d").catch(() => null);
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <header className="border-b border-[var(--ink-600)] px-6 py-4">
-        <div className="mx-auto max-w-4xl flex items-center justify-between">
-          <Link
-            href="/"
-            className="font-mono text-sm font-semibold tracking-widest text-[var(--signal-amber)] uppercase hover:opacity-80 transition-opacity"
-          >
-            llmstatus.io
-          </Link>
-          <span className="text-xs text-[var(--ink-400)]">
-            Real-time AI API monitoring
-          </span>
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+      {/* Breadcrumb */}
+      <nav className="mb-6 text-xs text-[var(--ink-400)]">
+        <Link href="/" className="hover:text-[var(--ink-200)] transition-colors">
+          All providers
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-[var(--ink-300)]">{provider.name}</span>
+      </nav>
+
+      {/* Header */}
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--ink-100)]">
+            {provider.name}
+          </h1>
+          <p className="mt-1 text-sm text-[var(--ink-400)]">
+            {provider.category} · {provider.region}
+            {provider.status_page_url && (
+              <>
+                {" · "}
+                <a
+                  href={provider.status_page_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-[var(--ink-200)] transition-colors"
+                >
+                  Status page ↗
+                </a>
+              </>
+            )}
+          </p>
         </div>
-      </header>
+        <StatusPill status={provider.current_status} />
+      </div>
 
-      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
-        {/* Breadcrumb */}
-        <nav className="mb-6 text-xs text-[var(--ink-400)]">
-          <Link href="/" className="hover:text-[var(--ink-200)] transition-colors">
-            All providers
-          </Link>
-          <span className="mx-2">/</span>
-          <span className="text-[var(--ink-300)]">{provider.name}</span>
-        </nav>
-
-        {/* Header */}
-        <div className="mb-8 flex items-start justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-semibold text-[var(--ink-100)]">
-              {provider.name}
-            </h1>
-            <p className="mt-1 text-sm text-[var(--ink-400)]">
-              {provider.category} · {provider.region}
-              {provider.status_page_url && (
-                <>
-                  {" · "}
-                  <a
-                    href={provider.status_page_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="hover:text-[var(--ink-200)] transition-colors"
-                  >
-                    Status page ↗
-                  </a>
-                </>
-              )}
-            </p>
-          </div>
-          <StatusPill status={provider.current_status} />
-        </div>
-
-        {/* Active incidents */}
-        {provider.active_incidents.length > 0 && (
-          <section className="mb-8">
-            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-              Active Incidents
-            </h2>
-            <div className="flex flex-col gap-2">
-              {provider.active_incidents.map((inc) => (
-                <IncidentCard key={inc.id} incident={inc} href={`/incidents/${inc.slug}`} />
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* Uptime sparkline */}
-        {history !== null && (
-          <section className="mb-8">
-            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-              Uptime History
-            </h2>
-            <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
-              <UptimeSparkline buckets={history} days={30} />
-            </div>
-          </section>
-        )}
-
-        {history !== null && history.some((b) => b.p95_ms > 0) && (
-          <section className="mb-8">
-            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-              Latency (p95)
-            </h2>
-            <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
-              <LatencyBar buckets={history} days={30} />
-            </div>
-          </section>
-        )}
-
-        {/* Models */}
-        <section>
+      {/* Active incidents */}
+      {provider.active_incidents.length > 0 && (
+        <section className="mb-8">
           <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-            Monitored Models
+            Active Incidents
           </h2>
-          <ModelList models={provider.models} />
+          <div className="flex flex-col gap-2">
+            {provider.active_incidents.map((inc) => (
+              <IncidentCard key={inc.id} incident={inc} href={`/incidents/${inc.slug}`} />
+            ))}
+          </div>
         </section>
-      </main>
+      )}
 
-      <footer className="border-t border-[var(--ink-600)] px-6 py-4">
-        <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
-          Data sourced from real API calls, not status pages. Updated every 60 s.
-        </div>
-      </footer>
-    </div>
+      {/* Uptime sparkline */}
+      {history !== null && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            Uptime History
+          </h2>
+          <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
+            <UptimeSparkline buckets={history} days={30} />
+          </div>
+        </section>
+      )}
+
+      {/* Latency bar */}
+      {history !== null && history.some((b) => b.p95_ms > 0) && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            Latency (p95)
+          </h2>
+          <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
+            <LatencyBar buckets={history} days={30} />
+          </div>
+        </section>
+      )}
+
+      {/* Models */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+          Monitored Models
+        </h2>
+        <ModelList models={provider.models} />
+      </section>
+    </main>
   );
 }

--- a/web/components/NavLink.tsx
+++ b/web/components/NavLink.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface Props {
+  href: string;
+  children: React.ReactNode;
+}
+
+export function NavLink({ href, children }: Props) {
+  const pathname = usePathname();
+  const active = pathname === href || (href !== "/" && pathname.startsWith(href));
+  return (
+    <Link
+      href={href}
+      className={`text-xs transition-colors ${
+        active
+          ? "text-[var(--ink-100)] font-medium"
+          : "text-[var(--ink-400)] hover:text-[var(--ink-200)]"
+      }`}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/web/components/ProviderTable.tsx
+++ b/web/components/ProviderTable.tsx
@@ -39,7 +39,7 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
           {providers.map((p, idx) => (
             <tr
               key={p.id}
-              className={`border-b border-[var(--ink-600)] last:border-0 ${
+              className={`border-b border-[var(--ink-600)] last:border-0 transition-colors hover:bg-[var(--canvas-overlay)] ${
                 idx % 2 === 0 ? "bg-[var(--canvas-raised)]" : "bg-[var(--canvas-base)]"
               }`}
             >

--- a/web/components/SiteFooter.tsx
+++ b/web/components/SiteFooter.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  message?: string;
+}
+
+const DEFAULT_MESSAGE =
+  "Data sourced from real API calls, not status pages. Updated every 30 s.";
+
+export function SiteFooter({ message = DEFAULT_MESSAGE }: Props) {
+  return (
+    <footer className="border-t border-[var(--ink-600)] px-6 py-4">
+      <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
+        {message}
+      </div>
+    </footer>
+  );
+}

--- a/web/components/SiteHeader.tsx
+++ b/web/components/SiteHeader.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { NavLink } from "./NavLink";
+
+export function SiteHeader() {
+  return (
+    <header className="border-b border-[var(--ink-600)] px-6 py-4">
+      <div className="mx-auto max-w-4xl flex items-center justify-between">
+        <Link
+          href="/"
+          className="font-mono text-sm font-semibold tracking-widest text-[var(--signal-amber)] uppercase hover:opacity-80 transition-opacity"
+        >
+          llmstatus.io
+        </Link>
+        <nav className="flex items-center gap-6" aria-label="Site navigation">
+          <NavLink href="/">Providers</NavLink>
+          <NavLink href="/incidents">Incidents</NavLink>
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- **`SiteHeader`** (server component): logo link + nav with `Providers` and `Incidents` links
- **`NavLink`** (`'use client'`): active-page highlighting via `usePathname()` — keeps `SiteHeader` a server component
- **`SiteFooter`** (server component): standard copy, rendered once in root `layout.tsx`
- All 4 pages stripped of copy-pasted header/footer — now just `<main>` content
- **`ProviderTable`** rows: `hover:bg-[var(--canvas-overlay)]` per brand spec §6.2

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` passes (5/5 static pages)
- [x] Nav links present on all pages; active page highlighted

Closes #57