### PR TITLE
fix LLMS-020: requestID before cors so preflight carries X-Request-ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Fixed (LLMS-020)
+- Corrected middleware stack order to `accessLog → requestID → cors → handler` so that X-Request-ID is present on every response, including CORS preflight (OPTIONS) 204 responses that previously short-circuited before `requestIDMiddleware` ran
+- Added `TestCORS_Preflight` assertion: `X-Request-ID` header must be non-empty on preflight responses
+
 ### Added (LLMS-026)
 - `ProviderLiveStat` type + `LiveStatsReader` interface in `internal/store/influx` — one SQL query returns 24h uptime + p95 latency for all providers
 - `influxHistoryReader.postQuery` private helper extracted from `ProviderHistory` — eliminates HTTP boilerplate duplication across both query methods

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -88,11 +88,14 @@ func (r *statusRecorder) WriteHeader(code int) {
 }
 
 // applyMiddleware wraps handler with the production middleware stack.
-// Execution order (outer-to-inner): accessLog → cors → requestID → handler.
+// Execution order (outer-to-inner): accessLog → requestID → cors → handler.
+// requestID runs before cors so that X-Request-ID is set on every response,
+// including CORS preflight (OPTIONS) 204 responses that short-circuit before
+// reaching the handler.
 func applyMiddleware(handler http.Handler) http.Handler {
 	return accessLogMiddleware(
-		corsMiddleware(
-			requestIDMiddleware(handler),
+		requestIDMiddleware(
+			corsMiddleware(handler),
 		),
 	)
 }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -89,6 +89,10 @@ func TestCORS_Preflight(t *testing.T) {
 	if got := rr.Header().Get("Access-Control-Max-Age"); got == "" {
 		t.Error("Access-Control-Max-Age header missing")
 	}
+	// X-Request-ID must be present even on preflight (requestID runs before cors).
+	if got := rr.Header().Get("X-Request-ID"); got == "" {
+		t.Error("X-Request-ID header missing on preflight response")
+	}
 	// Preflight should not forward to the actual handler.
 	if rr.Body.Len() != 0 {
 		t.Errorf("preflight response body should be empty, got %d bytes", rr.Body.Len())


### PR DESCRIPTION
## Summary

- All three middleware functions (CORS, Request ID, access logging) were already implemented; this PR fixes one ordering bug
- Middleware stack reordered from `accessLog → cors → requestID → handler` to `accessLog → requestID → cors → handler` so that X-Request-ID is set on every response, including CORS preflight (OPTIONS) 204 responses that previously short-circuited before requestIDMiddleware ran
- Added assertion to `TestCORS_Preflight`: X-Request-ID header must be non-empty on preflight responses

## Test plan

- [ ] `go test ./internal/api/... -run TestCORS_Preflight` — confirms X-Request-ID present on OPTIONS 204
- [ ] `go test ./internal/api/...` — all middleware tests pass
- [ ] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)