### PR TITLE
feat LLMS-044: static OG image for homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-044)
+- Homepage OG image (`/opengraph-image`) — edge-rendered brand card: site name, headline, tagline, and "20+ AI providers tracked" badge; no live data fetch (avoids stale-status problem on social shares)
+
 ### Added (LLMS-043)
 - Incident detail pages now have edge-rendered OG images (1200×630): incident title, severity color, provider ID, and status pill on dark background; graceful fallback when API unavailable
 

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -1,0 +1,106 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "llmstatus.io — AI API Status Monitor";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          padding: "80px 96px",
+          background: "#0A0E14",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {/* Dot grid background */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage:
+              "radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+          }}
+        />
+
+        {/* Site name */}
+        <div
+          style={{
+            fontSize: 20,
+            fontWeight: 700,
+            letterSpacing: "0.15em",
+            textTransform: "uppercase",
+            color: "#D97706",
+            marginBottom: 32,
+          }}
+        >
+          llmstatus.io
+        </div>
+
+        {/* Headline */}
+        <div
+          style={{
+            fontSize: 56,
+            fontWeight: 700,
+            color: "#E8ECF1",
+            lineHeight: 1.15,
+            marginBottom: 24,
+          }}
+        >
+          Independent real-time
+          <br />
+          AI API monitoring.
+        </div>
+
+        {/* Sub-line */}
+        <div
+          style={{
+            fontSize: 22,
+            color: "#6B7280",
+            lineHeight: 1.5,
+          }}
+        >
+          Measured from 7 global locations.
+          <br />
+          Not scraped from official status pages.
+        </div>
+
+        {/* Provider count badge */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginTop: 40,
+            background: "#111827",
+            border: "1px solid #1F2937",
+            borderRadius: 8,
+            padding: "12px 24px",
+          }}
+        >
+          <div
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: "50%",
+              background: "#5EEAD4",
+            }}
+          />
+          <span style={{ fontSize: 18, fontWeight: 600, color: "#5EEAD4" }}>
+            20+ AI providers tracked
+          </span>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}


### PR DESCRIPTION
## Summary
- `web/app/opengraph-image.tsx` — Next.js convention file, edge runtime, 1200×630 PNG
- Brand card: site name (amber), headline, tagline, dot-grid background, "20+ AI providers tracked" pill
- No live data fetch — homepage status changes every 30s and would be stale on social shares; static card is more reliable
- Completes OG image coverage across all three page types (homepage, provider, incident)

## Test plan
- [ ] `npm run build` passes — `/opengraph-image` appears as `ƒ` in route table
- [ ] OG image renders at `/opengraph-image`