### PR TITLE
feat LLMS-033: add /badges page with live preview and embed code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-033)
+- `/badges` page — live badge preview + Markdown / HTML / URL embed snippets for every monitored provider; linked from site nav
+- `CopyButton` client component — clipboard copy with 1.8s "Copied" confirmation
+- `web/app/api/badge/[id]/route.ts` — Next.js proxy route that forwards badge requests to the Go API (`/badge/{id}.svg`); lets the static badges page render `<img>` tags without exposing the internal `API_URL` to the browser
+- `/badges` added to sitemap with `changeFrequency: "monthly"`
+
 ### Fixed (LLMS-032)
 - `docker-compose.yml` rewritten for Go + Next.js stack; removes all Python/uvicorn references which no longer exist
 - `deploy/docker/Dockerfile.golang` — single parameterized multi-stage Go build (`--build-arg CMD=<api|ingest|detector|prober|migrate>`); runtime image is `alpine:3.21` with only `ca-certificates` + `tzdata`

--- a/web/app/api/badge/[id]/route.ts
+++ b/web/app/api/badge/[id]/route.ts
@@ -1,0 +1,31 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const API_URL = process.env.API_URL ?? "http://localhost:8081";
+
+// Proxies /api/badge/{id} → Go API /badge/{id}.svg.
+// Allows the Next.js app to serve badge previews without exposing
+// the internal API_URL to the browser.
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const upstream = `${API_URL}/badge/${encodeURIComponent(id)}.svg`;
+
+  let res: Response;
+  try {
+    res = await fetch(upstream, { next: { revalidate: 60 } });
+  } catch {
+    return new NextResponse("upstream unavailable", { status: 502 });
+  }
+
+  const svg = await res.text();
+  return new NextResponse(svg, {
+    status: res.status,
+    headers: {
+      "Content-Type": "image/svg+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=30, s-maxage=30",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/web/app/badges/page.tsx
+++ b/web/app/badges/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next";
+import { listProviders } from "@/lib/api";
+import { CopyButton } from "@/components/CopyButton";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Status Badges",
+  description:
+    "Embed llmstatus.io status badges on your site, README, or docs. " +
+    "Live SVG badges for every monitored AI provider.",
+  openGraph: {
+    title: "Status Badges — llmstatus.io",
+    description:
+      "Embed llmstatus.io status badges on your site, README, or docs.",
+  },
+};
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
+// Public badge URL — in production nginx proxies /badge/* to the Go API.
+// In dev the Next.js proxy route at /api/badge/{id} is used for preview.
+function publicBadgeUrl(providerId: string) {
+  return `${SITE_URL}/badge/${providerId}.svg`;
+}
+
+function previewBadgeUrl(providerId: string) {
+  return `/api/badge/${providerId}`;
+}
+
+function BadgeRow({ name, id }: { name: string; id: string }) {
+  const url = publicBadgeUrl(id);
+  const markdown = `[![${name} status](${url})](${SITE_URL}/providers/${id})`;
+  const html = `<a href="${SITE_URL}/providers/${id}"><img src="${url}" alt="${name} status" /></a>`;
+
+  return (
+    <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--ink-600)]">
+        <span className="text-sm font-semibold text-[var(--ink-100)]">{name}</span>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={previewBadgeUrl(id)}
+          alt={`${name} status badge`}
+          height={20}
+          className="h-5"
+        />
+      </div>
+
+      <div className="divide-y divide-[var(--ink-600)]">
+        <CodeSnippet label="Markdown" code={markdown} />
+        <CodeSnippet label="HTML" code={html} />
+        <CodeSnippet label="URL" code={url} />
+      </div>
+    </div>
+  );
+}
+
+function CodeSnippet({ label, code }: { label: string; code: string }) {
+  return (
+    <div className="px-4 py-3">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">
+          {label}
+        </span>
+        <CopyButton text={code} />
+      </div>
+      <pre className="text-[11px] font-mono text-[var(--ink-300)] break-all whitespace-pre-wrap leading-relaxed">
+        {code}
+      </pre>
+    </div>
+  );
+}
+
+export default async function BadgesPage() {
+  const providers = await listProviders().catch(() => null);
+
+  return (
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6">
+      <div className="py-10 mb-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--signal-amber)] mb-4">
+          Badges
+        </p>
+        <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-3">
+          Embed a live status badge
+        </h1>
+        <p className="text-sm text-[var(--ink-400)] leading-relaxed max-w-xl">
+          Badges update every 30 seconds. Paste the snippet below into your
+          README, documentation, or website.
+        </p>
+      </div>
+
+      {providers === null ? (
+        <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6 py-10 text-center">
+          <p className="text-sm text-[var(--ink-400)]">
+            Could not reach the API. Check that the backend is running.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4 pb-16">
+          {providers.map((p) => (
+            <BadgeRow key={p.id} name={p.name} id={p.id} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -11,6 +11,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: SITE_URL, lastModified: now, changeFrequency: "always", priority: 1 },
     { url: `${SITE_URL}/incidents`, lastModified: now, changeFrequency: "always", priority: 0.9 },
+    { url: `${SITE_URL}/badges`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
   ];
 
   const providerRoutes: MetadataRoute.Sitemap = await listProviders()

--- a/web/components/CopyButton.tsx
+++ b/web/components/CopyButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+
+interface CopyButtonProps {
+  text: string;
+}
+
+export function CopyButton({ text }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="text-[10px] font-semibold uppercase tracking-[0.08em] px-2 py-0.5 rounded border border-[var(--ink-600)] text-[var(--ink-300)] hover:text-[var(--ink-100)] hover:border-[var(--ink-500)] transition-colors"
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}

--- a/web/components/SiteHeader.tsx
+++ b/web/components/SiteHeader.tsx
@@ -14,6 +14,7 @@ export function SiteHeader() {
         <nav className="flex items-center gap-6" aria-label="Site navigation">
           <NavLink href="/">Providers</NavLink>
           <NavLink href="/incidents">Incidents</NavLink>
+          <NavLink href="/badges">Badges</NavLink>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary

- Adds `/badges` page showing live SVG badge preview + Markdown / HTML / URL embed snippets for every active provider
- `CopyButton` client component with 1.8s clipboard feedback (only interactive piece)
- `web/app/api/badge/[id]/route.ts` — Next.js proxy route that forwards `/api/badge/{id}` → Go API `/badge/{id}.svg`; avoids `dangerouslySetInnerHTML` and keeps the internal `API_URL` server-side
- `/badges` added to site nav and sitemap

## Test plan

- [ ] `GET /badges` renders all providers with badge previews
- [ ] Badge images load via `/api/badge/{id}` proxy route
- [ ] Click Copy on Markdown/HTML/URL copies correct text to clipboard
- [ ] "Copied" label appears for ~1.8s then reverts
- [ ] OG metadata set on page
- [ ] Badges link highlights correctly in nav when on `/badges`
- [ ] `/sitemap.xml` includes `/badges`

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)