### PR TITLE
feat LLMS-045: fixed dev ports + /about + /methodology

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,17 +3,21 @@
 #
 # Lines with defaults are optional — the service works without them.
 # Lines marked REQUIRED must be set before the service will start.
+#
+# HOST PORTS (fixed — see docker-compose.yml):
+#   PostgreSQL  → localhost:15432
+#   InfluxDB    → localhost:18086
+#   Ingest API  → localhost:18080
+#   Public API  → localhost:18081
+#   Next.js dev → localhost:13000  (run: cd web && npm run dev)
 
 # ── InfluxDB 3 ──────────────────────────────────────────────────────────────
-# For local dev: use the values below (matches docker-compose.yml defaults).
-# For production: point at your InfluxDB 3 Cloud or self-hosted instance.
-INFLUX_HOST=http://localhost:8086
+INFLUX_HOST=http://localhost:18086
 INFLUX_TOKEN=dev-token
 INFLUX_DATABASE=llmstatus
 
 # ── PostgreSQL ───────────────────────────────────────────────────────────────
-# For local dev: use the value below.
-DATABASE_URL=postgres://llmstatus:llmstatus@localhost:5432/llmstatus?sslmode=disable
+DATABASE_URL=postgres://llmstatus:llmstatus@localhost:15432/llmstatus?sslmode=disable
 
 # ── Public API (cmd/api) ─────────────────────────────────────────────────────
 API_ADDR=:8081
@@ -30,23 +34,14 @@ REGION_ID=local-dev
 PROBE_INTERVAL=60s
 PROBE_TIMEOUT=30s
 PROBE_CONCURRENCY=4
-
-# URL of the ingest service this prober pushes results to.
-INGEST_URL=http://localhost:8080
+INGEST_URL=http://localhost:18080
 
 # ── Provider API keys ────────────────────────────────────────────────────────
-# REQUIRED: at least one key must be set for the prober to do useful work.
-# Keys are loaded per-provider by the adapter registry.
-# See internal/probes/adapters/ for which env var each adapter reads.
-
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
-# ... add keys for other providers as you enable them
 
 # ── Frontend (web/) ───────────────────────────────────────────────────────────
-# Used by Next.js for server-side API calls (internal Docker network in prod).
-API_URL=http://localhost:8081
-
-# Public URL of this site — used by sitemap.xml and robots.txt.
-NEXT_PUBLIC_SITE_URL=http://localhost:3000
+# Used by Next.js SSR. Set in web/.env.local for local dev (see web/.env.local.example).
+API_URL=http://localhost:18081
+NEXT_PUBLIC_SITE_URL=http://localhost:13000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added (LLMS-045)
+- Fixed host port assignments for all dev services (avoid conflicts on this host): db→15432, influx→18086, ingest→18080, api→18081, Next.js dev→13000
+- `web/.env.local.example` added — copy to `web/.env.local` before running `npm run dev`
+- Docker `web` service moved to `web-docker` profile; default dev workflow uses `npm run dev` outside Docker
+- `/about` page — who we are, why we built it, independence statement, contact
+- `/methodology` page — probe types, 7 global locations, all 4 detection rules with triggers, data retention, known limitations
+- Footer now links to /about and /methodology on every page
+
 ### Added (LLMS-044)
 - Homepage OG image (`/opengraph-image`) — edge-rendered brand card: site name, headline, tagline, and "20+ AI providers tracked" badge; no live data fetch (avoids stale-status problem on social shares)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,26 @@
 #   db       — PostgreSQL 17 (relational state: providers, incidents)
 #   influx   — InfluxDB 3 Core (time-series probe samples)
 #   migrate  — one-shot migration runner; exits 0 when done
