### PR TITLE
feat LLMS-039: add /compare provider comparison page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-039)
+- `/compare` page — side-by-side provider comparison: current status, 24h uptime %, p95 latency, active incident count, category, region, and 30-day uptime sparklines for both providers
+- `CompareSelector` client component — two dropdowns that push URL params on change, so the Server Component page re-fetches data for the selected pair
+- "Compare" nav link added to SiteHeader
+- `/compare` added to sitemap
+
 ### Added (LLMS-038)
 - Provider detail pages now emit Schema.org `Service` JSON-LD for SEO (includes provider name, service type, status-page URL when present)
 - Incident detail pages now emit Schema.org `Event` JSON-LD (startDate, endDate if resolved, eventStatus)

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -1,0 +1,247 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import {
+  listProviders,
+  getProvider,
+  getProviderHistory,
+  type ProviderDetail,
+  type HistoryBucket,
+} from "@/lib/api";
+import { StatusPill } from "@/components/StatusPill";
+import { UptimeSparkline } from "@/components/UptimeSparkline";
+import { IncidentCard } from "@/components/IncidentCard";
+import { CompareSelector } from "@/components/CompareSelector";
+
+type SearchParams = Promise<{ a?: string; b?: string }>;
+type Props = { searchParams: SearchParams };
+
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+  const { a, b } = await searchParams;
+  if (!a || !b) return { title: "Compare Providers" };
+
+  const [left, right] = await Promise.all([
+    getProvider(a).catch(() => null),
+    getProvider(b).catch(() => null),
+  ]);
+  const nameA = left?.name ?? a;
+  const nameB = right?.name ?? b;
+
+  const title = `Compare ${nameA} vs ${nameB}`;
+  const description = `Side-by-side uptime, latency, and incident comparison for ${nameA} and ${nameB} — llmstatus.io`;
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+  };
+}
+
+function fmt(n: number | undefined, unit: string, decimals = 0): string {
+  if (n === undefined) return "—";
+  return `${n.toFixed(decimals)} ${unit}`;
+}
+
+function uptimePct(n: number | undefined): string {
+  if (n === undefined) return "—";
+  return `${(n * 100).toFixed(2)} %`;
+}
+
+interface ComparisonRowProps {
+  label: string;
+  left: React.ReactNode;
+  right: React.ReactNode;
+}
+
+function Row({ label, left, right }: ComparisonRowProps) {
+  return (
+    <div className="grid grid-cols-[1fr_1fr_1fr] divide-x divide-[var(--ink-600)] border-b border-[var(--ink-600)] last:border-b-0">
+      <div className="px-4 py-3 text-xs text-[var(--ink-400)]">{label}</div>
+      <div className="px-4 py-3 text-sm text-[var(--ink-200)]">{left}</div>
+      <div className="px-4 py-3 text-sm text-[var(--ink-200)]">{right}</div>
+    </div>
+  );
+}
+
+interface CompareDataProps {
+  left: ProviderDetail;
+  right: ProviderDetail;
+  leftHistory: HistoryBucket[] | null;
+  rightHistory: HistoryBucket[] | null;
+  a: string;
+  b: string;
+  providers: Awaited<ReturnType<typeof listProviders>>;
+}
+
+function CompareData({ left, right, leftHistory, rightHistory, a, b, providers }: CompareDataProps) {
+  return (
+    <div>
+      {/* Selector row */}
+      <div className="mb-8">
+        <CompareSelector providers={providers} a={a} b={b} />
+      </div>
+
+      {/* Header names */}
+      <div className="grid grid-cols-[1fr_1fr_1fr] mb-4 gap-4">
+        <div />
+        <Link href={`/providers/${left.id}`} className="group">
+          <h2 className="text-lg font-semibold text-[var(--ink-100)] group-hover:text-[var(--ink-200)] transition-colors">
+            {left.name}
+          </h2>
+        </Link>
+        <Link href={`/providers/${right.id}`} className="group">
+          <h2 className="text-lg font-semibold text-[var(--ink-100)] group-hover:text-[var(--ink-200)] transition-colors">
+            {right.name}
+          </h2>
+        </Link>
+      </div>
+
+      {/* Metrics table */}
+      <div className="mb-8 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] divide-y divide-[var(--ink-600)] overflow-hidden">
+        <Row
+          label="Status"
+          left={<StatusPill status={left.current_status} />}
+          right={<StatusPill status={right.current_status} />}
+        />
+        <Row
+          label="Uptime (24h)"
+          left={uptimePct(left.uptime_24h)}
+          right={uptimePct(right.uptime_24h)}
+        />
+        <Row
+          label="P95 latency"
+          left={fmt(left.p95_ms, "ms")}
+          right={fmt(right.p95_ms, "ms")}
+        />
+        <Row
+          label="Active incidents"
+          left={`${left.active_incidents.length}`}
+          right={`${right.active_incidents.length}`}
+        />
+        <Row
+          label="Category"
+          left={left.category}
+          right={right.category}
+        />
+        <Row
+          label="Region"
+          left={left.region}
+          right={right.region}
+        />
+      </div>
+
+      {/* Uptime sparklines */}
+      {(leftHistory !== null || rightHistory !== null) && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            Uptime History (30d)
+          </h2>
+          <div className="flex flex-col gap-4">
+            {leftHistory !== null && (
+              <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
+                <p className="mb-2 text-xs font-medium text-[var(--ink-300)]">{left.name}</p>
+                <UptimeSparkline buckets={leftHistory} days={30} />
+              </div>
+            )}
+            {rightHistory !== null && (
+              <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
+                <p className="mb-2 text-xs font-medium text-[var(--ink-300)]">{right.name}</p>
+                <UptimeSparkline buckets={rightHistory} days={30} />
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* Active incidents for both */}
+      {(left.active_incidents.length > 0 || right.active_incidents.length > 0) && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            Active Incidents
+          </h2>
+          <div className="flex flex-col gap-2">
+            {[...left.active_incidents, ...right.active_incidents].map((inc) => (
+              <IncidentCard key={inc.id} incident={inc} href={`/incidents/${inc.slug}`} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default async function ComparePage({ searchParams }: Props) {
+  const { a, b } = await searchParams;
+
+  const providers = await listProviders().catch(() => []);
+
+  if (!a || !b) {
+    return (
+      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+        <div className="mb-8">
+          <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">Compare Providers</h1>
+          <p className="text-sm text-[var(--ink-400)]">
+            Select two providers to compare uptime, latency, and incidents side by side.
+          </p>
+        </div>
+        <CompareSelector providers={providers} a="" b="" />
+      </main>
+    );
+  }
+
+  const [leftResult, rightResult, leftHistResult, rightHistResult] = await Promise.allSettled([
+    getProvider(a),
+    getProvider(b),
+    getProviderHistory(a, "30d"),
+    getProviderHistory(b, "30d"),
+  ]);
+
+  const left = leftResult.status === "fulfilled" ? leftResult.value : null;
+  const right = rightResult.status === "fulfilled" ? rightResult.value : null;
+
+  // If either provider lookup failed, fall back to the selector.
+  if (!left || !right) {
+    return (
+      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold text-[var(--ink-100)] mb-1">Compare Providers</h1>
+          <p className="text-sm text-[var(--signal-down)]">
+            One or both provider IDs could not be found. Please choose again.
+          </p>
+        </div>
+        <CompareSelector providers={providers} a={a} b={b} />
+      </main>
+    );
+  }
+
+  const leftHistory = leftHistResult.status === "fulfilled" ? leftHistResult.value : null;
+  const rightHistory = rightHistResult.status === "fulfilled" ? rightHistResult.value : null;
+
+  return (
+    <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
+      {/* Breadcrumb */}
+      <nav className="mb-6 text-xs text-[var(--ink-400)]">
+        <Link href="/" className="hover:text-[var(--ink-200)] transition-colors">
+          All providers
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-[var(--ink-300)]">Compare</span>
+      </nav>
+
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-[var(--ink-100)]">
+          {left.name} <span className="text-[var(--ink-500)]">vs</span> {right.name}
+        </h1>
+      </div>
+
+      <CompareData
+        left={left}
+        right={right}
+        leftHistory={leftHistory}
+        rightHistory={rightHistory}
+        a={a}
+        b={b}
+        providers={providers}
+      />
+    </main>
+  );
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -14,6 +14,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/incidents`, lastModified: now, changeFrequency: "always", priority: 0.9 },
     { url: `${SITE_URL}/api`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: `${SITE_URL}/badges`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${SITE_URL}/compare`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
   ];
 
   const providerRoutes: MetadataRoute.Sitemap = await listProviders()

--- a/web/components/CompareSelector.tsx
+++ b/web/components/CompareSelector.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { useRouter } from "next/navigation";
+import type { ProviderSummary } from "@/lib/api";
+
+interface Props {
+  providers: ProviderSummary[];
+  a: string;
+  b: string;
+}
+
+const SELECT_CLS =
+  "rounded border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-3 py-1.5 " +
+  "text-sm text-[var(--ink-200)] focus:outline-none focus:ring-1 focus:ring-[var(--ink-400)]";
+
+export function CompareSelector({ providers, a, b }: Props) {
+  const router = useRouter();
+
+  function navigate(nextA: string, nextB: string) {
+    if (nextA && nextB) {
+      router.push(`/compare?a=${encodeURIComponent(nextA)}&b=${encodeURIComponent(nextB)}`);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <select
+        className={SELECT_CLS}
+        value={a}
+        onChange={(e) => navigate(e.target.value, b)}
+        aria-label="First provider"
+      >
+        <option value="">Select provider…</option>
+        {providers.map((p) => (
+          <option key={p.id} value={p.id}>{p.name}</option>
+        ))}
+      </select>
+      <span className="text-sm text-[var(--ink-400)]">vs</span>
+      <select
+        className={SELECT_CLS}
+        value={b}
+        onChange={(e) => navigate(a, e.target.value)}
+        aria-label="Second provider"
+      >
+        <option value="">Select provider…</option>
+        {providers.map((p) => (
+          <option key={p.id} value={p.id}>{p.name}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/web/components/SiteHeader.tsx
+++ b/web/components/SiteHeader.tsx
@@ -14,6 +14,7 @@ export function SiteHeader() {
         <nav className="flex items-center gap-6" aria-label="Site navigation">
           <NavLink href="/providers">Providers</NavLink>
           <NavLink href="/incidents">Incidents</NavLink>
+          <NavLink href="/compare">Compare</NavLink>
           <NavLink href="/badges">Badges</NavLink>
           <NavLink href="/api">API</NavLink>
         </nav>


### PR DESCRIPTION
## Summary
- New `/compare?a={id}&b={id}` route — server-rendered side-by-side comparison for two AI API providers
- Shows current status pill, 24h uptime %, p95 latency, active incident count, category, region, and 30-day uptime sparklines for both providers
- `CompareSelector` client component owns the dropdown state; on change it pushes a new URL so the Server Component re-fetches fresh data
- "Compare" nav link added to SiteHeader; `/compare` added to sitemap

## Test plan
- [ ] `npx tsc --noEmit` passes (confirmed clean)
- [ ] `npm run build` passes — `/compare` appears as `ƒ` (dynamic) in the route table
- [ ] `/compare` with no params renders selector UI with two dropdowns
- [ ] `/compare?a=openai&b=anthropic` renders metrics table and sparklines for both providers
- [ ] Invalid provider ID falls back gracefully to selector with error message
- [ ] `generateMetadata` returns "Compare {A} vs {B}" title