### PR TITLE
feat LLMS-030: branded error.tsx and loading.tsx page states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-030)
+- `web/app/error.tsx` — client-component error boundary: branded dark page with amber "Error" label, digest-aware message, and secondary "Try again" button that calls Next.js `reset()`
+- `web/app/loading.tsx` — server-component loading skeleton: `animate-pulse` blocks mirroring the hero + table layout; shown during client-side navigation suspense
+
 ### Added (LLMS-029)
 - `web/app/not-found.tsx` — branded 404 page (amber "404" label, dark canvas, "Back to status" link) replacing Next.js default white page
 - `web/app/robots.ts` — serves `/robots.txt`: allow all crawlers, points to sitemap; respects `NEXT_PUBLIC_SITE_URL` env var

--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="flex-1 flex flex-col items-center justify-center px-6 py-20 text-center">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--signal-amber)] mb-4">
+        Error
+      </p>
+      <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-3">
+        Something went wrong.
+      </h1>
+      <p className="text-sm text-[var(--ink-400)] mb-8 max-w-xs">
+        {error.digest ? (
+          <>Could not load page data. Error ID: {error.digest}</>
+        ) : (
+          <>Could not load page data. Check that the backend is reachable.</>
+        )}
+      </p>
+      <button
+        onClick={reset}
+        className="text-xs border border-[var(--ink-500)] text-[var(--ink-100)] px-4 py-2 hover:border-[var(--ink-300)] transition-colors"
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/web/app/loading.tsx
+++ b/web/app/loading.tsx
@@ -1,0 +1,43 @@
+export default function LoadingPage() {
+  return (
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10 animate-pulse">
+      {/* Hero skeleton */}
+      <div className="py-14 mb-2">
+        <div className="h-2.5 w-24 rounded bg-[var(--ink-600)] mb-4" />
+        <div className="h-8 w-80 rounded bg-[var(--ink-600)] mb-2" />
+        <div className="h-8 w-56 rounded bg-[var(--ink-600)] mb-4" />
+        <div className="h-3 w-64 rounded bg-[var(--ink-700)] mb-1" />
+        <div className="h-3 w-52 rounded bg-[var(--ink-700)]" />
+      </div>
+
+      {/* Status summary skeleton */}
+      <div className="mb-6">
+        <div className="h-3 w-40 rounded bg-[var(--ink-600)]" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="overflow-hidden rounded-lg border border-[var(--ink-600)]">
+        {/* Header row */}
+        <div className="flex gap-4 px-4 py-3 border-b border-[var(--ink-600)] bg-[var(--canvas-sunken)]">
+          {[40, 24, 16, 20, 12, 16].map((w, i) => (
+            <div key={i} className={`h-2 w-${w} rounded bg-[var(--ink-700)]`} />
+          ))}
+        </div>
+        {/* Data rows */}
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 px-4 py-3 border-b border-[var(--ink-600)] last:border-0"
+          >
+            <div className="h-3 w-32 rounded bg-[var(--ink-600)]" />
+            <div className="h-3 w-20 rounded bg-[var(--ink-700)]" />
+            <div className="h-3 w-12 rounded bg-[var(--ink-700)]" />
+            <div className="h-3 w-16 rounded bg-[var(--ink-700)]" />
+            <div className="h-3 w-10 rounded bg-[var(--ink-700)]" />
+            <div className="h-2 w-2 rounded-full bg-[var(--ink-600)] ml-auto" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- `error.tsx` (`"use client"`): replaces Next.js generic white error page with branded dark canvas, amber "Error" label, factual message (includes `error.digest` when available for support correlation), secondary "Try again" button calling `reset()`
- `loading.tsx`: `animate-pulse` skeleton mirroring the homepage hero + 6-row data table layout; shown during client-side navigation while RSC data loads; no new dependencies

## Test plan

- [ ] `npx tsc --noEmit` — no errors
- [ ] Trigger error: temporarily make API unreachable, navigate to `/` — branded error page with "Try again" renders
- [ ] Client-side navigation: click nav links — loading skeleton flashes briefly before content

🤖 Generated with [Claude Code](https://claude.com/claude-code)