### PR TITLE
feat LLMS-035: add ?style=detailed badge variant with live uptime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-035)
+- `GET /badge/{id}.svg?style=detailed` — badge variant that appends live 24h uptime percentage when `LiveStatsReader` is wired (e.g. `operational · 99.9%`); falls back to simple format when live stats are unavailable
+- `/badges` page now shows both Simple and Detailed preview images side-by-side, with embed snippets for each style
+- 3 new badge tests: `DetailedStyle_WithUptime`, `DetailedStyle_NoLiveStats_FallsBack`, `UnknownStyle_FallsBack`
+
 ### Added (LLMS-034)
 - RSS discovery: `<link rel="alternate" type="application/rss+xml">` added to root `layout.tsx` (global feed) and to provider detail `generateMetadata` (per-provider feed) — satisfies ROADMAP §8.3 requirement
 - `web/app/api/feed/route.ts` — Next.js proxy for global feed (`/api/feed` → Go API `/feed.xml`)

--- a/internal/api/badge.go
+++ b/internal/api/badge.go
@@ -39,7 +39,21 @@ func (s *Server) getBadge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	status, _ := deriveStatus(p.ID, incMap)
-	writeBadge(w, p.Name, status, statusColor(status))
+	message := status
+
+	// ?style=detailed appends live uptime when available.
+	if r.URL.Query().Get("style") == "detailed" && s.liveStats != nil {
+		if stats, err := s.liveStats.AllProviderLiveStats(r.Context()); err == nil {
+			for _, st := range stats {
+				if st.ProviderID == id && st.Uptime24h >= 0 {
+					message = fmt.Sprintf("%s · %.1f%%", status, st.Uptime24h*100)
+					break
+				}
+			}
+		}
+	}
+
+	writeBadge(w, p.Name, message, statusColor(status))
 }
 
 func writeBadge(w http.ResponseWriter, label, message, color string) {

--- a/internal/api/badge_test.go
+++ b/internal/api/badge_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/llmstatus/llmstatus/internal/api"
+	"github.com/llmstatus/llmstatus/internal/store/influx"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 
@@ -142,6 +143,72 @@ func TestGetBadge_SVGStructure(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("SVG missing %q", want)
 		}
+	}
+}
+
+func TestGetBadge_DetailedStyle_WithUptime(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	ls := &fakeLiveStatsReader{
+		stats: []influx.ProviderLiveStat{
+			{ProviderID: "openai", Uptime24h: 0.9987, P95Ms: 450},
+		},
+	}
+	srv := api.New(store, api.WithLiveStatsReader(ls))
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/openai.svg?style=detailed", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "99.9%") {
+		t.Errorf("detailed badge should contain uptime percentage, got: %s", body[:min(200, len(body))])
+	}
+	if !strings.Contains(body, "operational") {
+		t.Error("detailed badge missing status word")
+	}
+}
+
+func TestGetBadge_DetailedStyle_NoLiveStats_FallsBack(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	// No live stats reader wired — should fall back to simple format.
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/openai.svg?style=detailed", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if strings.Contains(body, "%") {
+		t.Error("fallback badge should not contain a percentage")
+	}
+	if !strings.Contains(body, "operational") {
+		t.Error("fallback badge missing status")
+	}
+}
+
+func TestGetBadge_UnknownStyle_FallsBack(t *testing.T) {
+	store := &fakeStore{
+		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
+	}
+	srv := api.New(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/badge/openai.svg?style=whatever", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "operational") {
+		t.Error("badge with unknown style should show simple operational status")
 	}
 }
 

--- a/web/app/badges/page.tsx
+++ b/web/app/badges/page.tsx
@@ -21,37 +21,67 @@ const SITE_URL =
 
 // Public badge URL — in production nginx proxies /badge/* to the Go API.
 // In dev the Next.js proxy route at /api/badge/{id} is used for preview.
