### PR TITLE
feat LLMS-047: provider detail page

### DIFF
--- a/internal/api/live_stats.go
+++ b/internal/api/live_stats.go
@@ -11,6 +11,7 @@ type LiveStatsReader interface {
 	AllProviderLiveStats(ctx context.Context) ([]influx.ProviderLiveStat, error)
 	AllModelLiveStats(ctx context.Context) ([]influx.ModelLiveStat, error)
 	AllModelSparklines(ctx context.Context) (map[string][]float64, error)
+	ProviderRegionStats(ctx context.Context, providerID string) ([]influx.RegionLiveStat, error)
 }
 
 // compile-time check: influx.LiveStatsReader satisfies LiveStatsReader.

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -29,6 +29,12 @@ type providerSummary struct {
 	ModelStats       []modelStat `json:"model_stats"`
 }
 
+type regionStat struct {
+	RegionID  string  `json:"region_id"`
+	Uptime24h float64 `json:"uptime_24h"` // 0–1
+	P95Ms     float64 `json:"p95_ms"`
+}
+
 type modelSummary struct {
 	ModelID     string `json:"model_id"`
 	DisplayName string `json:"display_name"`
@@ -47,10 +53,11 @@ type incidentRef struct {
 
 type providerDetail struct {
 	providerSummary
-	StatusPageURL    *string       `json:"status_page_url,omitempty"`
-	DocumentationURL *string       `json:"documentation_url,omitempty"`
+	StatusPageURL    *string        `json:"status_page_url,omitempty"`
+	DocumentationURL *string        `json:"documentation_url,omitempty"`
 	Models           []modelSummary `json:"models"`
 	ActiveIncidents  []incidentRef  `json:"active_incidents"`
+	RegionStats      []regionStat   `json:"region_stats"` // 24 h stats per probe region
 }
 
 // ---- handlers ---------------------------------------------------------------
@@ -191,12 +198,47 @@ func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Fetch model live stats (non-fatal if InfluxDB is unavailable).
+	var (
+		modelLiveStats = make(map[string][2]float64)
+		sparklines     = make(map[string][]float64)
+	)
+	if s.liveStats != nil {
+		ctx := r.Context()
+		if mstats, err := s.liveStats.AllModelLiveStats(ctx); err == nil {
+			for _, ms := range mstats {
+				modelLiveStats[ms.ProviderID+":"+ms.Model] = [2]float64{ms.Uptime24h, ms.P95Ms}
+			}
+		}
+		if sl, err := s.liveStats.AllModelSparklines(ctx); err == nil {
+			sparklines = sl
+		}
+	}
+
+	var regionStats []regionStat
+	if s.liveStats != nil {
+		if rs, err := s.liveStats.ProviderRegionStats(r.Context(), id); err == nil {
+			regionStats = make([]regionStat, 0, len(rs))
+			for _, reg := range rs {
+				regionStats = append(regionStats, regionStat{
+					RegionID:  reg.RegionID,
+					Uptime24h: reg.Uptime24h,
+					P95Ms:     reg.P95Ms,
+				})
+			}
+		}
+	}
+
+	ps := toProviderSummary(p, incMap)
+	ps.ModelStats = buildModelStats(id, models, modelLiveStats, sparklines)
+
 	detail := providerDetail{
-		providerSummary:  toProviderSummary(p, incMap),
+		providerSummary:  ps,
 		StatusPageURL:    textVal(p.StatusPageUrl),
 		DocumentationURL: textVal(p.DocumentationUrl),
 		Models:           toModelSummaries(models),
 		ActiveIncidents:  toIncidentRefs(activeIncs),
+		RegionStats:      coalesceSlice(regionStats),
 	}
 
 	writeEnvelope(w, detail)

--- a/internal/api/testhelpers_test.go
+++ b/internal/api/testhelpers_test.go
@@ -22,6 +22,18 @@ func (f *fakeLiveStatsReader) AllProviderLiveStats(_ context.Context) ([]influx.
 	return f.stats, f.err
 }
 
+func (f *fakeLiveStatsReader) AllModelLiveStats(_ context.Context) ([]influx.ModelLiveStat, error) {
+	return nil, nil
+}
+
+func (f *fakeLiveStatsReader) AllModelSparklines(_ context.Context) (map[string][]float64, error) {
+	return nil, nil
+}
+
+func (f *fakeLiveStatsReader) ProviderRegionStats(_ context.Context, _ string) ([]influx.RegionLiveStat, error) {
+	return nil, nil
+}
+
 // fakeStore implements api.Store for unit tests.
 type fakeStore struct {
 	providers []pgstore.Provider

--- a/internal/store/influx/live_stats.go
+++ b/internal/store/influx/live_stats.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -29,6 +30,13 @@ type ModelLiveStat struct {
 	P95Ms      float64 // p95 duration of successful probes; 0 when none
 }
 
+// RegionLiveStat holds current 24 h aggregate stats for one probe region.
+type RegionLiveStat struct {
+	RegionID  string
+	Uptime24h float64 // 0–1; 1.0 when Total == 0
+	P95Ms     float64 // p95 duration of successful probes; 0 when no successful probes
+}
+
 // LiveStatsReader fetches current aggregate stats for every active provider
 // and model in a single InfluxDB round-trip each.
 type LiveStatsReader interface {
@@ -38,6 +46,8 @@ type LiveStatsReader interface {
 	// AllModelSparklines returns 60-bucket avg latency (ms) per provider+model.
 	// Key: "provider_id:model". Value: slice of length 60; 0 means no data.
 	AllModelSparklines(ctx context.Context) (map[string][]float64, error)
+	// ProviderRegionStats returns 24 h uptime + p95 grouped by region for one provider.
+	ProviderRegionStats(ctx context.Context, providerID string) ([]RegionLiveStat, error)
 }
 
 // compile-time check: *influxHistoryReader satisfies LiveStatsReader.
@@ -217,6 +227,68 @@ func (r *influxHistoryReader) AllModelSparklines(ctx context.Context) (map[strin
 		if row.AvgMs != nil {
 			out[key][idx] = *row.AvgMs
 		}
+	}
+	return out, nil
+}
+
+// ProviderRegionStats returns 24 h uptime + p95 per probe region for one provider.
+func (r *influxHistoryReader) ProviderRegionStats(ctx context.Context, providerID string) ([]RegionLiveStat, error) {
+	if strings.ContainsAny(providerID, "'\";\\") {
+		return nil, fmt.Errorf("influx: invalid provider_id %q", providerID)
+	}
+
+	sql := fmt.Sprintf(
+		`SELECT
+		    region_id,
+		    COUNT(*) AS total,
+		    COUNT(*) FILTER (WHERE success = false) AS errors,
+		    COALESCE(approx_percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms)
+		             FILTER (WHERE success = true AND duration_ms IS NOT NULL), 0) AS p95_ms
+		FROM probes
+		WHERE time >= now() - INTERVAL '86400 seconds'
+		  AND provider_id = '%s'
+		GROUP BY region_id
+		ORDER BY region_id`,
+		providerID,
+	)
+
+	body, err := json.Marshal(map[string]string{"q": sql, "db": r.cfg.Database, "format": "json"})
+	if err != nil {
+		return nil, fmt.Errorf("influx region stats: marshal: %w", err)
+	}
+
+	resp, err := r.postQuery(ctx, body)
+	if err != nil {
+		return nil, fmt.Errorf("influx region stats: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("influx region stats: status %d: %s", resp.StatusCode, detail)
+	}
+
+	var rows []struct {
+		RegionID string  `json:"region_id"`
+		Total    float64 `json:"total"`
+		Errors   float64 `json:"errors"`
+		P95Ms    float64 `json:"p95_ms"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("influx region stats: decode: %w", err)
+	}
+
+	out := make([]RegionLiveStat, 0, len(rows))
+	for _, row := range rows {
+		uptime := 1.0
+		if row.Total > 0 {
+			uptime = 1.0 - row.Errors/row.Total
+		}
+		out = append(out, RegionLiveStat{
+			RegionID:  row.RegionID,
+			Uptime24h: uptime,
+			P95Ms:     row.P95Ms,
+		})
 	}
 	return out, nil
 }

--- a/scripts/seed_dev.sh
+++ b/scripts/seed_dev.sh
@@ -98,7 +98,7 @@ docker exec llmstatus-db psql -U llmstatus llmstatus -f /tmp/seed_dev.sql
 echo "==> PostgreSQL seeded."
 
 # ── InfluxDB ──────────────────────────────────────────────────────────────────
-echo "==> Generating InfluxDB probe data (48 h × 11 provider/model pairs) …"
+echo "==> Generating InfluxDB probe data (48 h × 12 provider/model pairs × 4 regions) …"
 
 INFLUX_HOST="$INFLUX_HOST" INFLUX_DB="$INFLUX_DB" python3 - <<'PYEOF'
 import urllib.request
@@ -127,7 +127,15 @@ PROVIDERS = [
     ("groq",      "llama-3.1-8b-instant",          0.992,  120,  35),
 ]
 
-REGION      = "local-dev"
+# (region_id, latency_multiplier, error_rate_penalty)
+# latency_multiplier: >1 means slower; error_penalty: fraction added to error probability
+REGIONS = [
+    ("us-east-1",      1.0,  0.000),
+    ("eu-west-1",      1.25, 0.003),
+    ("ap-southeast-1", 1.75, 0.005),
+    ("ap-northeast-1", 1.45, 0.004),
+]
+
 PROBE_TYPE  = "chat_basic"
 INTERVAL_S  = 300         # 5-min samples
 WINDOW_S    = 48 * 3600   # 48 h of history
@@ -147,19 +155,22 @@ ANTHRO_LATENCY_E = now_ns - int(19 * 3600 * 1e9)
 def esc(s):
     return s.replace(",", r"\,").replace(" ", r"\ ").replace("=", r"\=")
 
-def make_line(pid, model, ts, sr, p50, sd):
-    _sr, _p50, _sd = sr, p50, sd
+def make_line(pid, model, region_id, lat_mult, err_penalty, ts, sr, p50, sd):
+    _sr  = max(0.0, sr - err_penalty)
+    _p50 = int(p50 * lat_mult)
+    _sd  = int(sd  * lat_mult)
+
     if pid == "openai" and model == "gpt-4o" and OPENAI_OUTAGE_S <= ts <= OPENAI_OUTAGE_E:
         _sr, _p50, _sd = 0.15, 800, 300
     if pid == "anthropic" and "sonnet" in model and ANTHRO_LATENCY_S <= ts <= ANTHRO_LATENCY_E:
-        _sr, _p50, _sd = 0.90, 9000, 2000
+        _sr, _p50, _sd = 0.90, int(9000 * lat_mult), int(2000 * lat_mult)
 
     ok = random.random() < _sr
     dur    = max(50,  int(random.gauss(_p50, _sd)))  if ok else max(100, int(random.gauss(_p50 * 1.5, _sd * 2)))
     status = 200                                       if ok else random.choices([429, 500, 503], weights=[3, 4, 3])[0]
     ecls   = ""                                        if ok else ("rate_limit" if status == 429 else "server_error")
 
-    tags = f"provider_id={esc(pid)},model={esc(model)},probe_type={PROBE_TYPE},region_id={REGION}"
+    tags = f"provider_id={esc(pid)},model={esc(model)},probe_type={PROBE_TYPE},region_id={esc(region_id)}"
     if ecls:
         tags += f",error_class={ecls}"
 
@@ -186,10 +197,11 @@ for step in range(steps):
     ts = now_ns - (steps - step) * INTERVAL_S * 1_000_000_000
     ts += random.randint(-30_000_000_000, 30_000_000_000)
     for (pid, model, sr, p50, sd) in PROVIDERS:
-        buf.append(make_line(pid, model, ts, sr, p50, sd))
-        if len(buf) >= BATCH_LINES:
-            flush(); buf.clear()
-            print(f"  flushed {total} points …")
+        for (region_id, lat_mult, err_penalty) in REGIONS:
+            buf.append(make_line(pid, model, region_id, lat_mult, err_penalty, ts, sr, p50, sd))
+            if len(buf) >= BATCH_LINES:
+                flush(); buf.clear()
+                print(f"  flushed {total} points …")
 
 if buf:
     flush()
@@ -201,4 +213,4 @@ echo ""
 echo "==> Dev seed complete."
 echo "    Providers : openai, anthropic, google, mistral (degraded), cohere, together, groq"
 echo "    Incidents : 1 ongoing (mistral), 2 resolved (openai, anthropic)"
-echo "    Probe data: 48 h × 11 provider/model pairs, 5-min intervals"
+echo "    Probe data: 48 h × 12 provider/model pairs × 4 regions, 5-min intervals"

--- a/web/app/providers/[id]/HistorySection.tsx
+++ b/web/app/providers/[id]/HistorySection.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { HistoryBucket, HistoryWindow } from "@/lib/api";
+import { fetchProviderHistory } from "./actions";
+import { UptimeSparkline } from "@/components/UptimeSparkline";
+import { LatencyBar } from "@/components/LatencyBar";
+
+const WINDOWS: { value: HistoryWindow; label: string }[] = [
+  { value: "24h", label: "24h" },
+  { value: "7d",  label: "7d"  },
+  { value: "30d", label: "30d" },
+];
+
+interface Props {
+  providerId: string;
+  initialHistory: HistoryBucket[] | null;
+}
+
+export function HistorySection({ providerId, initialHistory }: Props) {
+  const [selected, setSelected] = useState<HistoryWindow>("30d");
+  const [history, setHistory] = useState<HistoryBucket[] | null>(initialHistory);
+  const [isPending, startTransition] = useTransition();
+
+  function selectWindow(w: HistoryWindow) {
+    if (w === selected) return;
+    setSelected(w);
+    startTransition(async () => {
+      const data = await fetchProviderHistory(providerId, w);
+      setHistory(data);
+    });
+  }
+
+  const hasData = history !== null && history.length > 0;
+  const hasLatency = hasData && history!.some((b) => b.p95_ms > 0);
+
+  return (
+    <section className="mb-8">
+      {/* Header + window tabs */}
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+          History
+        </h2>
+        <div className="flex gap-px rounded bg-[var(--canvas-sunken)] p-0.5">
+          {WINDOWS.map((w) => (
+            <button
+              key={w.value}
+              onClick={() => selectWindow(w.value)}
+              className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+                selected === w.value
+                  ? "bg-[var(--canvas-raised)] text-[var(--ink-100)] shadow-sm"
+                  : "text-[var(--ink-400)] hover:text-[var(--ink-200)]"
+              }`}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Charts */}
+      <div className={`space-y-4 transition-opacity duration-150 ${isPending ? "opacity-40" : ""}`}>
+        {hasData ? (
+          <>
+            <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
+              <UptimeSparkline buckets={history!} window={selected} />
+            </div>
+            {hasLatency && (
+              <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
+                <LatencyBar buckets={history!} window={selected} />
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6 py-8 text-center">
+            <p className="text-sm text-[var(--ink-400)]">No history data for this window.</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web/app/providers/[id]/actions.ts
+++ b/web/app/providers/[id]/actions.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { getProviderHistory, type HistoryBucket, type HistoryWindow } from "@/lib/api";
+
+export async function fetchProviderHistory(
+  providerId: string,
+  window: HistoryWindow,
+): Promise<HistoryBucket[] | null> {
+  return getProviderHistory(providerId, window).catch(() => null);
+}

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -5,9 +5,8 @@ import Link from "next/link";
 import { getProvider, getProviderHistory, ApiNotFoundError } from "@/lib/api";
 import { StatusPill } from "@/components/StatusPill";
 import { IncidentCard } from "@/components/IncidentCard";
-import { ModelList } from "@/components/ModelList";
-import { UptimeSparkline } from "@/components/UptimeSparkline";
-import { LatencyBar } from "@/components/LatencyBar";
+import { ModelStatsTable } from "@/components/ModelStatsTable";
+import { HistorySection } from "./HistorySection";
 
 export const revalidate = 60;
 
@@ -28,11 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `Is ${provider.name} API down?`,
       description,
       openGraph: { title: `${provider.name} API Status`, description },
-      alternates: {
-        types: {
-          "application/rss+xml": `/api/feed/${id}`,
-        },
-      },
+      alternates: { types: { "application/rss+xml": `/api/feed/${id}` } },
     };
   } catch {
     return { title: "Provider not found" };
@@ -50,7 +45,7 @@ export default async function ProviderPage({ params }: Props) {
     throw e;
   }
 
-  // History fetch is best-effort — charts are hidden if unavailable.
+  // History is best-effort — the client component handles empty state.
   const history = await getProviderHistory(id, "30d").catch(() => null);
 
   const jsonLd = {
@@ -65,9 +60,8 @@ export default async function ProviderPage({ params }: Props) {
 
   return (
     <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-10">
-      {/* React 19 renders <script> children without HTML-escaping and auto-escapes
-          </script> sequences, so plain JSON.stringify is safe here. */}
       <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+
       {/* Breadcrumb */}
       <nav className="mb-6 text-xs text-[var(--ink-400)]">
         <Link href="/" className="hover:text-[var(--ink-200)] transition-colors">
@@ -80,11 +74,12 @@ export default async function ProviderPage({ params }: Props) {
       {/* Header */}
       <div className="mb-8 flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold text-[var(--ink-100)]">
-            {provider.name}
-          </h1>
+          <h1 className="text-2xl font-semibold text-[var(--ink-100)]">{provider.name}</h1>
           <p className="mt-1 text-sm text-[var(--ink-400)]">
-            {provider.category} · {provider.region}
+            {provider.category}
+            {provider.region && (
+              <span className="text-[var(--ink-600)]"> · Coverage: {provider.region}</span>
+            )}
             {provider.status_page_url && (
               <>
                 {" · "}
@@ -99,10 +94,7 @@ export default async function ProviderPage({ params }: Props) {
               </>
             )}
             {" · "}
-            <Link
-              href={`/api/feed/${id}`}
-              className="hover:text-[var(--ink-200)] transition-colors"
-            >
+            <Link href={`/api/feed/${id}`} className="hover:text-[var(--ink-200)] transition-colors">
               RSS
             </Link>
           </p>
@@ -124,36 +116,95 @@ export default async function ProviderPage({ params }: Props) {
         </section>
       )}
 
-      {/* Uptime sparkline */}
-      {history !== null && (
+      {/* History charts with window selector (client component) */}
+      <HistorySection providerId={id} initialHistory={history} />
+
+      {/* Regional breakdown */}
+      {(provider.region_stats ?? []).length > 0 && (
         <section className="mb-8">
           <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-            Uptime History
+            Regional Status
           </h2>
-          <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
-            <UptimeSparkline buckets={history} days={30} />
+          <div className="overflow-hidden rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--ink-600)]">
+                  <th className="px-4 py-2.5 text-left text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+                    Probe region
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+                    Uptime 24h
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+                    p95 latency
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {[...(provider.region_stats ?? [])]
+                  .sort((a, b) => a.uptime_24h - b.uptime_24h)
+                  .map((reg) => {
+                    const dotColor =
+                      reg.uptime_24h >= 0.995 ? "bg-[var(--signal-ok)]"
+                      : reg.uptime_24h >= 0.95 ? "bg-[var(--signal-warn)]"
+                      : "bg-[var(--signal-down)]";
+                    const uptimeColor =
+                      reg.uptime_24h >= 0.995 ? "text-[var(--signal-ok)]"
+                      : reg.uptime_24h >= 0.95 ? "text-[var(--signal-warn)]"
+                      : "text-[var(--signal-down)]";
+                    const barColor =
+                      reg.p95_ms <= 500  ? "bg-[var(--signal-ok)]"
+                      : reg.p95_ms <= 2000 ? "bg-[var(--signal-warn)]"
+                      : "bg-[var(--signal-down)]";
+                    const barWidth = reg.p95_ms > 0
+                      ? Math.min(100, Math.round((reg.p95_ms / 3000) * 100))
+                      : 0;
+                    const p95 = reg.p95_ms > 0
+                      ? reg.p95_ms < 1000
+                        ? `${Math.round(reg.p95_ms)}ms`
+                        : `${(reg.p95_ms / 1000).toFixed(1)}s`
+                      : "—";
+                    return (
+                      <tr key={reg.region_id} className="border-t border-[var(--ink-600)] first:border-t-0">
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-[3px]">
+                            <span className={`h-2 w-2 flex-shrink-0 rounded-full ${dotColor}`} />
+                            <span className="font-mono text-[12px] text-[var(--ink-300)]">
+                              {reg.region_id}
+                            </span>
+                          </div>
+                        </td>
+                        <td className={`px-4 py-3 text-right font-mono tabular-nums text-[12px] ${uptimeColor}`}>
+                          {(reg.uptime_24h * 100).toFixed(1)}%
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center justify-end gap-2.5">
+                            <div className="h-1.5 w-24 overflow-hidden rounded-full bg-[var(--ink-600)]">
+                              <div
+                                className={`h-full rounded-full ${barColor}`}
+                                style={{ width: `${barWidth}%` }}
+                              />
+                            </div>
+                            <span className="w-12 text-right font-mono tabular-nums text-[12px] text-[var(--ink-400)]">
+                              {p95}
+                            </span>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+              </tbody>
+            </table>
           </div>
         </section>
       )}
 
-      {/* Latency bar */}
-      {history !== null && history.some((b) => b.p95_ms > 0) && (
-        <section className="mb-8">
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-            Latency (p95)
-          </h2>
-          <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] px-4 py-4">
-            <LatencyBar buckets={history} days={30} />
-          </div>
-        </section>
-      )}
-
-      {/* Models */}
+      {/* Per-model stats */}
       <section>
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
-          Monitored Models
+          Models
         </h2>
-        <ModelList models={provider.models} />
+        <ModelStatsTable models={provider.model_stats ?? []} />
       </section>
     </main>
   );

--- a/web/components/LatencyBar.tsx
+++ b/web/components/LatencyBar.tsx
@@ -1,60 +1,78 @@
-import type { HistoryBucket } from "@/lib/api";
+import type { HistoryBucket, HistoryWindow } from "@/lib/api";
 
 interface Props {
   buckets: HistoryBucket[];
+  window?: HistoryWindow;
+  /** Legacy: number of daily slots; ignored when `window` is set. */
   days?: number;
 }
 
-// Reference ceiling for bar scaling. Bars at or above this value fill 100% height.
+type Config = { count: number; keyLen: number; label: string; granularity: "hour" | "day" };
+
+function windowConfig(w: HistoryWindow | undefined, days: number): Config {
+  switch (w) {
+    case "24h": return { count: 24, keyLen: 13, label: "p95 latency — 24h",     granularity: "hour" };
+    case "7d":  return { count: 7,  keyLen: 10, label: "p95 latency — 7 days",  granularity: "day"  };
+    default:    return { count: days, keyLen: 10, label: `p95 latency — ${days} days`, granularity: "day" };
+  }
+}
+
+function makeSlots(cfg: Config): string[] {
+  const slots: string[] = [];
+  const now = new Date();
+  for (let i = cfg.count - 1; i >= 0; i--) {
+    const d = new Date(now);
+    if (cfg.granularity === "hour") {
+      d.setUTCHours(d.getUTCHours() - i, 0, 0, 0);
+    } else {
+      d.setUTCDate(d.getUTCDate() - i);
+    }
+    slots.push(d.toISOString().slice(0, cfg.keyLen));
+  }
+  return slots;
+}
+
+function formatSlot(key: string, granularity: "hour" | "day"): string {
+  if (granularity === "hour") {
+    return `${key.slice(11, 13)}:00`;
+  }
+  return new Date(key + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short", day: "numeric", timeZone: "UTC",
+  });
+}
+
 const CEILING_MS = 3000;
 
 function latencyColor(p95Ms: number, hasData: boolean): string {
   if (!hasData) return "bg-[var(--ink-600)]";
-  if (p95Ms <= 500) return "bg-[var(--signal-ok)]";
+  if (p95Ms <= 500)  return "bg-[var(--signal-ok)]";
   if (p95Ms <= 2000) return "bg-[var(--signal-warn)]";
   return "bg-[var(--signal-down)]";
 }
 
 function formatMs(ms: number): string {
-  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
-  return `${Math.round(ms)}ms`;
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${Math.round(ms)}ms`;
 }
 
-function formatDay(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
-}
+export function LatencyBar({ buckets, window, days = 30 }: Props) {
+  const cfg = windowConfig(window, days);
+  const slots = makeSlots(cfg);
 
-export function LatencyBar({ buckets, days = 30 }: Props) {
-  const byDay = new Map<string, HistoryBucket>();
+  const bySlot = new Map<string, HistoryBucket>();
   for (const b of buckets) {
-    byDay.set(b.timestamp.slice(0, 10), b);
+    bySlot.set(b.timestamp.slice(0, cfg.keyLen), b);
   }
 
-  const slots: string[] = [];
-  const now = new Date();
-  for (let i = days - 1; i >= 0; i--) {
-    const d = new Date(now);
-    d.setUTCDate(d.getUTCDate() - i);
-    slots.push(d.toISOString().slice(0, 10));
-  }
-
-  // Summary: median p95 across all buckets that have data.
   const withData = buckets.filter((b) => b.total > 0 && b.p95_ms > 0);
   const medianP95 =
     withData.length === 0
       ? null
-      : withData
-          .map((b) => b.p95_ms)
-          .sort((a, b) => a - b)[Math.floor(withData.length / 2)];
+      : withData.map((b) => b.p95_ms).sort((a, b) => a - b)[Math.floor(withData.length / 2)];
 
   return (
     <div>
       <div className="mb-2 flex items-center justify-between text-xs text-[var(--ink-400)]">
-        <span>p95 latency — 30 days</span>
+        <span>{cfg.label}</span>
         {medianP95 !== null && (
           <span className="font-medium text-[var(--ink-200)]">
             {formatMs(medianP95)} median
@@ -62,22 +80,22 @@ export function LatencyBar({ buckets, days = 30 }: Props) {
         )}
       </div>
 
-      <div className="flex h-10 items-end gap-px" aria-label="30-day p95 latency chart">
-        {slots.map((day) => {
-          const b = byDay.get(day);
+      <div className="flex h-10 items-end gap-px" aria-label={`${cfg.label} chart`}>
+        {slots.map((slot) => {
+          const b = bySlot.get(slot);
           const hasData = b !== undefined && b.total > 0 && b.p95_ms > 0;
           const p95 = b?.p95_ms ?? 0;
           const color = latencyColor(p95, hasData);
           const label = hasData
-            ? `${formatDay(day)}: ${formatMs(p95)} p95`
-            : `${formatDay(day)}: no data`;
+            ? `${formatSlot(slot, cfg.granularity)}: ${formatMs(p95)} p95`
+            : `${formatSlot(slot, cfg.granularity)}: no data`;
           const heightPct = hasData
             ? Math.max(10, Math.min(100, Math.round((p95 / CEILING_MS) * 100)))
             : 20;
 
           return (
             <div
-              key={day}
+              key={slot}
               title={label}
               className={`flex-1 rounded-sm ${color}`}
               style={{ height: `${heightPct}%` }}
@@ -88,8 +106,8 @@ export function LatencyBar({ buckets, days = 30 }: Props) {
       </div>
 
       <div className="mt-1 flex justify-between text-xs text-[var(--ink-500)]">
-        <span>{formatDay(slots[0])}</span>
-        <span>{formatDay(slots[slots.length - 1])}</span>
+        <span>{formatSlot(slots[0], cfg.granularity)}</span>
+        <span>{formatSlot(slots[slots.length - 1], cfg.granularity)}</span>
       </div>
     </div>
   );

--- a/web/components/LatencySparkline.tsx
+++ b/web/components/LatencySparkline.tsx
@@ -2,6 +2,7 @@ interface Props {
   data: number[];   // 60 avg_ms values; 0 means no data
   width?: number;
   height?: number;
+  className?: string; // applied to the <svg> element; use "w-full" to fill container
 }
 
 // buildPath converts 60 avg_ms values into an SVG path string.
@@ -30,7 +31,7 @@ function buildPath(data: number[], w: number, h: number): string {
   return d;
 }
 
-export function LatencySparkline({ data, width = 88, height = 28 }: Props) {
+export function LatencySparkline({ data, width = 88, height = 28, className }: Props) {
   const d = buildPath(data, width, height);
   if (!d) {
     return <span className="text-[10px] text-[var(--ink-500)]">no data</span>;
@@ -38,9 +39,11 @@ export function LatencySparkline({ data, width = 88, height = 28 }: Props) {
 
   return (
     <svg
-      width={width}
+      width={className ? undefined : width}
       height={height}
       viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className={className}
       aria-hidden="true"
     >
       <path

--- a/web/components/ModelStatsTable.tsx
+++ b/web/components/ModelStatsTable.tsx
@@ -1,0 +1,71 @@
+import type { ModelStat } from "@/lib/api";
+import { LatencySparkline } from "./LatencySparkline";
+
+function uptimeColor(u: number): string {
+  if (u >= 0.995) return "text-[var(--signal-ok)]";
+  if (u >= 0.95)  return "text-[var(--signal-warn)]";
+  return "text-[var(--signal-down)]";
+}
+
+function formatP95(ms: number): string {
+  if (ms <= 0) return "—";
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function ModelStatsTable({ models }: { models: ModelStat[] }) {
+  if (models.length === 0) {
+    return <p className="text-sm text-[var(--ink-400)]">No probe data yet.</p>;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[var(--ink-600)]">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-[var(--ink-600)] bg-[var(--canvas-sunken)]">
+            <th className="px-4 py-2.5 text-left text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+              Model
+            </th>
+            <th className="px-4 py-2.5 text-right text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+              Uptime 24h
+            </th>
+            <th className="px-4 py-2.5 text-right text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+              p95
+            </th>
+            <th className="px-4 py-2.5 text-right text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+              Latency 24h
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {models.map((m) => (
+            <tr
+              key={m.model_id}
+              className="border-t border-[var(--ink-600)] first:border-t-0 bg-[var(--canvas-raised)]"
+            >
+              <td className="px-4 py-2.5">
+                <span
+                  className="block font-mono text-[12px] text-[var(--ink-200)]"
+                  title={m.model_id}
+                >
+                  {m.display_name}
+                </span>
+                <span className="block font-mono text-[10px] text-[var(--ink-500)]">
+                  {m.model_id}
+                </span>
+              </td>
+              <td className={`px-4 py-2.5 text-right font-mono tabular-nums text-[12px] ${uptimeColor(m.uptime_24h)}`}>
+                {(m.uptime_24h * 100).toFixed(1)}%
+              </td>
+              <td className="px-4 py-2.5 text-right font-mono tabular-nums text-[12px] text-[var(--ink-400)]">
+                {formatP95(m.p95_ms)}
+              </td>
+              <td className="px-4 py-2.5 text-right">
+                <LatencySparkline data={m.sparkline} width={96} height={24} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/components/ProviderCard.tsx
+++ b/web/components/ProviderCard.tsx
@@ -20,7 +20,7 @@ function StatusPill({ status }: { status: string }) {
   );
 }
 
-// ── Uptime badge (per-model) ────────────────────────────────────────────────
+// ── Stat cell ──────────────────────────────────────────────────────────────
 
 function uptimeColor(u: number): string {
   if (u >= 0.995) return "text-[var(--signal-ok)]";
@@ -28,37 +28,35 @@ function uptimeColor(u: number): string {
   return "text-[var(--signal-down)]";
 }
 
-function UptimeBadge({ uptime }: { uptime: number }) {
-  const pct = (uptime * 100).toFixed(1);
+function StatCell({ label, value, colorClass }: { label: string; value: string; colorClass?: string }) {
   return (
-    <span className={`text-[11px] font-mono tabular-nums ${uptimeColor(uptime)}`}>
-      {pct}%
-    </span>
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[9px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+        {label}
+      </span>
+      <span className={`text-sm font-mono tabular-nums ${colorClass ?? "text-[var(--ink-300)]"}`}>
+        {value}
+      </span>
+    </div>
   );
 }
 
-// ── Model row ──────────────────────────────────────────────────────────────
+// ── Provider-level sparkline ───────────────────────────────────────────────
+// Average non-zero avg_ms values across all models per time bucket.
 
-function ModelRow({ m }: { m: ModelStat }) {
-  return (
-    <div className="flex items-center gap-2 py-1.5 border-t border-[var(--ink-600)] first:border-t-0">
-      <span
-        className="flex-1 truncate text-[11px] text-[var(--ink-300)] font-mono"
-        title={m.model_id}
-      >
-        {m.display_name}
-      </span>
-      <UptimeBadge uptime={m.uptime_24h} />
-      <LatencySparkline data={m.sparkline} width={72} height={22} />
-      {m.p95_ms > 0 && (
-        <span className="w-[42px] text-right text-[11px] font-mono tabular-nums text-[var(--ink-400)]">
-          {m.p95_ms < 1000
-            ? `${Math.round(m.p95_ms)}ms`
-            : `${(m.p95_ms / 1000).toFixed(1)}s`}
-        </span>
-      )}
-    </div>
-  );
+function aggregateSparklines(modelStats: ModelStat[]): number[] {
+  const BUCKETS = 60;
+  const sums = new Array<number>(BUCKETS).fill(0);
+  const counts = new Array<number>(BUCKETS).fill(0);
+  for (const m of modelStats) {
+    for (let i = 0; i < BUCKETS; i++) {
+      if (m.sparkline[i] > 0) {
+        sums[i] += m.sparkline[i];
+        counts[i]++;
+      }
+    }
+  }
+  return sums.map((s, i) => (counts[i] > 0 ? s / counts[i] : 0));
 }
 
 // ── Provider card ──────────────────────────────────────────────────────────
@@ -68,29 +66,61 @@ interface Props {
 }
 
 export function ProviderCard({ provider: p }: Props) {
+  const uptime = p.uptime_24h !== undefined
+    ? (p.uptime_24h * 100).toFixed(1) + "%"
+    : "—";
+
+  const p95 = p.p95_ms !== undefined
+    ? p.p95_ms < 1000
+      ? `${Math.round(p.p95_ms)}ms`
+      : `${(p.p95_ms / 1000).toFixed(1)}s`
+    : "—";
+
+  const modelNames = (p.model_stats ?? []).map((m) => m.display_name);
+  const sparkline = aggregateSparklines(p.model_stats ?? []);
+
   return (
     <Link
       href={`/providers/${p.id}`}
-      className="block rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)]
+      className="flex flex-col rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)]
                  hover:border-[var(--ink-500)] hover:bg-[var(--canvas-overlay)]
                  transition-colors"
     >
-      {/* Card header */}
+      {/* Header */}
       <div className="flex items-center justify-between px-4 py-3">
         <span className="text-sm font-semibold text-[var(--ink-100)]">{p.name}</span>
         <StatusPill status={p.current_status} />
       </div>
 
-      {/* Model rows */}
-      {p.model_stats.length > 0 ? (
-        <div className="px-4 pb-3">
-          {p.model_stats.map((m) => (
-            <ModelRow key={m.model_id} m={m} />
-          ))}
+      {/* Stats + sparkline */}
+      <div className="flex items-end gap-4 border-t border-[var(--ink-600)] px-4 py-3">
+        <StatCell
+          label="Uptime 24h"
+          value={uptime}
+          colorClass={p.uptime_24h !== undefined ? uptimeColor(p.uptime_24h) : "text-[var(--ink-500)]"}
+        />
+        <StatCell label="p95" value={p95} />
+        <div className="flex-1">
+          <LatencySparkline data={sparkline} width={200} height={28} className="w-full" />
         </div>
-      ) : (
-        <div className="px-4 pb-3">
-          <p className="text-[11px] text-[var(--ink-500)]">No probe data yet.</p>
+      </div>
+
+      {/* Model tags */}
+      {modelNames.length > 0 && (
+        <div className="flex flex-wrap gap-1 border-t border-[var(--ink-600)] px-4 pb-3 pt-2">
+          {modelNames.slice(0, 4).map((name) => (
+            <span
+              key={name}
+              className="rounded bg-[var(--canvas-overlay)] px-1.5 py-0.5 text-[10px] text-[var(--ink-500)]"
+            >
+              {name}
+            </span>
+          ))}
+          {modelNames.length > 4 && (
+            <span className="px-1 py-0.5 text-[10px] text-[var(--ink-600)]">
+              +{modelNames.length - 4} more
+            </span>
+          )}
         </div>
       )}
     </Link>

--- a/web/components/UptimeSparkline.tsx
+++ b/web/components/UptimeSparkline.tsx
@@ -1,9 +1,46 @@
-import type { HistoryBucket } from "@/lib/api";
+import type { HistoryBucket, HistoryWindow } from "@/lib/api";
 
 interface Props {
   buckets: HistoryBucket[];
-  /** Number of days to show; padded with empty slots when data is sparse. */
+  window?: HistoryWindow;
+  /** Legacy: number of daily slots; ignored when `window` is set. */
   days?: number;
+}
+
+type Config = { count: number; keyLen: number; label: string; granularity: "hour" | "day" };
+
+function windowConfig(w: HistoryWindow | undefined, days: number): Config {
+  switch (w) {
+    case "24h": return { count: 24, keyLen: 13, label: "24h uptime",    granularity: "hour" };
+    case "7d":  return { count: 7,  keyLen: 10, label: "7-day uptime",  granularity: "day"  };
+    default:    return { count: days, keyLen: 10, label: `${days}-day uptime`, granularity: "day" };
+  }
+}
+
+function makeSlots(cfg: Config): string[] {
+  const slots: string[] = [];
+  const now = new Date();
+  for (let i = cfg.count - 1; i >= 0; i--) {
+    const d = new Date(now);
+    if (cfg.granularity === "hour") {
+      d.setUTCHours(d.getUTCHours() - i, 0, 0, 0);
+    } else {
+      d.setUTCDate(d.getUTCDate() - i);
+    }
+    slots.push(d.toISOString().slice(0, cfg.keyLen));
+  }
+  return slots;
+}
+
+function formatSlot(key: string, granularity: "hour" | "day"): string {
+  if (granularity === "hour") {
+    // key like "2026-04-19T14" → "14:00"
+    const hour = key.slice(11, 13);
+    return `${hour}:00`;
+  }
+  return new Date(key + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short", day: "numeric", timeZone: "UTC",
+  });
 }
 
 function uptimeColor(uptime: number, hasData: boolean): string {
@@ -13,37 +50,13 @@ function uptimeColor(uptime: number, hasData: boolean): string {
   return "bg-[var(--signal-down)]";
 }
 
-function uptimeHeight(uptime: number, hasData: boolean): string {
-  if (!hasData) return "h-2"; // gray stub for missing data
-  // Map 0–1 uptime to 20–100% of container height (always at least a sliver)
-  const pct = Math.max(20, Math.round(uptime * 100));
-  // Tailwind can't interpolate arbitrary values at runtime, so use inline style.
-  return `h-[${pct}%]`;
-}
+export function UptimeSparkline({ buckets, window, days = 30 }: Props) {
+  const cfg = windowConfig(window, days);
+  const slots = makeSlots(cfg);
 
-function formatDay(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
-}
-
-export function UptimeSparkline({ buckets, days = 30 }: Props) {
-  // Build a day-keyed map for O(1) lookup.
-  const byDay = new Map<string, HistoryBucket>();
+  const bySlot = new Map<string, HistoryBucket>();
   for (const b of buckets) {
-    const key = b.timestamp.slice(0, 10); // "YYYY-MM-DD"
-    byDay.set(key, b);
-  }
-
-  // Generate the last `days` day keys in ascending order.
-  const slots: string[] = [];
-  const now = new Date();
-  for (let i = days - 1; i >= 0; i--) {
-    const d = new Date(now);
-    d.setUTCDate(d.getUTCDate() - i);
-    slots.push(d.toISOString().slice(0, 10));
+    bySlot.set(b.timestamp.slice(0, cfg.keyLen), b);
   }
 
   const overall =
@@ -53,9 +66,8 @@ export function UptimeSparkline({ buckets, days = 30 }: Props) {
 
   return (
     <div>
-      {/* Summary line */}
       <div className="mb-2 flex items-center justify-between text-xs text-[var(--ink-400)]">
-        <span>30-day uptime</span>
+        <span>{cfg.label}</span>
         {overall !== null && (
           <span className="font-medium text-[var(--ink-200)]">
             {(overall * 100).toFixed(2)} %
@@ -63,21 +75,20 @@ export function UptimeSparkline({ buckets, days = 30 }: Props) {
         )}
       </div>
 
-      {/* Bars */}
-      <div className="flex h-10 items-end gap-px" aria-label="30-day uptime chart">
-        {slots.map((day) => {
-          const b = byDay.get(day);
+      <div className="flex h-10 items-end gap-px" aria-label={`${cfg.label} chart`}>
+        {slots.map((slot) => {
+          const b = bySlot.get(slot);
           const hasData = b !== undefined && b.total > 0;
           const uptime = b?.uptime ?? 0;
           const color = uptimeColor(uptime, hasData);
           const label = hasData
-            ? `${formatDay(day)}: ${(uptime * 100).toFixed(1)}% uptime`
-            : `${formatDay(day)}: no data`;
+            ? `${formatSlot(slot, cfg.granularity)}: ${(uptime * 100).toFixed(1)}% uptime`
+            : `${formatSlot(slot, cfg.granularity)}: no data`;
           const heightPct = hasData ? Math.max(20, Math.round(uptime * 100)) : 20;
 
           return (
             <div
-              key={day}
+              key={slot}
               title={label}
               className={`flex-1 rounded-sm ${color}`}
               style={{ height: `${heightPct}%` }}
@@ -87,10 +98,9 @@ export function UptimeSparkline({ buckets, days = 30 }: Props) {
         })}
       </div>
 
-      {/* Axis labels */}
       <div className="mt-1 flex justify-between text-xs text-[var(--ink-500)]">
-        <span>{formatDay(slots[0])}</span>
-        <span>{formatDay(slots[slots.length - 1])}</span>
+        <span>{formatSlot(slots[0], cfg.granularity)}</span>
+        <span>{formatSlot(slots[slots.length - 1], cfg.granularity)}</span>
       </div>
     </div>
   );

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -32,7 +32,7 @@ export interface ProviderSummary {
   active_incident_id?: string;
   uptime_24h?: number;    // 0–1; omitted when live stats unavailable
   p95_ms?: number;        // p95 latency ms; omitted when unavailable
-  model_stats: ModelStat[]; // always present; empty when no probe data
+  model_stats?: ModelStat[];
 }
 
 export interface IncidentRef {
@@ -51,11 +51,18 @@ export interface ModelSummary {
   active: boolean;
 }
 
+export interface RegionStat {
+  region_id: string;
+  uptime_24h: number; // 0–1
+  p95_ms: number;     // p95 latency ms; 0 when no data
+}
+
 export interface ProviderDetail extends ProviderSummary {
   status_page_url?: string;
   documentation_url?: string;
   models: ModelSummary[];
   active_incidents: IncidentRef[];
+  region_stats?: RegionStat[];
 }
 
 export type IncidentStatus = "ongoing" | "monitoring" | "resolved";


### PR DESCRIPTION
## Summary
- `getProvider` now populates `model_stats` (was always null — backend called `buildModelStats` in `listProviders` but not `getProvider`)
- New `ModelStatsTable` component: uptime %, p95, 24h sparkline per model
- `HistorySection` client component with 24h / 7d / 30d tab selector (server action for refetch, opacity fade during transition)
- `UptimeSparkline` + `LatencyBar` accept a `window` prop — hourly slots for 24h, daily for 7d/30d
- Regional Status table redesigned: status dot (●), latency inline bar sorted worst-first, column renamed "Probe region" to avoid confusion with `provider.region` (now shown as "Coverage: X")
- InfluxDB: `RegionLiveStat` type + `ProviderRegionStats()` query grouped by `region_id`
- `seed_dev.sh`: 4 probe regions with realistic latency multipliers
- `model_stats` / `region_stats` made optional in TypeScript to survive cached responses from older binary

## Test plan
- [ ] `/providers/anthropic` shows model table with uptime, p95, sparklines
- [ ] History tab selector switches between 24h (hourly bars) / 7d / 30d
- [ ] Regional Status shows dots, latency bars, sorted worst-first
- [ ] No regression on homepage provider cards
- [ ] `go test ./...` passes

Closes #103