### PR TITLE
fix LLMS-027: wire WithLiveStatsReader in cmd/api so uptime_24h/p95_ms appear in prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Fixed (LLMS-027)
+- `cmd/api/main.go` now passes `historyReader` to both `WithHistoryReader` and `WithLiveStatsReader`; previously `uptime_24h`/`p95_ms` would never appear in production despite the pipeline being complete
+- Added `TestListProviders_WithLiveStats` and `TestListProviders_LiveStatsNil_OmitsFields` to confirm field presence/absence
+
 ### Fixed (LLMS-020)
 - Corrected middleware stack order to `accessLog → requestID → cors → handler` so that X-Request-ID is present on every response, including CORS preflight (OPTIONS) 204 responses that previously short-circuited before `requestIDMiddleware` ran
 - Added `TestCORS_Preflight` assertion: `X-Request-ID` header must be non-empty on preflight responses

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -60,6 +60,7 @@ func main() {
 		Addr: addr,
 		Handler: api.New(store,
 			api.WithHistoryReader(historyReader),
+			api.WithLiveStatsReader(historyReader),
 			api.WithRateLimiter(limiter),
 		),
 		ReadTimeout:  10 * time.Second,

--- a/internal/api/providers_test.go
+++ b/internal/api/providers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/llmstatus/llmstatus/internal/api"
+	"github.com/llmstatus/llmstatus/internal/store/influx"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 
@@ -81,6 +82,74 @@ func TestListProviders_WithOngoingIncident(t *testing.T) {
 	}
 	if body.Data[0].ActiveIncidentID == nil {
 		t.Error("expected active_incident_id to be set")
+	}
+}
+
+func TestListProviders_WithLiveStats(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	liveReader := &fakeLiveStatsReader{
+		stats: []influx.ProviderLiveStat{
+			{ProviderID: "openai", Uptime24h: 0.99, P95Ms: 450.5},
+		},
+	}
+	srv := api.New(store, api.WithLiveStatsReader(liveReader))
+
+	rec := doGet(t, srv, "/v1/providers")
+
+	var body struct {
+		Data []struct {
+			ID        string   `json:"id"`
+			Uptime24h *float64 `json:"uptime_24h"`
+			P95Ms     *float64 `json:"p95_ms"`
+		} `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+
+	if len(body.Data) != 1 {
+		t.Fatalf("data length: got %d, want 1", len(body.Data))
+	}
+	p := body.Data[0]
+	if p.Uptime24h == nil {
+		t.Fatal("uptime_24h: got nil, want non-nil")
+	}
+	if *p.Uptime24h < 0.989 || *p.Uptime24h > 0.991 {
+		t.Errorf("uptime_24h: got %f, want ~0.99", *p.Uptime24h)
+	}
+	if p.P95Ms == nil {
+		t.Fatal("p95_ms: got nil, want non-nil")
+	}
+	if *p.P95Ms != 450.5 {
+		t.Errorf("p95_ms: got %f, want 450.5", *p.P95Ms)
+	}
+}
+
+func TestListProviders_LiveStatsNil_OmitsFields(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	srv := api.New(store) // no WithLiveStatsReader
+
+	rec := doGet(t, srv, "/v1/providers")
+
+	var body struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+	if len(body.Data) != 1 {
+		t.Fatalf("data length: got %d, want 1", len(body.Data))
+	}
+	// Fields must be absent (omitempty), not null.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body.Data[0], &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := raw["uptime_24h"]; ok {
+		t.Error("uptime_24h should be absent when liveStats is nil")
+	}
+	if _, ok := raw["p95_ms"]; ok {
+		t.Error("p95_ms should be absent when liveStats is nil")
 	}
 }
 

--- a/internal/api/testhelpers_test.go
+++ b/internal/api/testhelpers_test.go
@@ -8,8 +8,19 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/llmstatus/llmstatus/internal/store/influx"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
+
+// fakeLiveStatsReader implements api.LiveStatsReader for unit tests.
+type fakeLiveStatsReader struct {
+	stats []influx.ProviderLiveStat
+	err   error
+}
+
+func (f *fakeLiveStatsReader) AllProviderLiveStats(_ context.Context) ([]influx.ProviderLiveStat, error) {
+	return f.stats, f.err
+}
 
 // fakeStore implements api.Store for unit tests.
 type fakeStore struct {


### PR DESCRIPTION
## Summary

- `cmd/api/main.go` was missing `api.WithLiveStatsReader(historyReader)` — `uptime_24h` and `p95_ms` would never appear in production despite the full LLMS-026 pipeline being in place
- `*influxHistoryReader` satisfies both `HistoryReader` and `LiveStatsReader`; the same instance is passed to both options
- Added `fakeLiveStatsReader` to test helpers and two new tests: `TestListProviders_WithLiveStats` (fields present and correct) and `TestListProviders_LiveStatsNil_OmitsFields` (fields absent, not null, when reader not wired)

## Test plan

- [ ] `go test ./internal/api/... -run TestListProviders_WithLiveStats` — fields appear
- [ ] `go test ./internal/api/... -run TestListProviders_LiveStatsNil_OmitsFields` — fields absent
- [ ] `go build ./cmd/api` — clean build
- [ ] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)