### PR TITLE
feat LLMS-029: not-found page, sitemap.xml, robots.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-029)
+- `web/app/not-found.tsx` — branded 404 page (amber "404" label, dark canvas, "Back to status" link) replacing Next.js default white page
+- `web/app/robots.ts` — serves `/robots.txt`: allow all crawlers, points to sitemap; respects `NEXT_PUBLIC_SITE_URL` env var
+- `web/app/sitemap.ts` — serves `/sitemap.xml`: static routes (`/`, `/incidents`) + dynamic routes for every active provider and recent incident; revalidates hourly; falls back gracefully when API is unreachable
+
 ### Added (LLMS-028)
 - Homepage hero section: tagline + subhead verbatim from BRAND_SYSTEM.md §7.1; optional faint grid background per §6.5
 - `layout.tsx` base metadata: corrected site name to `llmstatus.io`, added `openGraph.siteName`, `twitter.card`

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+};
+
+export default function NotFound() {
+  return (
+    <main className="flex-1 flex flex-col items-center justify-center px-6 py-20 text-center">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--signal-amber)] mb-4">
+        404
+      </p>
+      <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-3">
+        Page not found.
+      </h1>
+      <p className="text-sm text-[var(--ink-400)] mb-8 max-w-xs">
+        This URL does not exist. If you followed a link, it may have moved.
+      </p>
+      <Link
+        href="/"
+        className="text-xs text-[var(--ink-300)] hover:text-[var(--ink-100)] transition-colors underline underline-offset-4"
+      >
+        ← Back to status
+      </Link>
+    </main>
+  );
+}

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://llmstatus.io";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+import { listProviders, listIncidents } from "@/lib/api";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://llmstatus.io";
+
+export const revalidate = 3600; // rebuild hourly
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: SITE_URL, lastModified: now, changeFrequency: "always", priority: 1 },
+    { url: `${SITE_URL}/incidents`, lastModified: now, changeFrequency: "always", priority: 0.9 },
+  ];
+
+  const providerRoutes: MetadataRoute.Sitemap = await listProviders()
+    .then((providers) =>
+      providers.map((p) => ({
+        url: `${SITE_URL}/providers/${p.id}`,
+        lastModified: now,
+        changeFrequency: "always" as const,
+        priority: 0.8,
+      }))
+    )
+    .catch(() => []);
+
+  const incidentRoutes: MetadataRoute.Sitemap = await listIncidents("all", 200)
+    .then((incidents) =>
+      incidents.map((inc) => ({
+        url: `${SITE_URL}/incidents/${inc.slug}`,
+        lastModified: new Date(inc.resolved_at ?? inc.started_at),
+        changeFrequency: (inc.status === "ongoing" ? "always" : "never") as
+          | "always"
+          | "never",
+        priority: inc.status === "ongoing" ? 0.7 : 0.5,
+      }))
+    )
+    .catch(() => []);
+
+  return [...staticRoutes, ...providerRoutes, ...incidentRoutes];
+}


### PR DESCRIPTION
## Summary

- `not-found.tsx`: branded 404 page matching site aesthetic — dark canvas, amber "404" label, plain copy ("Page not found."), "Back to status" link; replaces Next.js default white page
- `robots.ts`: serves `/robots.txt` allowing all crawlers; `Sitemap:` header points to `${NEXT_PUBLIC_SITE_URL}/sitemap.xml` (defaults to `https://llmstatus.io`)
- `sitemap.ts`: serves `/sitemap.xml` with static routes (`/` priority 1.0, `/incidents` priority 0.9), dynamic provider pages (priority 0.8), dynamic incident pages (ongoing: 0.7, resolved: 0.5); revalidates hourly; API failures degrade gracefully to empty sections

## Test plan

- [ ] `npx tsc --noEmit` — no errors
- [ ] Navigate to `/nonexistent` in dev: branded 404 renders, "Back to status" works
- [ ] `/sitemap.xml` reachable in dev; contains at least static routes
- [ ] `/robots.txt` returns `Allow: /` and `Sitemap:` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)