### PR TITLE
feat LLMS-031: GET /v1/status endpoint + real DB ping in /healthz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-031)
+- `GET /v1/status` — aggregate system status endpoint: worst-case status across all active providers (`"operational"` / `"degraded"` / `"down"`) plus breakdown counts; wrapped in standard envelope
+- `Pinger` interface + `WithPinger` functional option on `Server` — when wired, `/healthz` pings the DB and returns 503 if unreachable; without it, behaviour is unchanged (always 200)
+- `cmd/api/main.go` wires `WithPinger(pool)` so production health checks reflect actual DB state
+- 7 new tests: `GetStatus` (all-operational, one-down, one-degraded, empty) + `Healthz` (no pinger, pinger OK, pinger fail)
+
 ### Added (LLMS-030)
 - `web/app/error.tsx` — client-component error boundary: branded dark page with amber "Error" label, digest-aware message, and secondary "Try again" button that calls Next.js `reset()`
 - `web/app/loading.tsx` — server-component loading skeleton: `animate-pulse` blocks mirroring the hero + table layout; shown during client-side navigation suspense

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -59,6 +59,7 @@ func main() {
 	srv := &http.Server{
 		Addr: addr,
 		Handler: api.New(store,
+			api.WithPinger(pool),
 			api.WithHistoryReader(historyReader),
 			api.WithLiveStatsReader(historyReader),
 			api.WithRateLimiter(limiter),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -18,14 +19,25 @@ import (
 // compile-time check: pgstore.Queries satisfies Store.
 var _ Store = (*pgstore.Queries)(nil)
 
+// Pinger is satisfied by *pgxpool.Pool; used by /healthz.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
+
 // Server wires handlers to a ServeMux and owns the store reference.
 type Server struct {
 	store     Store
 	history   HistoryReader   // optional; nil → GET /history returns 503
 	liveStats LiveStatsReader // optional; nil → uptime24h/p95_ms omitted
+	pinger    Pinger          // optional; nil → /healthz always 200
 	limiter   *RateLimiter    // optional; nil → no rate limiting
 	mux       *http.ServeMux
 	handler   http.Handler // mux optionally wrapped with limiter middleware
+}
+
+// WithPinger enables a real DB liveness check in /healthz.
+func WithPinger(p Pinger) func(*Server) {
+	return func(s *Server) { s.pinger = p }
 }
 
 // New creates a Server and registers all routes. Pass functional options
@@ -50,6 +62,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
+	s.mux.HandleFunc("GET /v1/status", s.getStatus)
 	s.mux.HandleFunc("GET /v1/providers", s.listProviders)
 	s.mux.HandleFunc("GET /v1/providers/{id}", s.getProvider)
 	s.mux.HandleFunc("GET /v1/providers/{id}/history", s.getProviderHistory)
@@ -60,7 +73,13 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /v1/providers/{id}/feed.xml", s.getProviderFeed)
 }
 
-func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if s.pinger != nil {
+		if err := s.pinger.Ping(r.Context()); err != nil {
+			writeError(w, http.StatusServiceUnavailable, "database unavailable")
+			return
+		}
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"net/http"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+type statusCounts struct {
+	Total       int `json:"total"`
+	Operational int `json:"operational"`
+	Degraded    int `json:"degraded"`
+	Down        int `json:"down"`
+}
+
+type statusResponse struct {
+	Status string       `json:"status"`
+	Counts statusCounts `json:"counts"`
+}
+
+// getStatus returns the aggregate system status across all active providers.
+// Status is the worst observed: "down" > "degraded" > "operational".
+func (s *Server) getStatus(w http.ResponseWriter, r *http.Request) {
+	providers, err := s.store.ListActiveProviders(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list providers")
+		return
+	}
+
+	ongoing, err := s.store.ListIncidentsByStatus(r.Context(), pgstore.ListIncidentsByStatusParams{
+		Status: "ongoing",
+		Limit:  200,
+		Offset: 0,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load incidents")
+		return
+	}
+
+	incidentByProvider := make(map[string]pgstore.Incident)
+	for _, inc := range ongoing {
+		existing, seen := incidentByProvider[inc.ProviderID]
+		if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
+			incidentByProvider[inc.ProviderID] = inc
+		}
+	}
+
+	counts := statusCounts{Total: len(providers)}
+	worst := "operational"
+	for _, p := range providers {
+		st, _ := deriveStatus(p.ID, incidentByProvider)
+		switch st {
+		case "down":
+			counts.Down++
+			worst = "down"
+		case "degraded":
+			counts.Degraded++
+			if worst != "down" {
+				worst = "degraded"
+			}
+		default:
+			counts.Operational++
+		}
+	}
+
+	writeEnvelope(w, statusResponse{Status: worst, Counts: counts})
+}

--- a/internal/api/status_test.go
+++ b/internal/api/status_test.go
@@ -1,0 +1,165 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/llmstatus/llmstatus/internal/api"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// fakePinger satisfies api.Pinger for healthz tests.
+type fakePinger struct{ err error }
+
+func (f *fakePinger) Ping(_ context.Context) error { return f.err }
+
+// ---- /v1/status tests -------------------------------------------------------
+
+func TestGetStatus_AllOperational(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{
+			fixtureProvider("openai", "OpenAI"),
+			fixtureProvider("anthropic", "Anthropic"),
+		},
+	}
+	srv := api.New(store)
+	rec := doGet(t, srv, "/v1/status")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var body struct {
+		Data struct {
+			Status string `json:"status"`
+			Counts struct {
+				Total       int `json:"total"`
+				Operational int `json:"operational"`
+				Degraded    int `json:"degraded"`
+				Down        int `json:"down"`
+			} `json:"counts"`
+		} `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+
+	if body.Data.Status != "operational" {
+		t.Errorf("status: got %q, want operational", body.Data.Status)
+	}
+	if body.Data.Counts.Total != 2 {
+		t.Errorf("total: got %d, want 2", body.Data.Counts.Total)
+	}
+	if body.Data.Counts.Operational != 2 {
+		t.Errorf("operational: got %d, want 2", body.Data.Counts.Operational)
+	}
+}
+
+func TestGetStatus_OneDown(t *testing.T) {
+	inc := fixtureIncident("openai", "2026-04-18-openai-down", "ongoing", "critical")
+	store := &fakeStore{
+		providers: []pgstore.Provider{
+			fixtureProvider("openai", "OpenAI"),
+			fixtureProvider("anthropic", "Anthropic"),
+		},
+		incidents: []pgstore.Incident{inc},
+	}
+	srv := api.New(store)
+	rec := doGet(t, srv, "/v1/status")
+
+	var body struct {
+		Data struct {
+			Status string `json:"status"`
+			Counts struct {
+				Total       int `json:"total"`
+				Operational int `json:"operational"`
+				Down        int `json:"down"`
+			} `json:"counts"`
+		} `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+
+	if body.Data.Status != "down" {
+		t.Errorf("status: got %q, want down", body.Data.Status)
+	}
+	if body.Data.Counts.Down != 1 {
+		t.Errorf("down: got %d, want 1", body.Data.Counts.Down)
+	}
+	if body.Data.Counts.Operational != 1 {
+		t.Errorf("operational: got %d, want 1", body.Data.Counts.Operational)
+	}
+}
+
+func TestGetStatus_OneDegraded_NotDown(t *testing.T) {
+	inc := fixtureIncident("anthropic", "2026-04-18-anthropic-deg", "ongoing", "major")
+	store := &fakeStore{
+		providers: []pgstore.Provider{
+			fixtureProvider("openai", "OpenAI"),
+			fixtureProvider("anthropic", "Anthropic"),
+		},
+		incidents: []pgstore.Incident{inc},
+	}
+	srv := api.New(store)
+	rec := doGet(t, srv, "/v1/status")
+
+	var body struct {
+		Data struct {
+			Status string `json:"status"`
+			Counts struct {
+				Degraded int `json:"degraded"`
+			} `json:"counts"`
+		} `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+
+	if body.Data.Status != "degraded" {
+		t.Errorf("status: got %q, want degraded", body.Data.Status)
+	}
+	if body.Data.Counts.Degraded != 1 {
+		t.Errorf("degraded: got %d, want 1", body.Data.Counts.Degraded)
+	}
+}
+
+func TestGetStatus_Empty(t *testing.T) {
+	srv := api.New(&fakeStore{})
+	rec := doGet(t, srv, "/v1/status")
+
+	var body struct {
+		Data json.RawMessage `json:"data"`
+	}
+	mustDecode(t, rec.Body, &body)
+	// Should return operational when no providers configured.
+	var d struct{ Status string `json:"status"` }
+	if err := json.Unmarshal(body.Data, &d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if d.Status != "operational" {
+		t.Errorf("status: got %q, want operational", d.Status)
+	}
+}
+
+// ---- /healthz tests ---------------------------------------------------------
+
+func TestHealthz_NoPinger_Always200(t *testing.T) {
+	srv := api.New(&fakeStore{}) // no WithPinger
+	rec := doGet(t, srv, "/healthz")
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
+	}
+}
+
+func TestHealthz_PingerOK_Returns200(t *testing.T) {
+	srv := api.New(&fakeStore{}, api.WithPinger(&fakePinger{}))
+	rec := doGet(t, srv, "/healthz")
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
+	}
+}
+
+func TestHealthz_PingerFail_Returns503(t *testing.T) {
+	srv := api.New(&fakeStore{}, api.WithPinger(&fakePinger{err: errors.New("connection refused")}))
+	rec := doGet(t, srv, "/healthz")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status: got %d, want 503", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- `GET /v1/status`: aggregate system health in one call — worst-case status (`"operational"` / `"degraded"` / `"down"`) plus counts (`total`, `operational`, `degraded`, `down`); reuses existing `ListActiveProviders` + `ListIncidentsByStatus` queries
- `Pinger` interface + `WithPinger` functional option: when wired, `/healthz` pings the DB and returns 503 on failure; without it, behaviour is unchanged (always 200)
- `cmd/api/main.go` now passes `WithPinger(pool)` so uptime monitors get real signal
- 7 tests: status endpoint (all-operational, one-down, one-degraded, empty); healthz (no pinger → 200, pinger OK → 200, pinger fail → 503)

## Test plan

- [ ] `go test ./internal/api/... -run TestGetStatus` — all pass
- [ ] `go test ./internal/api/... -run TestHealthz` — all pass
- [ ] `go build ./cmd/api` — clean build
- [ ] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)