-#   ingest   — probe result ingestion API  (:8080)
-#   detector — incident detection rule runner
-#   api      — public read API             (:8081)
-#   web      — Next.js frontend            (:3000)
-#   prober   — local probe runner (dev only; production uses 7 remote nodes)
+#
+# FIXED HOST PORTS (do not change — chosen to avoid conflicts on this host):
+#   db       — PostgreSQL 17        host:15432 → container:5432
+#   influx   — InfluxDB 3 Core      host:18086 → container:8086
+#   ingest   — probe ingest API     host:18080 → container:8080
+#   api      — public read API      host:18081 → container:8081
+#
+# Next.js dev server runs OUTSIDE Docker:
+#   cd web && npm run dev           (reads web/.env.local, listens on :13000)
 #
 # First-time setup:
-#   cp .env.example .env          # fill in provider API keys
+#   cp .env.example .env
+#   cp web/.env.local.example web/.env.local
 #   docker compose up -d db influx
 #   docker compose run --rm migrate
-#   docker compose up -d
+#   docker compose up -d api ingest detector
+#   cd web && npm run dev          # browser → http://localhost:13000
 #
 # Usage:
-#   docker compose up -d            # start everything
+#   docker compose up -d            # start backend (db, influx, api, ingest, detector)
 #   docker compose logs -f api      # tail a service
 #   docker compose down -v          # stop and wipe volumes
 
@@ -36,7 +42,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "15432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U llmstatus"]
       interval: 10s
@@ -52,7 +58,7 @@ services:
     volumes:
       - influx_data:/var/lib/influxdb3
     ports:
-      - "8086:8086"
+      - "18086:8086"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8086/health || exit 1"]
       interval: 10s
@@ -94,7 +100,7 @@ services:
       influx:
         condition: service_healthy
     ports:
-      - "8080:8080"
+      - "18080:8080"
 
   detector:
     build:
@@ -137,7 +143,7 @@ services:
       influx:
         condition: service_healthy
     ports:
-      - "8081:8081"
+      - "18081:8081"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8081/healthz || exit 1"]
       interval: 15s
@@ -154,12 +160,14 @@ services:
     restart: unless-stopped
     environment:
       API_URL: http://api:8081
-      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:3000}
+      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:13000}
     depends_on:
       api:
         condition: service_healthy
     ports:
-      - "3000:3000"
+      - "13000:3000"
+    profiles:
+      - web-docker
 
   # ── local probe runner (dev only) ──────────────────────────────────────────
 