-function publicBadgeUrl(providerId: string) {
-  return `${SITE_URL}/badge/${providerId}.svg`;
+function publicBadgeUrl(providerId: string, style?: "simple" | "detailed") {
+  const base = `${SITE_URL}/badge/${providerId}.svg`;
+  return style === "detailed" ? `${base}?style=detailed` : base;
 }
 
-function previewBadgeUrl(providerId: string) {
-  return `/api/badge/${providerId}`;
+function previewBadgeUrl(providerId: string, style?: "simple" | "detailed") {
+  const base = `/api/badge/${providerId}`;
+  return style === "detailed" ? `${base}?style=detailed` : base;
 }
+
+type BadgeStyle = "simple" | "detailed";
 
 function BadgeRow({ name, id }: { name: string; id: string }) {
-  const url = publicBadgeUrl(id);
-  const markdown = `[![${name} status](${url})](${SITE_URL}/providers/${id})`;
-  const html = `<a href="${SITE_URL}/providers/${id}"><img src="${url}" alt="${name} status" /></a>`;
+  const styles: { key: BadgeStyle; label: string }[] = [
+    { key: "simple", label: "Simple" },
+    { key: "detailed", label: "Detailed" },
+  ];
 
   return (
     <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--ink-600)]">
-        <span className="text-sm font-semibold text-[var(--ink-100)]">{name}</span>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={previewBadgeUrl(id)}
-          alt={`${name} status badge`}
-          height={20}
-          className="h-5"
-        />
+      {/* Provider header + badge previews */}
+      <div className="px-4 py-3 border-b border-[var(--ink-600)]">
+        <span className="text-sm font-semibold text-[var(--ink-100)] block mb-3">{name}</span>
+        <div className="flex items-center gap-4 flex-wrap">
+          {styles.map(({ key, label }) => (
+            <div key={key} className="flex flex-col gap-1.5 items-start">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">
+                {label}
+              </span>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={previewBadgeUrl(id, key)}
+                alt={`${name} ${label} status badge`}
+                height={20}
+                className="h-5"
+              />
+            </div>
+          ))}
+        </div>
       </div>
 
-      <div className="divide-y divide-[var(--ink-600)]">
-        <CodeSnippet label="Markdown" code={markdown} />
-        <CodeSnippet label="HTML" code={html} />
-        <CodeSnippet label="URL" code={url} />
-      </div>
+      {/* Embed snippets — one section per style */}
+      {styles.map(({ key, label }) => {
+        const url = publicBadgeUrl(id, key);
+        const markdown = `[![${name} status](${url})](${SITE_URL}/providers/${id})`;
+        const html = `<a href="${SITE_URL}/providers/${id}"><img src="${url}" alt="${name} status" /></a>`;
+        return (
+          <div key={key} className="border-t border-[var(--ink-600)]">
+            <div className="px-4 py-2 bg-[var(--canvas-sunken)]">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-300)]">
+                {label} style
+              </span>
+            </div>
+            <div className="divide-y divide-[var(--ink-600)]">
+              <CodeSnippet label="Markdown" code={markdown} />
+              <CodeSnippet label="HTML" code={html} />
+              <CodeSnippet label="URL" code={url} />
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Implements ROADMAP §7.1: `GET /badge/{id}.svg?style=simple|detailed`
- `?style=detailed` appends 24h uptime percentage when `LiveStatsReader` is wired (e.g. `operational · 99.9%`)
- Falls back to simple format when live stats are unavailable or provider not found in stats
- `/badges` page updated: shows Simple and Detailed previews side-by-side, embed snippets for both styles

## Test plan

- [ ] `GET /badge/openai.svg` → simple badge (no `%` in message)
- [ ] `GET /badge/openai.svg?style=detailed` → badge message contains `%` when live stats available
- [ ] `GET /badge/openai.svg?style=detailed` with no live stats wired → falls back to simple (no `%`)
- [ ] `GET /badge/openai.svg?style=anything-else` → falls back to simple
- [ ] `/badges` page shows two preview images per provider (Simple + Detailed)
- [ ] All 9 badge tests pass: `go test ./internal/api/... -run TestGetBadge`

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)