### PR TITLE
feat LLMS-034: add RSS discovery links and feed proxy routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-034)
+- RSS discovery: `<link rel="alternate" type="application/rss+xml">` added to root `layout.tsx` (global feed) and to provider detail `generateMetadata` (per-provider feed) — satisfies ROADMAP §8.3 requirement
+- `web/app/api/feed/route.ts` — Next.js proxy for global feed (`/api/feed` → Go API `/feed.xml`)
+- `web/app/api/feed/[id]/route.ts` — Next.js proxy for per-provider feed (`/api/feed/{id}` → Go API `/v1/providers/{id}/feed.xml`)
+- RSS link added to `SiteFooter` and to provider detail page subtitle row
+- Provider detail page now shows "RSS" link alongside "Status page ↗"
+
 ### Added (LLMS-033)
 - `/badges` page — live badge preview + Markdown / HTML / URL embed snippets for every monitored provider; linked from site nav
 - `CopyButton` client component — clipboard copy with 1.8s "Copied" confirmation

--- a/web/app/api/feed/[id]/route.ts
+++ b/web/app/api/feed/[id]/route.ts
@@ -1,0 +1,28 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const API_URL = process.env.API_URL ?? "http://localhost:8081";
+
+// Proxies /api/feed/{id} → Go API /v1/providers/{id}/feed.xml.
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const upstream = `${API_URL}/v1/providers/${encodeURIComponent(id)}/feed.xml`;
+
+  let res: Response;
+  try {
+    res = await fetch(upstream, { next: { revalidate: 60 } });
+  } catch {
+    return new NextResponse("upstream unavailable", { status: 502 });
+  }
+
+  const xml = await res.text();
+  return new NextResponse(xml, {
+    status: res.status,
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=60, s-maxage=60",
+    },
+  });
+}

--- a/web/app/api/feed/route.ts
+++ b/web/app/api/feed/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const API_URL = process.env.API_URL ?? "http://localhost:8081";
+
+// Proxies /api/feed → Go API /feed.xml (global incident RSS feed).
+export async function GET(_req: NextRequest) {
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/feed.xml`, { next: { revalidate: 60 } });
+  } catch {
+    return new NextResponse("upstream unavailable", { status: 502 });
+  }
+
+  const xml = await res.text();
+  return new NextResponse(xml, {
+    status: res.status,
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=60, s-maxage=60",
+    },
+  });
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -25,6 +25,11 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary",
   },
+  alternates: {
+    types: {
+      "application/rss+xml": "/api/feed",
+    },
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -28,6 +28,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `Is ${provider.name} API down?`,
       description,
       openGraph: { title: `${provider.name} API Status`, description },
+      alternates: {
+        types: {
+          "application/rss+xml": `/api/feed/${id}`,
+        },
+      },
     };
   } catch {
     return { title: "Provider not found" };
@@ -80,6 +85,13 @@ export default async function ProviderPage({ params }: Props) {
                 </a>
               </>
             )}
+            {" · "}
+            <Link
+              href={`/api/feed/${id}`}
+              className="hover:text-[var(--ink-200)] transition-colors"
+            >
+              RSS
+            </Link>
           </p>
         </div>
         <StatusPill status={provider.current_status} />

--- a/web/components/SiteFooter.tsx
+++ b/web/components/SiteFooter.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 interface Props {
   message?: string;
 }
@@ -8,8 +10,15 @@ const DEFAULT_MESSAGE =
 export function SiteFooter({ message = DEFAULT_MESSAGE }: Props) {
   return (
     <footer className="border-t border-[var(--ink-600)] px-6 py-4">
-      <div className="mx-auto max-w-4xl text-xs text-[var(--ink-400)]">
-        {message}
+      <div className="mx-auto max-w-4xl flex items-center justify-between text-xs text-[var(--ink-400)]">
+        <span>{message}</span>
+        <Link
+          href="/api/feed"
+          className="hover:text-[var(--ink-200)] transition-colors"
+          aria-label="RSS feed"
+        >
+          RSS
+        </Link>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary

- Satisfies ROADMAP §8.3 requirement: every provider page now emits `<link rel="alternate" type="application/rss+xml">` in `<head>` for both the global and per-provider incident feed
- Root `layout.tsx` adds the global feed link so RSS readers auto-discover it on every page
- Provider detail `generateMetadata` adds the per-provider feed link
- Two Next.js proxy routes (`/api/feed`, `/api/feed/[id]`) forward to Go API `/feed.xml` and `/v1/providers/{id}/feed.xml` — feeds work in dev without nginx
- RSS link added to `SiteFooter` (every page) and provider detail subtitle row (contextual)

## Test plan

- [ ] `curl -s http://localhost:3000` → page source contains `<link rel="alternate" type="application/rss+xml" href="/api/feed">`
- [ ] `curl -s http://localhost:3000/providers/openai` → page source contains per-provider feed link
- [ ] `curl http://localhost:3000/api/feed` → proxies to Go API, returns XML with `Content-Type: application/rss+xml`
- [ ] `curl http://localhost:3000/api/feed/openai` → proxies per-provider feed
- [ ] RSS link visible in footer on all pages
- [ ] "RSS" link visible on provider detail pages

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)