--- a/web/app/about/page.tsx
+++ b/web/app/about/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "llmstatus.io is an independent real-time monitoring service for AI API providers. " +
+    "We make real API calls from 7 global locations — not scraped from official status pages.",
+  openGraph: {
+    title: "About — llmstatus.io",
+    description:
+      "Independent real-time monitoring for the AI infrastructure. " +
+      "Measured from 7 global locations. Not scraped from official status pages.",
+  },
+};
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-10">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+        {title}
+      </h2>
+      <div className="space-y-3 text-sm text-[var(--ink-200)] leading-6">{children}</div>
+    </section>
+  );
+}
+
+export default function AboutPage() {
+  return (
+    <main className="flex-1 mx-auto w-full max-w-2xl px-6 py-12">
+      {/* Header */}
+      <div className="mb-12">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--signal-amber)] mb-4">
+          llmstatus.io
+        </p>
+        <h1 className="text-3xl font-semibold text-[var(--ink-100)] leading-tight mb-4">
+          Independent monitoring
+          <br />
+          for the AI infrastructure.
+        </h1>
+        <p className="text-sm text-[var(--ink-400)] leading-relaxed">
+          We make real API calls from 7 global locations every 30–60 seconds
+          and publish what we find — uptime, latency, and incidents — as a public good.
+        </p>
+      </div>
+
+      <Section title="What this is">
+        <p>
+          llmstatus.io is a third-party monitoring service for AI API providers.
+          We measure uptime, latency, and reliability by sending real inference
+          requests from multiple geographic regions — not by reading official status
+          pages or aggregating user reports.
+        </p>
+        <p>
+          When you see a provider listed as operational on their own status page
+          while your application is failing, llmstatus.io is the independent data
+          source you can point to.
+        </p>
+      </Section>
+
+      <Section title="Why we built it">
+        <p>
+          Official status pages are operated by the same teams experiencing the
+          incidents. Historically, updates lag reality by 15–60 minutes on average.
+          Crowdsourced reports like Downdetector reflect consumer sentiment, not
+          API behavior.
+        </p>
+        <p>
+          Developers and infrastructure teams need accurate, timely, independent
+          data to set SLAs, triage incidents, and make provider decisions. That
+          data did not exist for AI APIs. We built it.
+        </p>
+      </Section>
+
+      <Section title="How we work">
+        <p>
+          Every 30–60 seconds, probes run from 7 independent server locations
+          across North America, Europe, and Asia-Pacific. Each probe makes a real
+          authenticated API call — a short inference request — and records whether
+          it succeeded, how long it took, and what error type occurred if it failed.
+        </p>
+        <p>
+          An incident is declared when our detection rules fire based on aggregate
+          probe data. Rules are public and documented in full on the{" "}
+          <Link
+            href="/methodology"
+            className="text-[var(--ink-300)] hover:text-[var(--ink-100)] transition-colors underline underline-offset-2"
+          >
+            Methodology
+          </Link>{" "}
+          page.
+        </p>
+      </Section>
+
+      <Section title="Independence">
+        <p>
+          We pay for our own API keys. We have no commercial relationship with
+          any provider we monitor. No provider can influence what we publish.
+        </p>
+        <p>
+          If our own infrastructure has an issue, we publish it with the same
+          rules as any other provider. Our source code — including all probe
+          logic and detection rules — is public on{" "}
+          <a
+            href="https://github.com/llmstatus/llmstatus"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--ink-300)] hover:text-[var(--ink-100)] transition-colors underline underline-offset-2"
+          >
+            GitHub
+          </a>
+          .
+        </p>
+      </Section>
+
+      <Section title="What we don't do">
+        <ul className="space-y-2 list-none">
+          {[
+            "Scrape official status pages.",
+            "Use crowdsourced incident reports.",
+            "Make up or infer data we didn't measure.",
+            "Silently drop anomalies we don't understand.",
+            "Delete historical data.",
+          ].map((item) => (
+            <li key={item} className="flex items-start gap-2">
+              <span className="mt-0.5 text-[var(--signal-down)] shrink-0">✕</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section title="Contact">
+        <p>
+          For questions about our methodology or data:{" "}
+          <a
+            href="mailto:methodology@llmstatus.io"
+            className="text-[var(--ink-300)] hover:text-[var(--ink-100)] transition-colors"
+          >
+            methodology@llmstatus.io
+          </a>
+        </p>
+        <p>
+          To report a security issue:{" "}
+          <a
+            href="mailto:security@llmstatus.io"
+            className="text-[var(--ink-300)] hover:text-[var(--ink-100)] transition-colors"
+          >
+            security@llmstatus.io
+          </a>
+        </p>
+        <p>
+          General:{" "}
+          <a
+            href="mailto:contact@llmstatus.io"
+            className="text-[var(--ink-300)] hover:text-[var(--ink-100)] transition-colors"
+          >
+            contact@llmstatus.io
+          </a>
+        </p>
+      </Section>
+    </main>
+  );
+}

--- a/web/app/methodology/page.tsx
+++ b/web/app/methodology/page.tsx
@@ -1,0 +1,258 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+  title: "Methodology",
+  description:
+    "How llmstatus.io measures AI API uptime, latency, and incidents. " +
+    "Real probe calls from 7 global locations — every metric is reproducible.",
+  openGraph: {
+    title: "Methodology — llmstatus.io",
+    description:
+      "How we measure AI API uptime, latency, and incidents — " +
+      "every metric is traceable to specific probe logic.",
+  },
+};
+
+function Section({ id, title, children }: { id: string; title: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="mb-12 scroll-mt-6">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+        {title}
+      </h2>
+      <div className="space-y-3 text-sm text-[var(--ink-200)] leading-6">{children}</div>
+    </section>
+  );
+}
+
+function Rule({
+  id,
+  severity,
+  trigger,
+  title,
+}: {
+  id: string;
+  severity: "critical" | "major" | "minor";
+  trigger: string;
+  title: string;
+}) {
+  const color =
+    severity === "critical"
+      ? "text-[var(--signal-down)]"
+      : severity === "major"
+      ? "text-[var(--signal-warn)]"
+      : "text-[var(--ink-300)]";
+  return (
+    <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-3">
+      <div className="flex items-center gap-3 mb-1">
+        <span className="text-xs font-mono text-[var(--ink-500)]">{id}</span>
+        <span className={`text-xs font-semibold uppercase tracking-wide ${color}`}>{severity}</span>
+      </div>
+      <p className="text-sm font-medium text-[var(--ink-100)] mb-1">{title}</p>
+      <p className="text-xs text-[var(--ink-400)]">{trigger}</p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start gap-4">
+      <span className="w-32 shrink-0 text-xs text-[var(--ink-400)]">{label}</span>
+      <span className="text-sm text-[var(--ink-200)]">{value}</span>
+    </div>
+  );
+}
+
+export default function MethodologyPage() {
+  return (
+    <main className="flex-1 mx-auto w-full max-w-2xl px-6 py-12">
+      {/* Header */}
+      <div className="mb-12">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--signal-amber)] mb-4">
+          Methodology
+        </p>
+        <h1 className="text-3xl font-semibold text-[var(--ink-100)] leading-tight mb-4">
+          How we measure.
+        </h1>
+        <p className="text-sm text-[var(--ink-400)] leading-relaxed">
+          Every number on llmstatus.io is traceable to specific probe logic. This page
+          documents exactly what we do, how we classify failures, and how we decide
+          when an incident is real.
+        </p>
+        <p className="mt-3 text-xs text-[var(--ink-500)]">
+          The complete specification is in{" "}
+          <a
+            href="https://github.com/llmstatus/llmstatus/blob/main/METHODOLOGY.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--ink-400)] hover:text-[var(--ink-200)] transition-colors underline underline-offset-2"
+          >
+            METHODOLOGY.md
+          </a>{" "}
+          on GitHub. This page is the human-readable summary.
+        </p>
+      </div>
+
+      <Section id="probes" title="How we probe">
+        <p>
+          From each of 7 server locations, we run two probe types against every
+          monitored provider on a fixed schedule:
+        </p>
+        <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] divide-y divide-[var(--ink-600)] overflow-hidden">
+          <div className="px-4 py-3 grid grid-cols-[6rem_1fr] gap-4">
+            <span className="text-xs font-semibold text-[var(--ink-400)]">Light inference</span>
+            <span className="text-xs text-[var(--ink-200)]">
+              Sends a minimal prompt ("Reply with OK"), expects ≤10 token response. Runs every 60 s.
+              This is the primary uptime signal.
+            </span>
+          </div>
+          <div className="px-4 py-3 grid grid-cols-[6rem_1fr] gap-4">
+            <span className="text-xs font-semibold text-[var(--ink-400)]">Medium inference</span>
+            <span className="text-xs text-[var(--ink-200)]">
+              ~200-token input, requests ~100-token output. Runs every 5 min.
+              This is the latency signal.
+            </span>
+          </div>
+        </div>
+        <p>
+          We use dedicated paid API accounts for monitoring. We are paying customers
+          of every provider we monitor — we do not free-ride on trial accounts.
+        </p>
+      </Section>
+
+      <Section id="locations" title="Probe locations">
+        <div className="space-y-1.5">
+          {[
+            ["us-west-2", "AWS Oregon — near OpenAI/Anthropic origins"],
+            ["us-east-1", "AWS Virginia — near AWS Bedrock, Google"],
+            ["eu-west", "Hetzner Germany — EU coverage"],
+            ["ap-northeast-1", "AWS Tokyo — APAC"],
+            ["ap-southeast-1", "AWS Singapore — Southeast Asia"],
+            ["cn-shanghai", "Alibaba Cloud Shanghai — China view"],
+            ["cn-guangzhou", "Tencent Cloud Guangzhou — China redundancy"],
+          ].map(([region, note]) => (
+            <div key={region} className="flex items-start gap-3 text-xs">
+              <span className="font-mono text-[var(--ink-400)] w-36 shrink-0">{region}</span>
+              <span className="text-[var(--ink-300)]">{note}</span>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section id="what-we-measure" title="What we measure">
+        <div className="space-y-3">
+          <Metric label="Uptime" value="Fraction of probe attempts that succeed in a given window." />
+          <Metric label="P95 latency" value="95th-percentile wall-clock time to receive the complete response, across successful probes only." />
+          <Metric label="Error type" value="When a probe fails, we classify the failure: timeout, network, rate_limit, auth, 5xx, 4xx, content_policy, model_overloaded, empty_response, malformed, or unknown." />
+        </div>
+        <p className="mt-2">
+          Rate-limit errors (429) are counted in the error rate. If a provider is
+          consistently returning 429, that is a real service-availability issue
+          from the customer perspective.
+        </p>
+      </Section>
+
+      <Section id="detection-rules" title="Detection rules">
+        <p>
+          The detector runs every 60 seconds and applies four rules to the most
+          recent probe data. All rules and thresholds are public in{" "}
+          <a
+            href="https://github.com/llmstatus/llmstatus/blob/main/internal/detector/rules.go"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--ink-400)] hover:text-[var(--ink-200)] transition-colors underline underline-offset-2"
+          >
+            rules.go
+          </a>
+          .
+        </p>
+        <div className="space-y-3">
+          <Rule
+            id="Rule 6.1"
+            severity="critical"
+            title="Provider is DOWN"
+            trigger="Error rate > 50% across all nodes in the last 5 minutes, with ≥ 3 probes."
+          />
+          <Rule
+            id="Rule 6.2"
+            severity="major"
+            title="Elevated error rate"
+            trigger="Error rate > 5% in the last 10 minutes. Suppressed if Rule 6.1 is already firing."
+          />
+          <Rule
+            id="Rule 6.3"
+            severity="minor"
+            title="Latency degradation"
+            trigger="P95 latency over the last 5 minutes exceeds 3× the 24-hour baseline, with ≥ 5 successful samples."
+          />
+          <Rule
+            id="Rule 6.4"
+            severity="minor"
+            title="Regional outage"
+            trigger="One probe region exceeds 50% error rate while the provider is not globally down, with ≥ 3 probes from that region."
+          />
+        </div>
+      </Section>
+
+      <Section id="deduplication" title="Deduplication and resolution">
+        <p>
+          If an incident of the same rule and provider is already ongoing, we do
+          not create a duplicate — we update the existing record.
+        </p>
+        <p>
+          An incident auto-resolves when its triggering rule has not fired for
+          10 consecutive minutes. Critical incidents are published immediately.
+          Minor and major incidents are also published immediately by default;
+          a human reviewer can edit the title and description after publication.
+        </p>
+      </Section>
+
+      <Section id="data-retention" title="Data retention">
+        <div className="space-y-3">
+          <Metric label="Raw probe data" value="90 days, then rolled up into hourly aggregates." />
+          <Metric label="Hourly aggregates" value="Permanent — never deleted." />
+          <Metric label="Daily aggregates" value="Permanent — never deleted." />
+          <Metric label="Incident records" value="Permanent. We do not retroactively delete or alter incident history." />
+        </div>
+      </Section>
+
+      <Section id="limitations" title="Known limitations">
+        <ul className="space-y-2">
+          {[
+            "We probe with a short fixed prompt. Real-world workloads — long contexts, system prompts, function calls — may behave differently.",
+            "We cover the chat/completion inference API. Embeddings, image generation, audio, and fine-tuning endpoints are not currently monitored.",
+            "Our latency baseline uses a 24-hour rolling window (V1). The METHODOLOGY.md specifies a 7-day same-hour median as the correct baseline; we will upgrade in V2.",
+            "Regional results depend on our probe servers' network paths. A problem on one transit provider between our server and the API may look like a regional outage.",
+            "We cannot distinguish a global rate-limit (429) from a partial outage if the provider uses 429 for both.",
+          ].map((item) => (
+            <li key={item} className="flex items-start gap-2 text-sm">
+              <span className="mt-0.5 text-[var(--signal-warn)] shrink-0">·</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <div className="border-t border-[var(--ink-600)] pt-6">
+        <p className="text-xs text-[var(--ink-500)]">
+          Questions or corrections?{" "}
+          <a
+            href="mailto:methodology@llmstatus.io"
+            className="text-[var(--ink-400)] hover:text-[var(--ink-200)] transition-colors"
+          >
+            methodology@llmstatus.io
+          </a>
+          {" · "}
+          <Link
+            href="/about"
+            className="text-[var(--ink-400)] hover:text-[var(--ink-200)] transition-colors"
+          >
+            About
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -15,6 +15,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/api`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: `${SITE_URL}/badges`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
     { url: `${SITE_URL}/compare`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${SITE_URL}/about`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${SITE_URL}/methodology`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
   ];
 
   const providerRoutes: MetadataRoute.Sitemap = await listProviders()

--- a/web/components/SiteFooter.tsx
+++ b/web/components/SiteFooter.tsx
@@ -12,13 +12,11 @@ export function SiteFooter({ message = DEFAULT_MESSAGE }: Props) {
     <footer className="border-t border-[var(--ink-600)] px-6 py-4">
       <div className="mx-auto max-w-4xl flex items-center justify-between text-xs text-[var(--ink-400)]">
         <span>{message}</span>
-        <Link
-          href="/api/feed"
-          className="hover:text-[var(--ink-200)] transition-colors"
-          aria-label="RSS feed"
-        >
-          RSS
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link href="/about" className="hover:text-[var(--ink-200)] transition-colors">About</Link>
+          <Link href="/methodology" className="hover:text-[var(--ink-200)] transition-colors">Methodology</Link>
+          <Link href="/api/feed" className="hover:text-[var(--ink-200)] transition-colors" aria-label="RSS feed">RSS</Link>
+        </div>
       </div>
     </footer>
   );

--- a/web/env.local.example
+++ b/web/env.local.example
@@ -1,0 +1,19 @@
+# Next.js local dev environment — copy to web/.env.local (never commit .env.local)
+#
+# Start dev server:
+#   npm run dev
+# Then open: http://localhost:13000
+#
+# Backend must be running via Docker:
+#   docker compose up -d db influx api ingest detector
+
+# Go public API — server-side only (used by Server Components during SSR)
+API_URL=http://localhost:18081
+
+# Public site URL — used by sitemap.xml and robots.txt
+NEXT_PUBLIC_SITE_URL=http://localhost:13000
+
+# Next.js dev port — set in your shell or package.json:
+#   PORT=13000 npm run dev
+# Or add to this file if your tooling supports it:
+PORT=13000


### PR DESCRIPTION
## Summary
- Fixed host port assignments for this host (avoids conflicts with other services): db→15432, influx→18086, ingest→18080, api→18081, Next.js→13000
- `docker-compose.yml` updated; web container moved to `web-docker` profile (dev uses `npm run dev` outside Docker)
- `web/env.local.example` added — copy to `web/.env.local` before starting dev server
- `/about` — who we are, why independent monitoring matters, contact (DRAFT — review copy before publishing)
- `/methodology` — probe types, 7 locations table, all 4 detection rules with triggers, data retention, known limitations (DRAFT)
- Footer links to /about and /methodology on every page
- sitemap.xml includes /about and /methodology

## Starting dev
\`\`\`bash
docker compose up -d db influx api ingest detector
cd web && npm run dev    # → http://localhost:13000
\`\`\`

## Test plan
- [ ] `npm run build` passes (confirmed — /about ○, /methodology ○)
- [ ] `/about` renders correctly at http://localhost:13000/about
- [ ] `/methodology` renders correctly at http://localhost:13000/methodology
- [ ] Footer shows About / Methodology / RSS links
- [ ] Docker compose starts without port conflicts on this host