### PR TITLE
feat LLMS-028: SEO metadata + homepage hero section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-028)
+- Homepage hero section: tagline + subhead verbatim from BRAND_SYSTEM.md §7.1; optional faint grid background per §6.5
+- `layout.tsx` base metadata: corrected site name to `llmstatus.io`, added `openGraph.siteName`, `twitter.card`
+- `page.tsx` exports named `metadata` with OG title + description
+- `providers/[id]/page.tsx` `generateMetadata` now includes `openGraph` with provider-specific title + description
+- `incidents/[slug]/page.tsx` `generateMetadata` now includes `openGraph` with incident title + description
+- `incidents/page.tsx` now includes `openGraph` metadata
+- `ProviderTable` table headers updated to all-caps 11px with 0.08em tracking per brand spec §6.2
+
 ### Fixed (LLMS-027)
 - `cmd/api/main.go` now passes `historyReader` to both `WithHistoryReader` and `WithLiveStatsReader`; previously `uptime_24h`/`p95_ms` would never appear in production despite the pipeline being complete
 - Added `TestListProviders_WithLiveStats` and `TestListProviders_LiveStatsNil_OmitsFields` to confirm field presence/absence

--- a/web/app/incidents/[slug]/page.tsx
+++ b/web/app/incidents/[slug]/page.tsx
@@ -29,9 +29,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   try {
     const inc = await getIncident(slug);
+    const title = incidentTitle(inc);
+    const description = inc.description ?? inc.title;
     return {
-      title: incidentTitle(inc),
-      description: inc.description ?? inc.title,
+      title,
+      description,
+      openGraph: { title, description },
     };
   } catch {
     return { title: "Incident not found" };

--- a/web/app/incidents/page.tsx
+++ b/web/app/incidents/page.tsx
@@ -8,6 +8,10 @@ export const revalidate = 30;
 export const metadata: Metadata = {
   title: "Incidents",
   description: "All detected incidents across AI API providers, past and present.",
+  openGraph: {
+    title: "Incidents | llmstatus.io",
+    description: "All detected incidents across AI API providers, past and present.",
+  },
 };
 
 export default async function IncidentsPage() {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -7,13 +7,24 @@ import { SiteFooter } from "@/components/SiteFooter";
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
 
+const DESCRIPTION =
+  "Independent real-time uptime and latency monitoring for AI API providers. " +
+  "Measured from 7 global locations. Not scraped from official status pages.";
+
 export const metadata: Metadata = {
   title: {
-    default: "LLM Status — Real-time AI API monitoring",
-    template: "%s — LLM Status",
+    default: "llmstatus.io — AI API Status Monitor",
+    template: "%s | llmstatus.io",
   },
-  description:
-    "Independent real-time uptime and latency monitoring for AI API providers. Live data, not scraped status pages.",
+  description: DESCRIPTION,
+  openGraph: {
+    siteName: "llmstatus.io",
+    type: "website",
+    description: DESCRIPTION,
+  },
+  twitter: {
+    card: "summary",
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,7 +1,21 @@
+import type { Metadata } from "next";
 import { listProviders } from "@/lib/api";
 import { ProviderTable } from "@/components/ProviderTable";
 
 export const revalidate = 30;
+
+export const metadata: Metadata = {
+  title: "AI API Status Monitor",
+  description:
+    "Independent real-time monitoring for the AI infrastructure. " +
+    "Measured from 7 global locations. Not scraped from official status pages.",
+  openGraph: {
+    title: "llmstatus.io — AI API Status Monitor",
+    description:
+      "Independent real-time monitoring for the AI infrastructure. " +
+      "Measured from 7 global locations. Not scraped from official status pages.",
+  },
+};
 
 export default async function HomePage() {
   const providers = await listProviders().catch(() => null);
@@ -31,11 +45,33 @@ export default async function HomePage() {
       : "text-[var(--signal-warn)]";
 
   return (
-    <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
-      <div className="mb-8">
-        <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">
-          AI API Status
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6">
+      {/* Hero — brand spec §7.1 + optional grid background §6.5 */}
+      <div
+        className="py-14 mb-2"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, rgba(255,255,255,0.02) 1px, transparent 1px)," +
+            "linear-gradient(to bottom, rgba(255,255,255,0.02) 1px, transparent 1px)",
+          backgroundSize: "8px 8px",
+        }}
+      >
+        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--signal-amber)] mb-4">
+          llmstatus.io
+        </p>
+        <h1 className="text-3xl font-semibold text-[var(--ink-100)] leading-tight mb-3">
+          Independent real-time monitoring
+          <br />
+          for the AI infrastructure.
         </h1>
+        <p className="text-sm text-[var(--ink-400)] leading-relaxed">
+          Measured from 7 global locations.
+          <br />
+          Not scraped from official status pages.
+        </p>
+      </div>
+
+      <div className="mb-6">
         <p className={`text-sm font-medium ${summaryColor}`}>{summaryText}</p>
       </div>
 

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -23,9 +23,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         : provider.current_status === "down"
         ? "experiencing an outage"
         : "degraded";
+    const description = `${provider.name} API is currently ${statusLabel}. Real-time uptime monitoring from llmstatus.io.`;
     return {
       title: `Is ${provider.name} API down?`,
-      description: `${provider.name} API is currently ${statusLabel}. Real-time uptime monitoring from llmstatus.io.`,
+      description,
+      openGraph: { title: `${provider.name} API Status`, description },
     };
   } catch {
     return { title: "Provider not found" };

--- a/web/components/ProviderTable.tsx
+++ b/web/components/ProviderTable.tsx
@@ -39,12 +39,12 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-[var(--ink-600)] bg-[var(--canvas-sunken)]">
-            <th className="px-4 py-3 text-left font-medium text-[var(--ink-300)]">Provider</th>
-            <th className="px-4 py-3 text-left font-medium text-[var(--ink-300)]">Category</th>
-            <th className="px-4 py-3 text-left font-medium text-[var(--ink-300)]">Region</th>
-            <th className="px-4 py-3 text-right font-medium text-[var(--ink-300)]">Uptime 24h</th>
-            <th className="px-4 py-3 text-right font-medium text-[var(--ink-300)]">p95</th>
-            <th className="px-4 py-3 text-right font-medium text-[var(--ink-300)]">Status</th>
+            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Provider</th>
+            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Category</th>
+            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Region</th>
+            <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Uptime 24h</th>
+            <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">p95</th>
+            <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Status</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Summary

- Homepage hero: tagline + subhead verbatim from BRAND_SYSTEM.md §7.1 (`"Independent real-time monitoring for the AI infrastructure."` / `"Measured from 7 global locations. Not scraped from official status pages."`); optional faint grid background per §6.5
- Root `layout.tsx`: corrected site name from `"LLM Status"` → `"llmstatus.io"`, title template `"%s | llmstatus.io"`, added `openGraph.siteName` and `twitter.card: "summary"`
- All four page entry points now export OpenGraph metadata (homepage, provider detail, incidents list, incident detail)
- `ProviderTable` headers updated to all-caps 11px `tracking-[0.08em]` per brand spec §6.2 (was: `font-medium` 14px, no letter-spacing)

## Test plan

- [ ] `npx tsc --noEmit` — no errors
- [ ] `go test ./...` — full Go suite green
- [ ] View-source on dev server: `<title>` and `og:title` correct on `/`, `/providers/openai`, `/incidents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)