### PR TITLE
feat LLMS-040: add recent incidents section to homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-040)
+- Homepage now shows a "Recent Incidents" section (up to 5, ongoing/monitoring first) above the provider table; hidden when no incidents exist
+- Incidents are fetched in parallel with providers via `Promise.allSettled` — no added latency, each fails independently
+- "All incidents →" link to /incidents included in section header
+
 ### Added (LLMS-039)
 - `/compare` page — side-by-side provider comparison: current status, 24h uptime %, p95 latency, active incident count, category, region, and 30-day uptime sparklines for both providers
 - `CompareSelector` client component — two dropdowns that push URL params on change, so the Server Component page re-fetches data for the selected pair

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
-import { listProviders } from "@/lib/api";
+import Link from "next/link";
+import { listProviders, listIncidents } from "@/lib/api";
 import { ProviderTable } from "@/components/ProviderTable";
+import { IncidentCard } from "@/components/IncidentCard";
 
 export const revalidate = 30;
 
@@ -18,7 +20,18 @@ export const metadata: Metadata = {
 };
 
 export default async function HomePage() {
-  const providers = await listProviders().catch(() => null);
+  const [providerResult, incidentResult] = await Promise.allSettled([
+    listProviders(),
+    listIncidents("all", 10),
+  ]);
+
+  const providers = providerResult.status === "fulfilled" ? providerResult.value : null;
+  const allIncidents = incidentResult.status === "fulfilled" ? incidentResult.value : [];
+
+  // Ongoing/monitoring incidents first, then resolved; cap at 5.
+  const recentIncidents = [...allIncidents]
+    .sort((a, b) => (a.status === "resolved" ? 1 : 0) - (b.status === "resolved" ? 1 : 0))
+    .slice(0, 5);
 
   const allOk =
     providers !== null &&
@@ -74,6 +87,28 @@ export default async function HomePage() {
       <div className="mb-6">
         <p className={`text-sm font-medium ${summaryColor}`}>{summaryText}</p>
       </div>
+
+      {/* Recent incidents — shown only when data exists */}
+      {recentIncidents.length > 0 && (
+        <section className="mb-8">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+              Recent Incidents
+            </h2>
+            <Link
+              href="/incidents"
+              className="text-xs text-[var(--ink-400)] hover:text-[var(--ink-200)] transition-colors"
+            >
+              All incidents →
+            </Link>
+          </div>
+          <div className="flex flex-col gap-2">
+            {recentIncidents.map((inc) => (
+              <IncidentCard key={inc.id} incident={inc} href={`/incidents/${inc.slug}`} />
+            ))}
+          </div>
+        </section>
+      )}
 
       {providers !== null ? (
         <ProviderTable providers={providers} />


### PR DESCRIPTION
## Summary
- Adds a "Recent Incidents" section on the homepage above the provider table
- Up to 5 incidents shown; ongoing/monitoring sorted first, resolved below
- Both fetches (providers + incidents) run in parallel with `Promise.allSettled` — each fails independently with no waterfall
- Section hidden entirely when no incidents exist
- "All incidents →" link in section header

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes — homepage remains `○` (static 30s)
- [ ] With active incidents: section appears above provider table
- [ ] With no incidents: section is absent (empty list)
- [ ] API failure for incidents: section absent, provider table still renders