### PR TITLE
feat LLMS-026: provider live stats (uptime 24h + p95) in /v1/providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-026)
+- `ProviderLiveStat` type + `LiveStatsReader` interface in `internal/store/influx` — one SQL query returns 24h uptime + p95 latency for all providers
+- `influxHistoryReader.postQuery` private helper extracted from `ProviderHistory` — eliminates HTTP boilerplate duplication across both query methods
+- `WithLiveStatsReader` functional option on API `Server` — optional; summaries still return without uptime/p95 fields when not wired
+- `/v1/providers` response now includes `uptime_24h` (0–1) and `p95_ms` fields when live stats available, omitted otherwise
+- `ProviderTable` now shows "Uptime 24h" and "p95" columns per brand spec §6.2; values formatted as `99.9%` / `450ms` / `1.2s`; `—` when data unavailable
+
 ### Fixed (LLMS-025)
 - `internal/detector` coverage raised from 79.7% → 89.3% (floor: 85%)
 - Added tests: `Run` context-cancel, `runOnce` 5m read error, `ensureIncident` store error + create error, `resolveStale` list error + resolve error, `incidentTitle` all rule branches

--- a/internal/api/live_stats.go
+++ b/internal/api/live_stats.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"context"
+
+	"github.com/llmstatus/llmstatus/internal/store/influx"
+)
+
+// LiveStatsReader is the subset of influx.LiveStatsReader used by the API.
+type LiveStatsReader interface {
+	AllProviderLiveStats(ctx context.Context) ([]influx.ProviderLiveStat, error)
+}
+
+// compile-time check: influx.LiveStatsReader satisfies LiveStatsReader.
+var _ LiveStatsReader = (influx.LiveStatsReader)(nil)
+
+// WithLiveStatsReader wires an InfluxDB live stats reader into the Server.
+func WithLiveStatsReader(r LiveStatsReader) func(*Server) {
+	return func(s *Server) { s.liveStats = r }
+}

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -10,12 +10,14 @@ import (
 // ---- response types ---------------------------------------------------------
 
 type providerSummary struct {
-	ID               string  `json:"id"`
-	Name             string  `json:"name"`
-	Category         string  `json:"category"`
-	Region           string  `json:"region"`
-	CurrentStatus    string  `json:"current_status"`
-	ActiveIncidentID *string `json:"active_incident_id,omitempty"`
+	ID               string   `json:"id"`
+	Name             string   `json:"name"`
+	Category         string   `json:"category"`
+	Region           string   `json:"region"`
+	CurrentStatus    string   `json:"current_status"`
+	ActiveIncidentID *string  `json:"active_incident_id,omitempty"`
+	Uptime24h        *float64 `json:"uptime_24h,omitempty"`
+	P95Ms            *float64 `json:"p95_ms,omitempty"`
 }
 
 type modelSummary struct {
@@ -70,10 +72,26 @@ func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Fetch live stats (optional; nil liveStats → fields omitted).
+	liveByProvider := make(map[string][2]float64) // [uptime24h, p95_ms]
+	if s.liveStats != nil {
+		if stats, err := s.liveStats.AllProviderLiveStats(r.Context()); err == nil {
+			for _, st := range stats {
+				liveByProvider[st.ProviderID] = [2]float64{st.Uptime24h, st.P95Ms}
+			}
+		}
+		// Live stats failure is non-fatal: summaries still return without fields.
+	}
+
 	summaries := make([]providerSummary, 0, len(providers))
 	for _, p := range providers {
-		s := toProviderSummary(p, incidentByProvider)
-		summaries = append(summaries, s)
+		ps := toProviderSummary(p, incidentByProvider)
+		if live, ok := liveByProvider[p.ID]; ok {
+			u, p95 := live[0], live[1]
+			ps.Uptime24h = &u
+			ps.P95Ms = &p95
+		}
+		summaries = append(summaries, ps)
 	}
 
 	writeEnvelope(w, summaries)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,11 +20,12 @@ var _ Store = (*pgstore.Queries)(nil)
 
 // Server wires handlers to a ServeMux and owns the store reference.
 type Server struct {
-	store   Store
-	history HistoryReader // optional; nil → GET /history returns 503
-	limiter *RateLimiter  // optional; nil → no rate limiting
-	mux     *http.ServeMux
-	handler http.Handler // mux optionally wrapped with limiter middleware
+	store     Store
+	history   HistoryReader   // optional; nil → GET /history returns 503
+	liveStats LiveStatsReader // optional; nil → uptime24h/p95_ms omitted
+	limiter   *RateLimiter    // optional; nil → no rate limiting
+	mux       *http.ServeMux
+	handler   http.Handler // mux optionally wrapped with limiter middleware
 }
 
 // New creates a Server and registers all routes. Pass functional options

--- a/internal/store/influx/history_reader.go
+++ b/internal/store/influx/history_reader.go
@@ -32,8 +32,9 @@ type HistoryReaderConfig struct {
 	Database string
 }
 
-// NewHistoryReader returns a HistoryReader that queries via POST /api/v3/query_sql.
-func NewHistoryReader(cfg HistoryReaderConfig, client *http.Client) HistoryReader {
+// NewHistoryReader returns an *influxHistoryReader that satisfies both
+// HistoryReader and LiveStatsReader.
+func NewHistoryReader(cfg HistoryReaderConfig, client *http.Client) *influxHistoryReader {
 	if client == nil {
 		client = &http.Client{Timeout: 15 * time.Second}
 	}
@@ -43,6 +44,17 @@ func NewHistoryReader(cfg HistoryReaderConfig, client *http.Client) HistoryReade
 type influxHistoryReader struct {
 	cfg    HistoryReaderConfig
 	client *http.Client
+}
+
+func (r *influxHistoryReader) postQuery(ctx context.Context, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.cfg.Host+"/api/v3/query_sql", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+r.cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+	return r.client.Do(req)
 }
 
 func (r *influxHistoryReader) ProviderHistory(
@@ -80,17 +92,9 @@ func (r *influxHistoryReader) ProviderHistory(
 		return nil, fmt.Errorf("influx history: marshal query: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		r.cfg.Host+"/api/v3/query_sql", bytes.NewReader(body))
+	resp, err := r.postQuery(ctx, body)
 	if err != nil {
-		return nil, fmt.Errorf("influx history: build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Token "+r.cfg.Token)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := r.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("influx history: query: %w", err)
+		return nil, fmt.Errorf("influx history: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/internal/store/influx/live_stats.go
+++ b/internal/store/influx/live_stats.go
@@ -1,0 +1,82 @@
+package influx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// ProviderLiveStat holds current 24 h aggregate stats for one provider.
+type ProviderLiveStat struct {
+	ProviderID string
+	Uptime24h  float64 // 0–1; 1.0 when Total == 0
+	P95Ms      float64 // p95 duration of successful probes; 0 when no successful probes
+}
+
+// LiveStatsReader fetches current aggregate stats for every active provider
+// in a single InfluxDB round-trip.
+type LiveStatsReader interface {
+	AllProviderLiveStats(ctx context.Context) ([]ProviderLiveStat, error)
+}
+
+// compile-time check: *influxHistoryReader satisfies LiveStatsReader.
+var _ LiveStatsReader = (*influxHistoryReader)(nil)
+
+// AllProviderLiveStats queries the last 24 h of probes, grouped by provider_id,
+// returning uptime and p95 latency for each.
+func (r *influxHistoryReader) AllProviderLiveStats(ctx context.Context) ([]ProviderLiveStat, error) {
+	sql := `SELECT
+	    provider_id,
+	    COUNT(*) AS total,
+	    COUNT(*) FILTER (WHERE success = false) AS errors,
+	    COALESCE(approx_percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms)
+	             FILTER (WHERE success = true AND duration_ms IS NOT NULL), 0) AS p95_ms
+	FROM probes
+	WHERE time >= now() - INTERVAL '86400 seconds'
+	GROUP BY provider_id`
+
+	body, err := json.Marshal(map[string]string{
+		"q":      sql,
+		"db":     r.cfg.Database,
+		"format": "json",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("influx live stats: marshal query: %w", err)
+	}
+
+	resp, err := r.postQuery(ctx, body)
+	if err != nil {
+		return nil, fmt.Errorf("influx live stats: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("influx live stats: status %d: %s", resp.StatusCode, detail)
+	}
+
+	var rows []struct {
+		ProviderID string  `json:"provider_id"`
+		Total      float64 `json:"total"`
+		Errors     float64 `json:"errors"`
+		P95Ms      float64 `json:"p95_ms"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("influx live stats: decode: %w", err)
+	}
+
+	out := make([]ProviderLiveStat, 0, len(rows))
+	for _, row := range rows {
+		uptime := 1.0
+		if row.Total > 0 {
+			uptime = 1.0 - row.Errors/row.Total
+		}
+		out = append(out, ProviderLiveStat{
+			ProviderID: row.ProviderID,
+			Uptime24h:  uptime,
+			P95Ms:      row.P95Ms,
+		})
+	}
+	return out, nil
+}

--- a/internal/store/influx/live_stats_test.go
+++ b/internal/store/influx/live_stats_test.go
@@ -1,0 +1,87 @@
+package influx
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAllProviderLiveStats_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v3/query_sql" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"provider_id":"openai","total":1440,"errors":144,"p95_ms":750.0},
+			{"provider_id":"anthropic","total":720,"errors":0,"p95_ms":0}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewHistoryReader(HistoryReaderConfig{
+		Host: srv.URL, Token: "t", Database: "db",
+	}, nil)
+
+	stats, err := reader.AllProviderLiveStats(context.Background())
+	if err != nil {
+		t.Fatalf("AllProviderLiveStats: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+
+	openai := stats[0]
+	if openai.ProviderID != "openai" {
+		t.Errorf("provider_id: got %q, want openai", openai.ProviderID)
+	}
+	wantUptime := 1.0 - 144.0/1440.0
+	if openai.Uptime24h < wantUptime-0.001 || openai.Uptime24h > wantUptime+0.001 {
+		t.Errorf("uptime: got %f, want ~%f", openai.Uptime24h, wantUptime)
+	}
+	if openai.P95Ms != 750.0 {
+		t.Errorf("p95_ms: got %f, want 750.0", openai.P95Ms)
+	}
+
+	anthropic := stats[1]
+	if anthropic.Uptime24h != 1.0 {
+		t.Errorf("anthropic uptime: got %f, want 1.0", anthropic.Uptime24h)
+	}
+}
+
+func TestAllProviderLiveStats_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewHistoryReader(HistoryReaderConfig{
+		Host: srv.URL, Token: "t", Database: "db",
+	}, nil)
+
+	stats, err := reader.AllProviderLiveStats(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected 0 stats, got %d", len(stats))
+	}
+}
+
+func TestAllProviderLiveStats_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	reader := NewHistoryReader(HistoryReaderConfig{
+		Host: srv.URL, Token: "t", Database: "db",
+	}, nil)
+
+	_, err := reader.AllProviderLiveStats(context.Background())
+	if err == nil {
+		t.Fatal("expected error on 500, got nil")
+	}
+}

--- a/web/components/ProviderTable.tsx
+++ b/web/components/ProviderTable.tsx
@@ -15,6 +15,16 @@ const REGION_LABEL: Record<string, string> = {
   eu: "EU",
 };
 
+function formatUptime(u: number | undefined): string {
+  if (u === undefined) return "—";
+  return `${(u * 100).toFixed(1)}%`;
+}
+
+function formatP95(ms: number | undefined): string {
+  if (ms === undefined || ms === 0) return "—";
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
+}
+
 export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
   if (providers.length === 0) {
     return (
@@ -32,6 +42,8 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
             <th className="px-4 py-3 text-left font-medium text-[var(--ink-300)]">Provider</th>
             <th className="px-4 py-3 text-left font-medium text-[var(--ink-300)]">Category</th>
             <th className="px-4 py-3 text-left font-medium text-[var(--ink-300)]">Region</th>
+            <th className="px-4 py-3 text-right font-medium text-[var(--ink-300)]">Uptime 24h</th>
+            <th className="px-4 py-3 text-right font-medium text-[var(--ink-300)]">p95</th>
             <th className="px-4 py-3 text-right font-medium text-[var(--ink-300)]">Status</th>
           </tr>
         </thead>
@@ -56,6 +68,12 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
               </td>
               <td className="px-4 py-3 text-[var(--ink-300)]">
                 {REGION_LABEL[p.region] ?? p.region}
+              </td>
+              <td className="px-4 py-3 text-right font-mono text-[var(--ink-200)]">
+                {formatUptime(p.uptime_24h)}
+              </td>
+              <td className="px-4 py-3 text-right font-mono text-[var(--ink-200)]">
+                {formatP95(p.p95_ms)}
               </td>
               <td className="px-4 py-3 text-right">
                 <StatusPill status={p.current_status} />

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -22,6 +22,8 @@ export interface ProviderSummary {
   region: string;
   current_status: ProviderStatus;
   active_incident_id?: string;
+  uptime_24h?: number; // 0–1; omitted when live stats unavailable
+  p95_ms?: number;     // p95 latency ms of successful probes; omitted when unavailable
 }
 
 export interface IncidentRef {


### PR DESCRIPTION
## Summary

- Adds `ProviderLiveStat` type + `LiveStatsReader` interface in `internal/store/influx` — single SQL query aggregates 24h uptime and p95 latency across all providers in one round-trip
- Extracts `postQuery` private helper from `influxHistoryReader.ProviderHistory` — both history and live-stats methods now share the same HTTP transport path
- Wires `WithLiveStatsReader` functional option into API `Server`; `listProviders` merges live stats into each summary; fields are omitted (not null) when the reader is not configured
- `ProviderSummary` response gains `uptime_24h` (0–1) and `p95_ms` (ms) — `omitempty` so existing clients see no change when stats are unavailable
- `ProviderTable` now renders "Uptime 24h" and "p95" columns per BRAND_SYSTEM.md §6.2; formatted as `99.9%` / `450ms` / `1.2s` / `—`

## Test plan

- [ ] `go test ./internal/store/influx/...` — 3 new tests: success/empty/HTTP-error for `AllProviderLiveStats`
- [ ] `go test ./internal/api/...` — existing provider handler tests still pass; `liveStats = nil` path (no fields in response) covered implicitly
- [ ] `go test ./...` — full suite green
- [ ] TypeScript: `npx tsc --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)