### PR TITLE
feat LLMS-042: sortable columns on ProviderTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-042)
+- Provider table columns are now sortable: click Name, Uptime 24h, P95, or Status to cycle asc → desc → default
+- Default sort: worst status first (down → degraded → operational), then alphabetical within each group
+- Active sort column shows ▲/▼ indicator; unsorted columns show a muted ↕
+
 ### Added (LLMS-041)
 - `/incidents` page now has filter chips: status (All / Ongoing / Resolved) and a provider dropdown; filters combine with AND logic
 - Result count shown; empty-state message when no incidents match

--- a/web/components/ProviderTable.tsx
+++ b/web/components/ProviderTable.tsx
@@ -1,3 +1,5 @@
+"use client";
+import { useState } from "react";
 import Link from "next/link";
 import type { ProviderSummary } from "@/lib/api";
 import { StatusPill } from "./StatusPill";
@@ -15,6 +17,12 @@ const REGION_LABEL: Record<string, string> = {
   eu: "EU",
 };
 
+const STATUS_RANK: Record<string, number> = {
+  down: 0,
+  degraded: 1,
+  operational: 2,
+};
+
 function formatUptime(u: number | undefined): string {
   if (u === undefined) return "—";
   return `${(u * 100).toFixed(1)}%`;
@@ -25,7 +33,61 @@ function formatP95(ms: number | undefined): string {
   return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
 }
 
+type SortKey = "name" | "uptime" | "p95" | "status";
+type SortDir = "asc" | "desc" | "default";
+
+function sortProviders(
+  providers: ProviderSummary[],
+  key: SortKey,
+  dir: SortDir,
+): ProviderSummary[] {
+  if (dir === "default") {
+    // default: worst status first, then alphabetical within group
+    return [...providers].sort((a, b) => {
+      const rankDiff = (STATUS_RANK[a.current_status] ?? 2) - (STATUS_RANK[b.current_status] ?? 2);
+      return rankDiff !== 0 ? rankDiff : a.name.localeCompare(b.name);
+    });
+  }
+
+  const factor = dir === "asc" ? 1 : -1;
+  return [...providers].sort((a, b) => {
+    switch (key) {
+      case "name":
+        return factor * a.name.localeCompare(b.name);
+      case "uptime":
+        return factor * ((a.uptime_24h ?? -1) - (b.uptime_24h ?? -1));
+      case "p95":
+        return factor * ((a.p95_ms ?? Infinity) - (b.p95_ms ?? Infinity));
+      case "status":
+        return factor * ((STATUS_RANK[a.current_status] ?? 2) - (STATUS_RANK[b.current_status] ?? 2));
+      default:
+        return 0;
+    }
+  });
+}
+
+function SortIcon({ col, active, dir }: { col: SortKey; active: SortKey; dir: SortDir }) {
+  if (col !== active || dir === "default") {
+    return <span className="ml-1 text-[var(--ink-600)]">↕</span>;
+  }
+  return <span className="ml-1 text-[var(--ink-300)]">{dir === "asc" ? "▲" : "▼"}</span>;
+}
+
 export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
+  const [sortKey, setSortKey] = useState<SortKey>("status");
+  const [sortDir, setSortDir] = useState<SortDir>("default");
+
+  function handleSort(key: SortKey) {
+    if (key !== sortKey) {
+      setSortKey(key);
+      setSortDir("asc");
+      return;
+    }
+    setSortDir((prev) => (prev === "default" ? "asc" : prev === "asc" ? "desc" : "default"));
+  }
+
+  const sorted = sortProviders(providers, sortKey, sortDir);
+
   if (providers.length === 0) {
     return (
       <p className="py-12 text-center text-sm text-[var(--ink-400)]">
@@ -34,21 +96,37 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
     );
   }
 
+  const thCls =
+    "px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)] " +
+    "cursor-pointer select-none hover:text-[var(--ink-200)] transition-colors";
+
   return (
     <div className="overflow-hidden rounded-lg border border-[var(--ink-600)]">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-[var(--ink-600)] bg-[var(--canvas-sunken)]">
-            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Provider</th>
-            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Category</th>
-            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Region</th>
-            <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Uptime 24h</th>
-            <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">p95</th>
-            <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">Status</th>
+            <th className={`${thCls} text-left`} onClick={() => handleSort("name")}>
+              Provider <SortIcon col="name" active={sortKey} dir={sortDir} />
+            </th>
+            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">
+              Category
+            </th>
+            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">
+              Region
+            </th>
+            <th className={`${thCls} text-right`} onClick={() => handleSort("uptime")}>
+              <SortIcon col="uptime" active={sortKey} dir={sortDir} /> Uptime 24h
+            </th>
+            <th className={`${thCls} text-right`} onClick={() => handleSort("p95")}>
+              <SortIcon col="p95" active={sortKey} dir={sortDir} /> p95
+            </th>
+            <th className={`${thCls} text-right`} onClick={() => handleSort("status")}>
+              <SortIcon col="status" active={sortKey} dir={sortDir} /> Status
+            </th>
           </tr>
         </thead>
         <tbody>
-          {providers.map((p, idx) => (
+          {sorted.map((p, idx) => (
             <tr
               key={p.id}
               className={`border-b border-[var(--ink-600)] last:border-0 transition-colors hover:bg-[var(--canvas-overlay)] ${


### PR DESCRIPTION
## Summary
- `ProviderTable` is now a client component with sort state
- Sortable columns: Name, Uptime 24h, P95, Status — click to cycle asc → desc → default
- Default sort: worst status first (down→degraded→operational), then alphabetical
- ▲/▼ on active column; ↕ on unsorted columns
- Homepage server component and ProvidersClient both pass provider arrays as props — no structural change needed

## Test plan
- [ ] `npx tsc --noEmit` passes; `npm run build` passes
- [ ] Clicking Status header: down providers float to top
- [ ] Clicking Uptime 24h header asc: lowest uptime first
- [ ] Clicking same header again: desc; again: back to default
- [ ] Works on both / and /providers