### PR TITLE
feat LLMS-036: add /providers page with status and category filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-036)
+- `/providers` page — dedicated provider list page with filter chips for status (all / operational / degraded / down) and category (all / official / aggregator / CN official); filters combine with AND logic
+- `ProvidersClient` client component — owns filter state, renders result count and filtered `ProviderTable`
+- SiteHeader "Providers" nav link now points to `/providers` (previously pointed to `/`)
+- `/providers` added to sitemap with `changeFrequency: "always"`, priority 0.95
+
 ### Added (LLMS-035)
 - `GET /badge/{id}.svg?style=detailed` — badge variant that appends live 24h uptime percentage when `LiveStatsReader` is wired (e.g. `operational · 99.9%`); falls back to simple format when live stats are unavailable
 - `/badges` page now shows both Simple and Detailed preview images side-by-side, with embed snippets for each style

--- a/web/app/providers/page.tsx
+++ b/web/app/providers/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { listProviders } from "@/lib/api";
+import { ProvidersClient } from "@/components/ProvidersClient";
+
+export const revalidate = 30;
+
+export const metadata: Metadata = {
+  title: "All Providers",
+  description:
+    "Real-time status for 20+ AI API providers. Filter by status and category. " +
+    "Independent monitoring from 7 global locations.",
+  openGraph: {
+    title: "AI API Providers — llmstatus.io",
+    description:
+      "Real-time status for 20+ AI API providers monitored from 7 global locations.",
+  },
+};
+
+export default async function ProvidersPage() {
+  const providers = await listProviders().catch(() => null);
+
+  return (
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+      <div className="mb-8">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--signal-amber)] mb-4">
+          Providers
+        </p>
+        <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-2">
+          All monitored providers
+        </h1>
+        <p className="text-sm text-[var(--ink-400)]">
+          Real API calls from 7 global locations. Updated every 30 s.
+        </p>
+      </div>
+
+      {providers === null ? (
+        <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6 py-10 text-center">
+          <p className="text-sm text-[var(--ink-400)]">
+            Could not reach the API. Check that the backend is running.
+          </p>
+        </div>
+      ) : (
+        <ProvidersClient providers={providers} />
+      )}
+    </main>
+  );
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -10,6 +10,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: SITE_URL, lastModified: now, changeFrequency: "always", priority: 1 },
+    { url: `${SITE_URL}/providers`, lastModified: now, changeFrequency: "always", priority: 0.95 },
     { url: `${SITE_URL}/incidents`, lastModified: now, changeFrequency: "always", priority: 0.9 },
     { url: `${SITE_URL}/badges`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
   ];

--- a/web/components/ProvidersClient.tsx
+++ b/web/components/ProvidersClient.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import type { ProviderSummary, ProviderStatus } from "@/lib/api";
+import { ProviderTable } from "./ProviderTable";
+
+type CategoryFilter = "all" | "official" | "aggregator" | "chinese_official";
+type StatusFilter = "all" | ProviderStatus;
+
+interface FilterChipProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+function FilterChip({ label, active, onClick }: FilterChipProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1 rounded text-[11px] font-semibold uppercase tracking-[0.08em] border transition-colors ${
+        active
+          ? "bg-[var(--canvas-overlay)] border-[var(--ink-400)] text-[var(--ink-100)]"
+          : "border-[var(--ink-600)] text-[var(--ink-400)] hover:text-[var(--ink-200)] hover:border-[var(--ink-500)]"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface FilterRowProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function FilterRow({ label, children }: FilterRowProps) {
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)] w-20 shrink-0">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+interface Props {
+  providers: ProviderSummary[];
+}
+
+export function ProvidersClient({ providers }: Props) {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
+
+  const filtered = providers.filter((p) => {
+    const statusOk = statusFilter === "all" || p.current_status === statusFilter;
+    const categoryOk = categoryFilter === "all" || p.category === categoryFilter;
+    return statusOk && categoryOk;
+  });
+
+  const counts = {
+    operational: providers.filter((p) => p.current_status === "operational").length,
+    degraded: providers.filter((p) => p.current_status === "degraded").length,
+    down: providers.filter((p) => p.current_status === "down").length,
+    official: providers.filter((p) => p.category === "official").length,
+    aggregator: providers.filter((p) => p.category === "aggregator").length,
+    chinese_official: providers.filter((p) => p.category === "chinese_official").length,
+  };
+
+  const statusChips: { key: StatusFilter; label: string }[] = [
+    { key: "all", label: "All" },
+    { key: "operational", label: `Operational (${counts.operational})` },
+    { key: "degraded", label: `Degraded (${counts.degraded})` },
+    { key: "down", label: `Down (${counts.down})` },
+  ];
+
+  const categoryChips: { key: CategoryFilter; label: string }[] = [
+    { key: "all", label: "All" },
+    { key: "official", label: `Official (${counts.official})` },
+    { key: "aggregator", label: `Aggregator (${counts.aggregator})` },
+    { key: "chinese_official", label: `CN Official (${counts.chinese_official})` },
+  ];
+
+  return (
+    <div>
+      {/* Filters */}
+      <div className="mb-6 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4 flex flex-col gap-3">
+        <FilterRow label="Status">
+          {statusChips.map(({ key, label }) => (
+            <FilterChip
+              key={key}
+              label={label}
+              active={statusFilter === key}
+              onClick={() => setStatusFilter(key)}
+            />
+          ))}
+        </FilterRow>
+        <FilterRow label="Category">
+          {categoryChips.map(({ key, label }) => (
+            <FilterChip
+              key={key}
+              label={label}
+              active={categoryFilter === key}
+              onClick={() => setCategoryFilter(key)}
+            />
+          ))}
+        </FilterRow>
+      </div>
+
+      {/* Result count */}
+      <p className="mb-3 text-xs text-[var(--ink-400)]">
+        {filtered.length === providers.length
+          ? `${providers.length} providers`
+          : `${filtered.length} of ${providers.length} providers`}
+      </p>
+
+      <ProviderTable providers={filtered} />
+    </div>
+  );
+}

--- a/web/components/SiteHeader.tsx
+++ b/web/components/SiteHeader.tsx
@@ -12,7 +12,7 @@ export function SiteHeader() {
           llmstatus.io
         </Link>
         <nav className="flex items-center gap-6" aria-label="Site navigation">
-          <NavLink href="/">Providers</NavLink>
+          <NavLink href="/providers">Providers</NavLink>
           <NavLink href="/incidents">Incidents</NavLink>
           <NavLink href="/badges">Badges</NavLink>
         </nav>


### PR DESCRIPTION
## Summary

- Adds `/providers` route (ROADMAP §8.1 "Full provider list with filters")
- `ProvidersClient` client component holds filter state; page is a Server Component for fast initial render
- Filter chips: **Status** (all / operational / degraded / down) + **Category** (all / official / aggregator / CN official) — AND logic across dimensions, counts shown in each chip
- SiteHeader "Providers" nav link corrected from `/` to `/providers`
- `/providers` added to sitemap at priority 0.95

## Test plan

- [ ] `/providers` renders all providers
- [ ] Status filter: click "Degraded" → only degraded rows shown, count updates
- [ ] Category filter: click "Official" → only official providers shown
- [ ] Both filters active: AND logic — only rows matching both conditions shown
- [ ] "All" resets that filter dimension
- [ ] SiteHeader "Providers" link highlights when on `/providers`
- [ ] `/sitemap.xml` includes `/providers`
- [ ] OG metadata includes correct title/description

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)