### PR TITLE
feat LLMS-048: user report signal + community probe types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ pnpm-debug.log*
 
 # Docker
 docker-compose.override.yml
+data/
 
 # Go compiled binaries (build artifacts — never commit)
 /api
@@ -62,3 +63,6 @@ docker-compose.override.yml
 
 # Ansible production inventory (contains live IPs — use hosts.yml.example as template)
 deploy/ansible/inventories/prod/hosts.yml
+
+# Ansible vault (plain-text secrets — keep locally, never commit unencrypted)
+deploy/ansible/group_vars/all/vault.yml

--- a/deploy/ansible/group_vars/all/vars.yml
+++ b/deploy/ansible/group_vars/all/vars.yml
@@ -9,3 +9,6 @@ ingest_url: "https://llmstatus.io/ingest"
 
 # Go binary version tag to deploy
 app_version: main
+
+# Region ID for the main server probe node
+main_region_id: us-west-2

--- a/deploy/ansible/roles/main-server/templates/env.j2
+++ b/deploy/ansible/roles/main-server/templates/env.j2
@@ -5,18 +5,15 @@ POSTGRES_USER=llmstatus
 POSTGRES_PASSWORD={{ postgres_password }}
 POSTGRES_DB=llmstatus
 DATABASE_URL=postgres://llmstatus:{{ postgres_password }}@db:5432/llmstatus
+POSTGRES_DATA_DIR={{ data_dir }}/postgres
 
 # InfluxDB
 INFLUX_URL=http://influx:8086
+INFLUX_HOST=http://influx:8181
 INFLUX_TOKEN={{ influx_token }}
 INFLUX_ORG=llmstatus
-INFLUX_BUCKET=probes
-DOCKER_INFLUXDB_INIT_MODE=setup
-DOCKER_INFLUXDB_INIT_USERNAME=admin
-DOCKER_INFLUXDB_INIT_PASSWORD={{ influx_admin_password }}
-DOCKER_INFLUXDB_INIT_ORG=llmstatus
-DOCKER_INFLUXDB_INIT_BUCKET=probes
-DOCKER_INFLUXDB_INIT_ADMIN_TOKEN={{ influx_token }}
+INFLUX_DATABASE=probes
+INFLUX_DATA_DIR={{ data_dir }}/influx
 
 # Redis
 REDIS_URL=redis://redis:6379
@@ -28,27 +25,70 @@ INGEST_SECRET={{ ingest_secret }}
 # Site
 NEXT_PUBLIC_SITE_URL=https://llmstatus.io
 
-# Provider API keys
+# Probe node
+REGION_ID=us-west-2
+
+# Provider API keys — omitted when vault value is false (provider skipped by init)
+{% if llms_openai_api_key %}
 LLMS_OPENAI_API_KEY={{ llms_openai_api_key }}
+{% endif %}
+{% if llms_anthropic_api_key %}
 LLMS_ANTHROPIC_API_KEY={{ llms_anthropic_api_key }}
+{% endif %}
+{% if llms_gemini_api_key %}
 LLMS_GEMINI_API_KEY={{ llms_gemini_api_key }}
+{% endif %}
+{% if llms_deepseek_api_key %}
 LLMS_DEEPSEEK_API_KEY={{ llms_deepseek_api_key }}
+{% endif %}
+{% if llms_mistral_api_key %}
 LLMS_MISTRAL_API_KEY={{ llms_mistral_api_key }}
+{% endif %}
+{% if llms_groq_api_key %}
 LLMS_GROQ_API_KEY={{ llms_groq_api_key }}
+{% endif %}
+{% if llms_xai_api_key %}
 LLMS_XAI_API_KEY={{ llms_xai_api_key }}
+{% endif %}
+{% if llms_together_api_key %}
 LLMS_TOGETHER_API_KEY={{ llms_together_api_key }}
+{% endif %}
+{% if llms_perplexity_api_key %}
 LLMS_PERPLEXITY_API_KEY={{ llms_perplexity_api_key }}
+{% endif %}
+{% if llms_cohere_api_key %}
 LLMS_COHERE_API_KEY={{ llms_cohere_api_key }}
+{% endif %}
+{% if llms_fireworks_api_key %}
 LLMS_FIREWORKS_API_KEY={{ llms_fireworks_api_key }}
+{% endif %}
+{% if llms_huggingface_api_key %}
 LLMS_HUGGINGFACE_API_KEY={{ llms_huggingface_api_key }}
+{% endif %}
+{% if llms_minimax_api_key %}
 LLMS_MINIMAX_API_KEY={{ llms_minimax_api_key }}
+{% endif %}
+{% if llms_doubao_api_key %}
 LLMS_DOUBAO_API_KEY={{ llms_doubao_api_key }}
+{% endif %}
+{% if llms_azure_openai_api_key %}
 LLMS_AZURE_OPENAI_API_KEY={{ llms_azure_openai_api_key }}
 LLMS_AZURE_OPENAI_RESOURCE={{ llms_azure_openai_resource }}
 LLMS_AZURE_OPENAI_DEPLOYMENT={{ llms_azure_openai_deployment }}
 LLMS_AZURE_OPENAI_API_VERSION=2024-10-21
+{% endif %}
+{% if llms_ai21_api_key %}
 LLMS_AI21_API_KEY={{ llms_ai21_api_key }}
+{% endif %}
+{% if llms_moonshot_api_key %}
 LLMS_MOONSHOT_API_KEY={{ llms_moonshot_api_key }}
+{% endif %}
+{% if llms_zhipu_api_key %}
 LLMS_ZHIPU_API_KEY={{ llms_zhipu_api_key }}
+{% endif %}
+{% if llms_qwen_api_key %}
 LLMS_QWEN_API_KEY={{ llms_qwen_api_key }}
+{% endif %}
+{% if llms_zeroone_api_key %}
 LLMS_ZEROONE_API_KEY={{ llms_zeroone_api_key }}
+{% endif %}

--- a/deploy/ansible/roles/main-server/templates/nginx.conf.j2
+++ b/deploy/ansible/roles/main-server/templates/nginx.conf.j2
@@ -23,29 +23,29 @@ server {
 
     # ── Go API (/v1/*, /badge/*, /feed.xml) ──────────────────────────────
     location /v1/ {
-        proxy_pass http://127.0.0.1:8081;
+        proxy_pass http://127.0.0.1:18081;
         proxy_read_timeout 10s;
     }
 
     location /badge/ {
-        proxy_pass http://127.0.0.1:8081;
+        proxy_pass http://127.0.0.1:18081;
         proxy_read_timeout 5s;
     }
 
     location = /feed.xml {
-        proxy_pass http://127.0.0.1:8081;
+        proxy_pass http://127.0.0.1:18081;
         proxy_read_timeout 5s;
     }
 
     # ── Ingest API (probe nodes push here with INGEST_SECRET header) ──────
     location /ingest/ {
-        proxy_pass http://127.0.0.1:8080;
+        proxy_pass http://127.0.0.1:18080;
         proxy_read_timeout 10s;
     }
 
     # ── Next.js frontend (everything else) ───────────────────────────────
     location / {
-        proxy_pass http://127.0.0.1:3000;
+        proxy_pass http://127.0.0.1:13000;
         proxy_read_timeout 30s;
         proxy_buffering off;
     }

--- a/deploy/ansible/roles/probe/templates/prober.env.j2
+++ b/deploy/ansible/roles/probe/templates/prober.env.j2
@@ -2,15 +2,67 @@ NODE_NAME={{ probe_node_name }}
 INGEST_URL={{ ingest_url }}
 INGEST_SECRET={{ ingest_secret }}
 
+# Provider API keys — omitted when vault value is false (provider skipped by init)
+{% if llms_openai_api_key %}
 LLMS_OPENAI_API_KEY={{ llms_openai_api_key }}
+{% endif %}
+{% if llms_anthropic_api_key %}
 LLMS_ANTHROPIC_API_KEY={{ llms_anthropic_api_key }}
+{% endif %}
+{% if llms_gemini_api_key %}
 LLMS_GEMINI_API_KEY={{ llms_gemini_api_key }}
+{% endif %}
+{% if llms_deepseek_api_key %}
 LLMS_DEEPSEEK_API_KEY={{ llms_deepseek_api_key }}
+{% endif %}
+{% if llms_mistral_api_key %}
 LLMS_MISTRAL_API_KEY={{ llms_mistral_api_key }}
+{% endif %}
+{% if llms_groq_api_key %}
 LLMS_GROQ_API_KEY={{ llms_groq_api_key }}
+{% endif %}
+{% if llms_xai_api_key %}
 LLMS_XAI_API_KEY={{ llms_xai_api_key }}
+{% endif %}
+{% if llms_together_api_key %}
 LLMS_TOGETHER_API_KEY={{ llms_together_api_key }}
+{% endif %}
+{% if llms_perplexity_api_key %}
 LLMS_PERPLEXITY_API_KEY={{ llms_perplexity_api_key }}
+{% endif %}
+{% if llms_cohere_api_key %}
 LLMS_COHERE_API_KEY={{ llms_cohere_api_key }}
+{% endif %}
+{% if llms_fireworks_api_key %}
 LLMS_FIREWORKS_API_KEY={{ llms_fireworks_api_key }}
+{% endif %}
+{% if llms_huggingface_api_key %}
 LLMS_HUGGINGFACE_API_KEY={{ llms_huggingface_api_key }}
+{% endif %}
+{% if llms_minimax_api_key %}
+LLMS_MINIMAX_API_KEY={{ llms_minimax_api_key }}
+{% endif %}
+{% if llms_doubao_api_key %}
+LLMS_DOUBAO_API_KEY={{ llms_doubao_api_key }}
+{% endif %}
+{% if llms_azure_openai_api_key %}
+LLMS_AZURE_OPENAI_API_KEY={{ llms_azure_openai_api_key }}
+LLMS_AZURE_OPENAI_RESOURCE={{ llms_azure_openai_resource }}
+LLMS_AZURE_OPENAI_DEPLOYMENT={{ llms_azure_openai_deployment }}
+LLMS_AZURE_OPENAI_API_VERSION=2024-10-21
+{% endif %}
+{% if llms_ai21_api_key %}
+LLMS_AI21_API_KEY={{ llms_ai21_api_key }}
+{% endif %}
+{% if llms_moonshot_api_key %}
+LLMS_MOONSHOT_API_KEY={{ llms_moonshot_api_key }}
+{% endif %}
+{% if llms_zhipu_api_key %}
+LLMS_ZHIPU_API_KEY={{ llms_zhipu_api_key }}
+{% endif %}
+{% if llms_qwen_api_key %}
+LLMS_QWEN_API_KEY={{ llms_qwen_api_key }}
+{% endif %}
+{% if llms_zeroone_api_key %}
+LLMS_ZEROONE_API_KEY={{ llms_zeroone_api_key }}
+{% endif %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,7 @@
 #   influx   — InfluxDB 3 Core      host:18086 → container:8181
 #   ingest   — probe ingest API     host:18080 → container:8080
 #   api      — public read API      host:18081 → container:8081
-#
-# Next.js dev server runs OUTSIDE Docker:
-#   cd web && npm run dev           (reads web/.env.local, listens on :13000)
+#   web      — Next.js frontend     host:13000 → container:3000
 #
 # First-time setup:
 #   cp .env.example .env
@@ -23,7 +21,7 @@
 #   cd web && npm run dev          # browser → http://localhost:13000
 #
 # Usage:
-#   docker compose up -d            # start backend (db, influx, api, ingest, detector)
+#   docker compose up -d            # start all services
 #   docker compose logs -f api      # tail a service
 #   docker compose down -v          # stop and wipe volumes
 
@@ -37,10 +35,10 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: llmstatus
-      POSTGRES_PASSWORD: llmstatus
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-llmstatus}
       POSTGRES_DB: llmstatus
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - ${POSTGRES_DATA_DIR:-./data/postgres}:/var/lib/postgresql/data
     ports:
       - "15432:5432"
     healthcheck:
@@ -53,11 +51,11 @@ services:
     image: influxdb:3-core
     container_name: llmstatus-influx
     restart: unless-stopped
-    command: serve --without-auth   # dev only; prod uses token auth
+    command: serve --without-auth
     environment:
-      INFLUXDB3_NODE_IDENTIFIER_PREFIX: local-dev
+      INFLUXDB3_NODE_IDENTIFIER_PREFIX: ${REGION_ID:-local-dev}
     volumes:
-      - influx_data:/var/lib/influxdb3
+      - ${INFLUX_DATA_DIR:-./data/influx}:/var/lib/influxdb3
     ports:
       - "18086:8181"
     healthcheck:
@@ -76,7 +74,7 @@ services:
         CMD: migrate
     container_name: llmstatus-migrate
     environment:
-      DATABASE_URL: pgx5://llmstatus:llmstatus@db:5432/llmstatus?sslmode=disable
+      DATABASE_URL: pgx5://llmstatus:${POSTGRES_PASSWORD:-llmstatus}@db:5432/llmstatus?sslmode=disable
     depends_on:
       db:
         condition: service_healthy
@@ -95,7 +93,7 @@ services:
     environment:
       INFLUX_HOST: http://influx:8181
       INFLUX_TOKEN: ${INFLUX_TOKEN:-dev-token}
-      INFLUX_DATABASE: ${INFLUX_DATABASE:-llmstatus}
+      INFLUX_DATABASE: ${INFLUX_DATABASE:-probes}
       INGEST_ADDR: ":8080"
     depends_on:
       influx:
@@ -112,10 +110,10 @@ services:
     container_name: llmstatus-detector
     restart: unless-stopped
     environment:
-      DATABASE_URL: postgres://llmstatus:llmstatus@db:5432/llmstatus?sslmode=disable
+      DATABASE_URL: postgres://llmstatus:${POSTGRES_PASSWORD:-llmstatus}@db:5432/llmstatus?sslmode=disable
       INFLUX_HOST: http://influx:8181
       INFLUX_TOKEN: ${INFLUX_TOKEN:-dev-token}
-      INFLUX_DATABASE: ${INFLUX_DATABASE:-llmstatus}
+      INFLUX_DATABASE: ${INFLUX_DATABASE:-probes}
       DETECTOR_INTERVAL: ${DETECTOR_INTERVAL:-60s}
     depends_on:
       db:
@@ -132,10 +130,10 @@ services:
     container_name: llmstatus-api
     restart: unless-stopped
     environment:
-      DATABASE_URL: postgres://llmstatus:llmstatus@db:5432/llmstatus?sslmode=disable
+      DATABASE_URL: postgres://llmstatus:${POSTGRES_PASSWORD:-llmstatus}@db:5432/llmstatus?sslmode=disable
       INFLUX_HOST: http://influx:8181
       INFLUX_TOKEN: ${INFLUX_TOKEN:-dev-token}
-      INFLUX_DATABASE: ${INFLUX_DATABASE:-llmstatus}
+      INFLUX_DATABASE: ${INFLUX_DATABASE:-probes}
       API_ADDR: ":8081"
       API_RATE_LIMIT: ${API_RATE_LIMIT:-60}
     depends_on:
@@ -160,7 +158,7 @@ services:
     container_name: llmstatus-notifier
     restart: unless-stopped
     environment:
-      DATABASE_URL: postgres://llmstatus:llmstatus@db:5432/llmstatus?sslmode=disable
+      DATABASE_URL: postgres://llmstatus:${POSTGRES_PASSWORD:-llmstatus}@db:5432/llmstatus?sslmode=disable
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       EMAIL_FROM: ${EMAIL_FROM:-noreply@llmstatus.io}
       SITE_URL: ${SITE_URL:-https://llmstatus.io}
@@ -185,10 +183,8 @@ services:
         condition: service_healthy
     ports:
       - "13000:3000"
-    profiles:
-      - web-docker
 
-  # ── local probe runner (dev only) ──────────────────────────────────────────
+  # ── probe runner ──────────────────────────────────────────────────────────
 
   prober:
     build:
@@ -199,7 +195,7 @@ services:
     container_name: llmstatus-prober
     restart: unless-stopped
     environment:
-      DATABASE_URL: postgres://llmstatus:llmstatus@db:5432/llmstatus?sslmode=disable
+      DATABASE_URL: postgres://llmstatus:${POSTGRES_PASSWORD:-llmstatus}@db:5432/llmstatus?sslmode=disable
       REGION_ID: ${REGION_ID:-local-dev}
       PROBE_INTERVAL: ${PROBE_INTERVAL:-60s}
       PROBE_TIMEOUT: ${PROBE_TIMEOUT:-30s}
@@ -233,9 +229,3 @@ services:
         condition: service_healthy
       ingest:
         condition: service_started
-    profiles:
-      - prober
-
-volumes:
-  db_data:
-  influx_data:

--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// postReport handles POST /v1/providers/{id}/report.
+// It inserts a report for the provider keyed by the SHA-256 of the client IP.
+// The SQL query enforces a 5-minute per-IP per-provider dedup; when the insert
+// is a no-op (duplicate), we still return 204 so the client cannot probe
+// whether another user reported from the same IP.
+func (s *Server) postReport(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	// Verify provider exists; return 404 for unknown IDs.
+	if _, err := s.store.GetProvider(r.Context(), id); err != nil {
+		writeError(w, http.StatusNotFound, "provider not found")
+		return
+	}
+
+	ipHash := hashIP(r)
+	if err := s.store.InsertUserReport(r.Context(), pgstore.InsertUserReportParams{
+		ProviderID: id,
+		IpHash:     ipHash,
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "could not record report")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// getReportHistogram handles GET /v1/providers/{id}/reports/histogram.
+// Returns 24 hourly buckets (oldest first) with zero-filled gaps.
+func (s *Server) getReportHistogram(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if _, err := s.store.GetProvider(r.Context(), id); err != nil {
+		writeError(w, http.StatusNotFound, "provider not found")
+		return
+	}
+
+	rows, err := s.store.UserReportHistogram(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "could not fetch histogram")
+		return
+	}
+
+	type bucket struct {
+		Hour  time.Time `json:"hour"`
+		Count int64     `json:"count"`
+	}
+	out := make([]bucket, 0, len(rows))
+	for _, row := range rows {
+		// generate_series returns pgtype.Timestamptz at runtime; assert to time.Time.
+		t, _ := row.Bucket.(time.Time)
+		out = append(out, bucket{Hour: t.UTC(), Count: row.Count})
+	}
+	writeEnvelope(w, out)
+}
+
+// hashIP returns the hex-encoded SHA-256 of the client IP address (port stripped).
+// We never store raw IPs.
+func hashIP(r *http.Request) string {
+	addr := r.RemoteAddr
+	// Prefer X-Forwarded-For when behind a trusted proxy (nginx sets it).
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		addr = fwd
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	sum := sha256.Sum256([]byte(host))
+	return fmt.Sprintf("%x", sum)
+}

--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 
@@ -17,19 +19,13 @@ import (
 // whether another user reported from the same IP.
 func (s *Server) postReport(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-
-	// Verify provider exists; return 404 for unknown IDs.
-	if _, err := s.store.GetProvider(r.Context(), id); err != nil {
-		writeError(w, http.StatusNotFound, "provider not found")
-		return
-	}
-
 	ipHash := hashIP(r)
 	if err := s.store.InsertUserReport(r.Context(), pgstore.InsertUserReportParams{
 		ProviderID: id,
 		IpHash:     ipHash,
 	}); err != nil {
-		writeError(w, http.StatusInternalServerError, "could not record report")
+		// FK violation means unknown provider_id — treat as 404.
+		writeError(w, http.StatusNotFound, "provider not found")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -57,8 +53,13 @@ func (s *Server) getReportHistogram(w http.ResponseWriter, r *http.Request) {
 	}
 	out := make([]bucket, 0, len(rows))
 	for _, row := range rows {
-		// generate_series returns pgtype.Timestamptz at runtime; assert to time.Time.
-		t, _ := row.Bucket.(time.Time)
+		var t time.Time
+		switch v := row.Bucket.(type) {
+		case time.Time:
+			t = v
+		case pgtype.Timestamptz:
+			t = v.Time
+		}
 		out = append(out, bucket{Hour: t.UTC(), Count: row.Count})
 	}
 	writeEnvelope(w, out)
@@ -66,16 +67,19 @@ func (s *Server) getReportHistogram(w http.ResponseWriter, r *http.Request) {
 
 // hashIP returns the hex-encoded SHA-256 of the client IP address (port stripped).
 // We never store raw IPs.
+//
+// When behind nginx, X-Forwarded-For is "client, proxy1, ..., $remote_addr".
+// We take only the rightmost entry — the one nginx itself appended — which cannot
+// be spoofed by the client. Left-hand entries are client-controlled and untrusted.
 func hashIP(r *http.Request) string {
 	addr := r.RemoteAddr
-	// Prefer X-Forwarded-For when behind a trusted proxy (nginx sets it).
 	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		addr = fwd
+		parts := strings.Split(fwd, ",")
+		addr = strings.TrimSpace(parts[len(parts)-1])
 	}
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		host = addr
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		addr = host
 	}
-	sum := sha256.Sum256([]byte(host))
+	sum := sha256.Sum256([]byte(addr))
 	return fmt.Sprintf("%x", sum)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -98,6 +98,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /badge/{id}", s.getBadge)
 	s.mux.HandleFunc("GET /feed.xml", s.getGlobalFeed)
 	s.mux.HandleFunc("GET /v1/providers/{id}/feed.xml", s.getProviderFeed)
+	s.mux.HandleFunc("POST /v1/providers/{id}/report", s.postReport)
+	s.mux.HandleFunc("GET /v1/providers/{id}/reports/histogram", s.getReportHistogram)
 
 	// WebSocket for real-time updates
 	s.mux.HandleFunc("GET /ws", HandleWebSocket)

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -20,6 +20,8 @@ type Store interface {
 	ListIncidentsByStatus(ctx context.Context, arg pgstore.ListIncidentsByStatusParams) ([]pgstore.Incident, error)
 	GetIncidentByID(ctx context.Context, id uuid.UUID) (pgstore.Incident, error)
 	GetIncidentBySlug(ctx context.Context, slug string) (pgstore.Incident, error)
+	InsertUserReport(ctx context.Context, arg pgstore.InsertUserReportParams) error
+	UserReportHistogram(ctx context.Context, providerID string) ([]pgstore.UserReportHistogramRow, error)
 
 	// Sponsors
 	ListActiveSponsors(ctx context.Context) ([]pgstore.Sponsor, error)

--- a/internal/api/testhelpers_test.go
+++ b/internal/api/testhelpers_test.go
@@ -114,6 +114,14 @@ func (f *fakeStore) GetIncidentBySlug(_ context.Context, slug string) (pgstore.I
 	return pgstore.Incident{}, pgx.ErrNoRows
 }
 
+func (f *fakeStore) InsertUserReport(_ context.Context, _ pgstore.InsertUserReportParams) error {
+	return f.err
+}
+
+func (f *fakeStore) UserReportHistogram(_ context.Context, _ string) ([]pgstore.UserReportHistogramRow, error) {
+	return nil, f.err
+}
+
 func (f *fakeStore) ListActiveSponsors(_ context.Context) ([]pgstore.Sponsor, error) {
 	return nil, f.err
 }

--- a/internal/probes/adapters/anthropic.go
+++ b/internal/probes/adapters/anthropic.go
@@ -93,17 +93,13 @@ func (p *anthropicProvider) ProbeLightInference(ctx context.Context, model strin
 	return r, nil
 }
 
-func (p *anthropicProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: anthropicProviderID, ProbeType: "quality"}
-}
-
+// ProbeEmbedding: Anthropic has no embeddings API.
 func (p *anthropicProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
 	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: anthropicProviderID, ProbeType: "embedding"}
 }
 
-func (p *anthropicProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: anthropicProviderID, ProbeType: "streaming"}
-}
+// ProbeQuality and ProbeStreaming are in anthropic_quality.go and
+// anthropic_streaming.go respectively.
 
 // ---- request / response types -----------------------------------------------
 
@@ -155,6 +151,7 @@ func (p *anthropicProvider) buildLightRequest(ctx context.Context, model string)
 	req.Header.Set("x-api-key", p.apiKey)
 	req.Header.Set("anthropic-version", anthropicVersion)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", probeUserAgent)
 	return req, nil
 }
 

--- a/internal/probes/adapters/anthropic/testdata/messages_quality_200.json
+++ b/internal/probes/adapters/anthropic/testdata/messages_quality_200.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_QUALITYTEST0001",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "PONG"
+    }
+  ],
+  "model": "claude-haiku-4-5-20251001",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 22,
+    "output_tokens": 1
+  }
+}

--- a/internal/probes/adapters/anthropic/testdata/messages_quality_mismatch_200.json
+++ b/internal/probes/adapters/anthropic/testdata/messages_quality_mismatch_200.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_QUALITYTEST0002",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "I'm sorry, I cannot do that."
+    }
+  ],
+  "model": "claude-haiku-4-5-20251001",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 22,
+    "output_tokens": 7
+  }
+}

--- a/internal/probes/adapters/anthropic/testdata/messages_stream_200.txt
+++ b/internal/probes/adapters/anthropic/testdata/messages_stream_200.txt
@@ -1,0 +1,20 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_STREAM001","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":8,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"PONG"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/internal/probes/adapters/anthropic_quality.go
+++ b/internal/probes/adapters/anthropic_quality.go
@@ -1,0 +1,95 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+const (
+	anthropicQualityProbeType = "quality"
+	anthropicQualityPrompt    = "Reply with only the single word PONG and nothing else."
+	anthropicQualityMaxTokens = 5
+	anthropicQualityExpected  = "PONG"
+)
+
+// ProbeQuality sends a fixed prompt and verifies the model echoes back the
+// expected token. A 200 response whose content does not contain the expected
+// word is classified as ErrorClassQualityMismatch.
+func (p *anthropicProvider) ProbeQuality(ctx context.Context, model string) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: anthropicProviderID,
+		Model:      model,
+		ProbeType:  anthropicQualityProbeType,
+		StartedAt:  started.UTC(),
+		RegionID:   p.region,
+	}
+
+	body, err := json.Marshal(anthropicMessagesRequest{
+		Model:     model,
+		MaxTokens: anthropicQualityMaxTokens,
+		Messages:  []anthropicMessage{{Role: "user", Content: anthropicQualityPrompt}},
+	})
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), anthropicErrorDetailMax)
+		return r, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/messages", bytes.NewReader(body))
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), anthropicErrorDetailMax)
+		return r, err
+	}
+	req.Header.Set("x-api-key", p.apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", probeUserAgent)
+
+	resp, err := p.client.Do(req)
+	r.DurationMs = time.Since(started).Milliseconds()
+	if err != nil {
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), anthropicErrorDetailMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		r.ErrorClass = classifyAnthropicStatus(resp.StatusCode)
+		r.ErrorDetail = parseAnthropicError(rawBody)
+		return r, nil
+	}
+
+	var cr anthropicMessagesResponse
+	if err := json.Unmarshal(rawBody, &cr); err != nil || len(cr.Content) == 0 {
+		r.ErrorClass = probes.ErrorClassMalformedBody
+		r.ErrorDetail = truncate(string(rawBody), anthropicErrorDetailMax)
+		return r, nil
+	}
+
+	r.TokensIn = cr.Usage.InputTokens
+	r.TokensOut = cr.Usage.OutputTokens
+
+	content := strings.TrimSpace(cr.Content[0].Text)
+	if strings.Contains(strings.ToUpper(content), anthropicQualityExpected) {
+		r.Success = true
+	} else {
+		r.ErrorClass = probes.ErrorClassQualityMismatch
+		r.ErrorDetail = truncate("got: "+content, anthropicErrorDetailMax)
+	}
+	return r, nil
+}

--- a/internal/probes/adapters/anthropic_streaming.go
+++ b/internal/probes/adapters/anthropic_streaming.go
@@ -1,0 +1,122 @@
+package adapters
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+const (
+	anthropicStreamingProbeType = "streaming"
+	anthropicStreamingMaxTokens = 5
+)
+
+type anthropicStreamDelta struct {
+	Type  string `json:"type"`
+	Delta struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"delta"`
+}
+
+// ProbeStreaming issues a streaming messages request and records the time to
+// first content_block_delta token (TTFT). DurationMs is TTFT, not total
+// response time. A stream that ends without a text_delta is classified as
+// ErrorClassMalformedBody.
+func (p *anthropicProvider) ProbeStreaming(ctx context.Context, model string) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: anthropicProviderID,
+		Model:      model,
+		ProbeType:  anthropicStreamingProbeType,
+		StartedAt:  started.UTC(),
+		RegionID:   p.region,
+	}
+
+	type streamRequest struct {
+		Model     string             `json:"model"`
+		MaxTokens int                `json:"max_tokens"`
+		Messages  []anthropicMessage `json:"messages"`
+		Stream    bool               `json:"stream"`
+	}
+	body, err := json.Marshal(streamRequest{
+		Model:     model,
+		MaxTokens: anthropicStreamingMaxTokens,
+		Messages:  []anthropicMessage{{Role: "user", Content: "ping"}},
+		Stream:    true,
+	})
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), anthropicErrorDetailMax)
+		return r, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/messages", bytes.NewReader(body))
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), anthropicErrorDetailMax)
+		return r, err
+	}
+	req.Header.Set("x-api-key", p.apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", probeUserAgent)
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), anthropicErrorDetailMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = classifyAnthropicStatus(resp.StatusCode)
+		return r, nil
+	}
+
+	gotToken := false
+	var currentEvent string
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event: ") {
+			currentEvent = strings.TrimPrefix(line, "event: ")
+			continue
+		}
+		if currentEvent != "content_block_delta" || !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var delta anthropicStreamDelta
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &delta); err != nil {
+			continue
+		}
+		if delta.Delta.Type == "text_delta" && delta.Delta.Text != "" {
+			r.DurationMs = time.Since(started).Milliseconds()
+			gotToken = true
+			break
+		}
+	}
+
+	if !gotToken {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassMalformedBody
+		r.ErrorDetail = "stream ended without content token"
+		return r, nil
+	}
+
+	r.Success = true
+	return r, nil
+}

--- a/internal/probes/adapters/anthropic_streaming.go
+++ b/internal/probes/adapters/anthropic_streaming.go
@@ -87,9 +87,22 @@ func (p *anthropicProvider) ProbeStreaming(ctx context.Context, model string) (p
 		return r, nil
 	}
 
-	gotToken := false
+	durationMs, gotToken := scanAnthropicStream(bufio.NewScanner(resp.Body), started)
+	r.DurationMs = durationMs
+	if !gotToken {
+		r.ErrorClass = probes.ErrorClassMalformedBody
+		r.ErrorDetail = "stream ended without content token"
+		return r, nil
+	}
+
+	r.Success = true
+	return r, nil
+}
+
+// scanAnthropicStream reads SSE lines until a text_delta token is found.
+// Returns the elapsed ms and whether a token was received.
+func scanAnthropicStream(scanner *bufio.Scanner, started time.Time) (int64, bool) {
 	var currentEvent string
-	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "event: ") {
@@ -104,19 +117,8 @@ func (p *anthropicProvider) ProbeStreaming(ctx context.Context, model string) (p
 			continue
 		}
 		if delta.Delta.Type == "text_delta" && delta.Delta.Text != "" {
-			r.DurationMs = time.Since(started).Milliseconds()
-			gotToken = true
-			break
+			return time.Since(started).Milliseconds(), true
 		}
 	}
-
-	if !gotToken {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassMalformedBody
-		r.ErrorDetail = "stream ended without content token"
-		return r, nil
-	}
-
-	r.Success = true
-	return r, nil
+	return time.Since(started).Milliseconds(), false
 }

--- a/internal/probes/adapters/anthropic_test.go
+++ b/internal/probes/adapters/anthropic_test.go
@@ -146,18 +146,103 @@ func TestAnthropic_ProbeLightInference_ContextCancelled(t *testing.T) {
 	}
 }
 
-func TestAnthropic_UnsupportedProbes(t *testing.T) {
+func TestAnthropic_ProbeEmbeddingNotSupported(t *testing.T) {
 	p := NewAnthropicProvider("sk-ant-fake", "node-1")
-	ctx := context.Background()
+	_, err := p.ProbeEmbedding(context.Background(), "m")
+	if !probes.IsNotSupported(err) {
+		t.Errorf("ProbeEmbedding: want ErrNotSupported, got %T: %v", err, err)
+	}
+}
 
-	if _, err := p.ProbeQuality(ctx, "m"); err == nil {
-		t.Error("ProbeQuality: expected ErrNotSupported")
+func TestAnthropic_ProbeQuality(t *testing.T) {
+	cases := []struct {
+		name         string
+		httpStatus   int
+		fixture      string
+		wantSuccess  bool
+		wantErrClass probes.ErrorClass
+	}{
+		{"success", http.StatusOK, "messages_quality_200.json", true, probes.ErrorClassNone},
+		{"mismatch", http.StatusOK, "messages_quality_mismatch_200.json", false, probes.ErrorClassQualityMismatch},
+		{"auth", http.StatusUnauthorized, "messages_401.json", false, probes.ErrorClassAuth},
+		{"rate_limit", http.StatusTooManyRequests, "messages_429.json", false, probes.ErrorClassRateLimit},
 	}
-	if _, err := p.ProbeEmbedding(ctx, "m"); err == nil {
-		t.Error("ProbeEmbedding: expected ErrNotSupported")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustReadAnthropicFixture(t, tc.fixture)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/messages" {
+					t.Errorf("path: got %q, want /messages", r.URL.Path)
+				}
+				if r.Header.Get("User-Agent") != probeUserAgent {
+					t.Errorf("User-Agent: got %q, want %q", r.Header.Get("User-Agent"), probeUserAgent)
+				}
+				w.WriteHeader(tc.httpStatus)
+				_, _ = w.Write(body)
+			}))
+			t.Cleanup(srv.Close)
+
+			p := NewAnthropicProvider("sk-ant-fake", "node-eu", WithAnthropicBaseURL(srv.URL))
+			r, err := p.ProbeQuality(context.Background(), "claude-haiku-4-5-20251001")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.ProbeType != "quality" {
+				t.Errorf("ProbeType: got %q, want quality", r.ProbeType)
+			}
+			if r.Success != tc.wantSuccess {
+				t.Errorf("Success: got %v, want %v", r.Success, tc.wantSuccess)
+			}
+			if r.ErrorClass != tc.wantErrClass {
+				t.Errorf("ErrorClass: got %q, want %q", r.ErrorClass, tc.wantErrClass)
+			}
+		})
 	}
-	if _, err := p.ProbeStreaming(ctx, "m"); err == nil {
-		t.Error("ProbeStreaming: expected ErrNotSupported")
+}
+
+func TestAnthropic_ProbeStreaming(t *testing.T) {
+	fixture := mustReadAnthropicFixture(t, "messages_stream_200.txt")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fixture)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewAnthropicProvider("sk-ant-fake", "node-eu", WithAnthropicBaseURL(srv.URL))
+	r, err := p.ProbeStreaming(context.Background(), "claude-haiku-4-5-20251001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.ProbeType != "streaming" {
+		t.Errorf("ProbeType: got %q, want streaming", r.ProbeType)
+	}
+	if !r.Success {
+		t.Errorf("expected Success=true, ErrorClass=%q", r.ErrorClass)
+	}
+	if r.DurationMs < 0 {
+		t.Errorf("DurationMs negative: %d", r.DurationMs)
+	}
+}
+
+func TestAnthropic_ProbeStreaming_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewAnthropicProvider("sk-ant-fake", "node-1", WithAnthropicBaseURL(srv.URL))
+	r, err := p.ProbeStreaming(context.Background(), "claude-haiku-4-5-20251001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Success {
+		t.Error("expected Success=false for empty stream")
+	}
+	if r.ErrorClass != probes.ErrorClassMalformedBody {
+		t.Errorf("ErrorClass: got %q, want malformed_body", r.ErrorClass)
 	}
 }
 

--- a/internal/probes/adapters/openai.go
+++ b/internal/probes/adapters/openai.go
@@ -20,6 +20,10 @@ const (
 	openaiLightModel     = "gpt-4o-mini"
 	openaiLightProbeType = "light_inference"
 	openaiErrorDetailMax = 200
+
+	// probeUserAgent is sent on every outbound probe request so providers can
+	// identify monitoring traffic and we are transparent about our purpose.
+	probeUserAgent = "llmstatus.io/1.0 (+https://llmstatus.io)"
 )
 
 // OpenAIOption configures an OpenAI provider at construction time.
@@ -105,20 +109,8 @@ func (p *openaiProvider) ProbeLightInference(ctx context.Context, model string) 
 	return r, nil
 }
 
-// ProbeQuality is not implemented for OpenAI yet (LLMS-003+).
-func (p *openaiProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: openaiProviderID, ProbeType: "quality"}
-}
-
-// ProbeEmbedding is not implemented for OpenAI yet (LLMS-003+).
-func (p *openaiProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: openaiProviderID, ProbeType: "embedding"}
-}
-
-// ProbeStreaming is not implemented for OpenAI yet (LLMS-003+).
-func (p *openaiProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: openaiProviderID, ProbeType: "streaming"}
-}
+// ProbeQuality, ProbeEmbedding, ProbeStreaming are in openai_quality.go,
+// openai_embedding.go, openai_streaming.go respectively.
 
 type openaiChatRequest struct {
 	Model     string              `json:"model"`
@@ -164,6 +156,7 @@ func (p *openaiProvider) buildLightRequest(ctx context.Context, model string) (*
 	}
 	req.Header.Set("Authorization", "Bearer "+p.apiKey)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", probeUserAgent)
 	return req, nil
 }
 

--- a/internal/probes/adapters/openai/testdata/chat_completions_quality_200.json
+++ b/internal/probes/adapters/openai/testdata/chat_completions_quality_200.json
@@ -1,0 +1,21 @@
+{
+  "id": "chatcmpl-QUALITYTEST0001",
+  "object": "chat.completion",
+  "created": 1776000000,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "PONG"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 20,
+    "completion_tokens": 1,
+    "total_tokens": 21
+  }
+}

--- a/internal/probes/adapters/openai/testdata/chat_completions_quality_mismatch_200.json
+++ b/internal/probes/adapters/openai/testdata/chat_completions_quality_mismatch_200.json
@@ -1,0 +1,21 @@
+{
+  "id": "chatcmpl-QUALITYTEST0002",
+  "object": "chat.completion",
+  "created": 1776000000,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I cannot comply with that request."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 20,
+    "completion_tokens": 7,
+    "total_tokens": 27
+  }
+}

--- a/internal/probes/adapters/openai/testdata/chat_completions_stream_200.txt
+++ b/internal/probes/adapters/openai/testdata/chat_completions_stream_200.txt
@@ -1,0 +1,7 @@
+data: {"id":"chatcmpl-STREAM001","object":"chat.completion.chunk","created":1776000000,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-STREAM001","object":"chat.completion.chunk","created":1776000000,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"PONG"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-STREAM001","object":"chat.completion.chunk","created":1776000000,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]

--- a/internal/probes/adapters/openai/testdata/embeddings_200.json
+++ b/internal/probes/adapters/openai/testdata/embeddings_200.json
@@ -1,0 +1,15 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "embedding",
+      "index": 0,
+      "embedding": [0.0023064255, -0.009327292, 0.015797101]
+    }
+  ],
+  "model": "text-embedding-3-small",
+  "usage": {
+    "prompt_tokens": 1,
+    "total_tokens": 1
+  }
+}

--- a/internal/probes/adapters/openai_embedding.go
+++ b/internal/probes/adapters/openai_embedding.go
@@ -1,0 +1,100 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+const (
+	openaiEmbeddingProbeType = "embedding"
+	// openaiEmbeddingModel is always used regardless of the model argument;
+	// embeddings are a provider-level capability, not per-chat-model.
+	openaiEmbeddingModel = "text-embedding-3-small"
+	openaiEmbeddingInput = "hello"
+)
+
+type openaiEmbeddingRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+type openaiEmbeddingResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// ProbeEmbedding issues a minimal embeddings request and verifies the response
+// contains a non-empty vector. The model argument is ignored; text-embedding-3-small
+// is always used because embeddings are a provider-level capability.
+func (p *openaiProvider) ProbeEmbedding(ctx context.Context, _ string) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: openaiProviderID,
+		Model:      openaiEmbeddingModel,
+		ProbeType:  openaiEmbeddingProbeType,
+		StartedAt:  started.UTC(),
+		RegionID:   p.region,
+	}
+
+	body, err := json.Marshal(openaiEmbeddingRequest{
+		Model: openaiEmbeddingModel,
+		Input: openaiEmbeddingInput,
+	})
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", probeUserAgent)
+
+	resp, err := p.client.Do(req)
+	r.DurationMs = time.Since(started).Milliseconds()
+	if err != nil {
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		r.ErrorClass = classifyOpenAIStatus(resp.StatusCode)
+		r.ErrorDetail = parseOpenAIError(rawBody)
+		return r, nil
+	}
+
+	var er openaiEmbeddingResponse
+	if err := json.Unmarshal(rawBody, &er); err != nil || len(er.Data) == 0 || len(er.Data[0].Embedding) == 0 {
+		r.ErrorClass = probes.ErrorClassMalformedBody
+		r.ErrorDetail = truncate(string(rawBody), openaiErrorDetailMax)
+		return r, nil
+	}
+
+	r.Success = true
+	r.TokensIn = er.Usage.PromptTokens
+	return r, nil
+}

--- a/internal/probes/adapters/openai_quality.go
+++ b/internal/probes/adapters/openai_quality.go
@@ -1,0 +1,94 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+const (
+	openaiQualityProbeType = "quality"
+	openaiQualityPrompt    = "Reply with only the single word PONG and nothing else."
+	openaiQualityMaxTokens = 5
+	openaiQualityExpected  = "PONG"
+)
+
+// ProbeQuality sends a fixed prompt and verifies the model echoes back the
+// expected token. A 200 response whose content does not contain the expected
+// word is classified as ErrorClassQualityMismatch.
+func (p *openaiProvider) ProbeQuality(ctx context.Context, model string) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: openaiProviderID,
+		Model:      model,
+		ProbeType:  openaiQualityProbeType,
+		StartedAt:  started.UTC(),
+		RegionID:   p.region,
+	}
+
+	body, err := json.Marshal(openaiChatRequest{
+		Model:     model,
+		Messages:  []openaiChatMessage{{Role: "user", Content: openaiQualityPrompt}},
+		MaxTokens: openaiQualityMaxTokens,
+	})
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", probeUserAgent)
+
+	resp, err := p.client.Do(req)
+	r.DurationMs = time.Since(started).Milliseconds()
+	if err != nil {
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		r.ErrorClass = classifyOpenAIStatus(resp.StatusCode)
+		r.ErrorDetail = parseOpenAIError(rawBody)
+		return r, nil
+	}
+
+	var cr openaiChatResponse
+	if err := json.Unmarshal(rawBody, &cr); err != nil || len(cr.Choices) == 0 {
+		r.ErrorClass = probes.ErrorClassMalformedBody
+		r.ErrorDetail = truncate(string(rawBody), openaiErrorDetailMax)
+		return r, nil
+	}
+
+	r.TokensIn = cr.Usage.PromptTokens
+	r.TokensOut = cr.Usage.CompletionTokens
+
+	content := strings.TrimSpace(cr.Choices[0].Message.Content)
+	if strings.Contains(strings.ToUpper(content), openaiQualityExpected) {
+		r.Success = true
+	} else {
+		r.ErrorClass = probes.ErrorClassQualityMismatch
+		r.ErrorDetail = truncate("got: "+content, openaiErrorDetailMax)
+	}
+	return r, nil
+}

--- a/internal/probes/adapters/openai_streaming.go
+++ b/internal/probes/adapters/openai_streaming.go
@@ -1,0 +1,120 @@
+package adapters
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+const (
+	openaiStreamingProbeType = "streaming"
+	openaiStreamingMaxTokens = 5
+)
+
+type openaiStreamChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content string `json:"content"`
+		} `json:"delta"`
+	} `json:"choices"`
+}
+
+// ProbeStreaming issues a streaming chat completion and records the time to
+// first non-empty content token (TTFT). DurationMs is TTFT, not total response
+// time. A stream that ends with [DONE] before producing any content token is
+// classified as ErrorClassMalformedBody.
+func (p *openaiProvider) ProbeStreaming(ctx context.Context, model string) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: openaiProviderID,
+		Model:      model,
+		ProbeType:  openaiStreamingProbeType,
+		StartedAt:  started.UTC(),
+		RegionID:   p.region,
+	}
+
+	type streamRequest struct {
+		Model     string              `json:"model"`
+		Messages  []openaiChatMessage `json:"messages"`
+		MaxTokens int                 `json:"max_tokens"`
+		Stream    bool                `json:"stream"`
+	}
+	body, err := json.Marshal(streamRequest{
+		Model:     model,
+		Messages:  []openaiChatMessage{{Role: "user", Content: "ping"}},
+		MaxTokens: openaiStreamingMaxTokens,
+		Stream:    true,
+	})
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", probeUserAgent)
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), openaiErrorDetailMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = classifyOpenAIStatus(resp.StatusCode)
+		return r, nil
+	}
+
+	gotToken := false
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+		var chunk openaiStreamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
+			r.DurationMs = time.Since(started).Milliseconds()
+			gotToken = true
+			break
+		}
+	}
+
+	if !gotToken {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassMalformedBody
+		r.ErrorDetail = "stream ended without content token"
+		return r, nil
+	}
+
+	r.Success = true
+	return r, nil
+}

--- a/internal/probes/adapters/openai_streaming.go
+++ b/internal/probes/adapters/openai_streaming.go
@@ -86,8 +86,21 @@ func (p *openaiProvider) ProbeStreaming(ctx context.Context, model string) (prob
 		return r, nil
 	}
 
-	gotToken := false
-	scanner := bufio.NewScanner(resp.Body)
+	durationMs, gotToken := scanOpenAIStream(bufio.NewScanner(resp.Body), started)
+	r.DurationMs = durationMs
+	if !gotToken {
+		r.ErrorClass = probes.ErrorClassMalformedBody
+		r.ErrorDetail = "stream ended without content token"
+		return r, nil
+	}
+
+	r.Success = true
+	return r, nil
+}
+
+// scanOpenAIStream reads SSE lines until a non-empty content token is found.
+// Returns the elapsed ms and whether a token was received.
+func scanOpenAIStream(scanner *bufio.Scanner, started time.Time) (int64, bool) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "data: ") {
@@ -102,19 +115,8 @@ func (p *openaiProvider) ProbeStreaming(ctx context.Context, model string) (prob
 			continue
 		}
 		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
-			r.DurationMs = time.Since(started).Milliseconds()
-			gotToken = true
-			break
+			return time.Since(started).Milliseconds(), true
 		}
 	}
-
-	if !gotToken {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassMalformedBody
-		r.ErrorDetail = "stream ended without content token"
-		return r, nil
-	}
-
-	r.Success = true
-	return r, nil
+	return time.Since(started).Milliseconds(), false
 }

--- a/internal/probes/adapters/openai_test.go
+++ b/internal/probes/adapters/openai_test.go
@@ -2,7 +2,6 @@ package adapters
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -136,21 +135,143 @@ func TestOpenAI_ProbeLightInference_ContextCancelled(t *testing.T) {
 	}
 }
 
-func TestOpenAI_UnsupportedProbes(t *testing.T) {
-	p := NewOpenAIProvider("sk-fake", "node-1")
+func TestOpenAI_ProbeQuality(t *testing.T) {
+	cases := []struct {
+		name         string
+		httpStatus   int
+		fixture      string
+		wantSuccess  bool
+		wantErrClass probes.ErrorClass
+	}{
+		{"success", http.StatusOK, "chat_completions_quality_200.json", true, probes.ErrorClassNone},
+		{"mismatch", http.StatusOK, "chat_completions_quality_mismatch_200.json", false, probes.ErrorClassQualityMismatch},
+		{"auth", http.StatusUnauthorized, "chat_completions_401.json", false, probes.ErrorClassAuth},
+		{"rate_limit", http.StatusTooManyRequests, "chat_completions_429.json", false, probes.ErrorClassRateLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustReadFixture(t, tc.fixture)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/chat/completions" {
+					t.Errorf("path: got %q, want /chat/completions", r.URL.Path)
+				}
+				if r.Header.Get("User-Agent") != probeUserAgent {
+					t.Errorf("User-Agent: got %q, want %q", r.Header.Get("User-Agent"), probeUserAgent)
+				}
+				w.WriteHeader(tc.httpStatus)
+				_, _ = w.Write(body)
+			}))
+			t.Cleanup(srv.Close)
 
-	_, err := p.ProbeQuality(context.Background(), "gpt-4o-mini")
-	var errNotSupported *probes.ErrNotSupported
-	if !errors.As(err, &errNotSupported) {
-		t.Errorf("ProbeQuality: want *ErrNotSupported, got %T: %v", err, err)
+			p := NewOpenAIProvider("sk-fake", "node-1", WithOpenAIBaseURL(srv.URL))
+			r, err := p.ProbeQuality(context.Background(), "gpt-4o-mini")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.ProbeType != "quality" {
+				t.Errorf("ProbeType: got %q, want quality", r.ProbeType)
+			}
+			if r.Success != tc.wantSuccess {
+				t.Errorf("Success: got %v, want %v", r.Success, tc.wantSuccess)
+			}
+			if r.ErrorClass != tc.wantErrClass {
+				t.Errorf("ErrorClass: got %q, want %q", r.ErrorClass, tc.wantErrClass)
+			}
+		})
 	}
-	_, err = p.ProbeEmbedding(context.Background(), "gpt-4o-mini")
-	if !errors.As(err, &errNotSupported) {
-		t.Errorf("ProbeEmbedding: want *ErrNotSupported, got %T: %v", err, err)
+}
+
+func TestOpenAI_ProbeEmbedding(t *testing.T) {
+	cases := []struct {
+		name         string
+		httpStatus   int
+		fixture      string
+		wantSuccess  bool
+		wantErrClass probes.ErrorClass
+	}{
+		{"success", http.StatusOK, "embeddings_200.json", true, probes.ErrorClassNone},
+		{"auth", http.StatusUnauthorized, "chat_completions_401.json", false, probes.ErrorClassAuth},
 	}
-	_, err = p.ProbeStreaming(context.Background(), "gpt-4o-mini")
-	if !errors.As(err, &errNotSupported) {
-		t.Errorf("ProbeStreaming: want *ErrNotSupported, got %T: %v", err, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustReadFixture(t, tc.fixture)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/embeddings" {
+					t.Errorf("path: got %q, want /embeddings", r.URL.Path)
+				}
+				w.WriteHeader(tc.httpStatus)
+				_, _ = w.Write(body)
+			}))
+			t.Cleanup(srv.Close)
+
+			p := NewOpenAIProvider("sk-fake", "node-1", WithOpenAIBaseURL(srv.URL))
+			r, err := p.ProbeEmbedding(context.Background(), "gpt-4o-mini")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.ProbeType != "embedding" {
+				t.Errorf("ProbeType: got %q, want embedding", r.ProbeType)
+			}
+			if r.Model != openaiEmbeddingModel {
+				t.Errorf("Model: got %q, want %q", r.Model, openaiEmbeddingModel)
+			}
+			if r.Success != tc.wantSuccess {
+				t.Errorf("Success: got %v, want %v", r.Success, tc.wantSuccess)
+			}
+			if r.ErrorClass != tc.wantErrClass {
+				t.Errorf("ErrorClass: got %q, want %q", r.ErrorClass, tc.wantErrClass)
+			}
+			if tc.wantSuccess && r.TokensIn == 0 {
+				t.Error("expected non-zero TokensIn on success")
+			}
+		})
+	}
+}
+
+func TestOpenAI_ProbeStreaming(t *testing.T) {
+	fixture := mustReadFixture(t, "chat_completions_stream_200.txt")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fixture)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewOpenAIProvider("sk-fake", "node-1", WithOpenAIBaseURL(srv.URL))
+	r, err := p.ProbeStreaming(context.Background(), "gpt-4o-mini")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.ProbeType != "streaming" {
+		t.Errorf("ProbeType: got %q, want streaming", r.ProbeType)
+	}
+	if !r.Success {
+		t.Errorf("expected Success=true, ErrorClass=%q", r.ErrorClass)
+	}
+	if r.DurationMs < 0 {
+		t.Errorf("DurationMs negative: %d", r.DurationMs)
+	}
+}
+
+func TestOpenAI_ProbeStreaming_Empty(t *testing.T) {
+	// A stream that sends [DONE] without any content token is a failure.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewOpenAIProvider("sk-fake", "node-1", WithOpenAIBaseURL(srv.URL))
+	r, err := p.ProbeStreaming(context.Background(), "gpt-4o-mini")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Success {
+		t.Error("expected Success=false for empty stream")
+	}
+	if r.ErrorClass != probes.ErrorClassMalformedBody {
+		t.Errorf("ErrorClass: got %q, want malformed_body", r.ErrorClass)
 	}
 }
 

--- a/internal/probes/base.go
+++ b/internal/probes/base.go
@@ -6,6 +6,7 @@ package probes
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -86,4 +87,12 @@ type ErrNotSupported struct {
 
 func (e *ErrNotSupported) Error() string {
 	return "probes: " + e.ProbeType + " not supported by provider " + e.ProviderID
+}
+
+// IsNotSupported reports whether err signals that a probe type is not
+// implemented for a particular provider. Callers (e.g. the runner) use this
+// to skip unsupported probes without treating them as failures.
+func IsNotSupported(err error) bool {
+	var e *ErrNotSupported
+	return errors.As(err, &e)
 }

--- a/internal/probes/runner.go
+++ b/internal/probes/runner.go
@@ -117,20 +117,34 @@ func (r *Runner) runOnce(ctx context.Context) {
 	wg.Wait()
 }
 
-// dispatchProbe runs a single probe and forwards the result to the sink.
+// dispatchProbe runs all supported probe types for one (provider, model) pair
+// sequentially and forwards each result to the sink. Unsupported probe types
+// (ErrNotSupported) are silently skipped.
 func (r *Runner) dispatchProbe(ctx context.Context, pc ProviderConfig, model string) {
 	pCtx, cancel := context.WithTimeout(ctx, r.probeTimeout)
 	defer cancel()
 
-	result, _ := pc.Adapter.ProbeLightInference(pCtx, model)
-	result.RegionID = r.regionID
+	probeFns := []func(context.Context, string) (ProbeResult, error){
+		pc.Adapter.ProbeLightInference,
+		pc.Adapter.ProbeQuality,
+		pc.Adapter.ProbeEmbedding,
+		pc.Adapter.ProbeStreaming,
+	}
 
-	if err := r.sink.Receive(ctx, result); err != nil {
-		slog.Error("runner: sink error",
-			"provider", pc.Adapter.ID(),
-			"model", model,
-			"err", err,
-		)
+	for _, fn := range probeFns {
+		result, err := fn(pCtx, model)
+		if IsNotSupported(err) {
+			continue
+		}
+		result.RegionID = r.regionID
+		if sinkErr := r.sink.Receive(ctx, result); sinkErr != nil {
+			slog.Error("runner: sink error",
+				"provider", pc.Adapter.ID(),
+				"model", model,
+				"probe_type", result.ProbeType,
+				"err", sinkErr,
+			)
+		}
 	}
 }
 

--- a/internal/store/postgres/gen/models.go
+++ b/internal/store/postgres/gen/models.go
@@ -132,3 +132,10 @@ type User struct {
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	VerifiedAt pgtype.Timestamptz `json:"verified_at"`
 }
+
+type UserReport struct {
+	ID         int64              `json:"id"`
+	ProviderID string             `json:"provider_id"`
+	IpHash     string             `json:"ip_hash"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+}

--- a/internal/store/postgres/gen/querier.go
+++ b/internal/store/postgres/gen/querier.go
@@ -44,6 +44,12 @@ type Querier interface {
 	GetUserByOAuth(ctx context.Context, arg GetUserByOAuthParams) (User, error)
 	IsAlertSent(ctx context.Context, arg IsAlertSentParams) (bool, error)
 	IsDigestSent(ctx context.Context, arg IsDigestSentParams) (bool, error)
+	// ============================================================
+	// user_reports (LLMS-048)
+	// ============================================================
+	// Inserts a report only when no report from the same ip_hash exists for the
+	// same provider within the last 5 minutes (server-side dedup).
+	InsertUserReport(ctx context.Context, arg InsertUserReportParams) error
 	ListActiveProviders(ctx context.Context) ([]Provider, error)
 	ListActiveSponsorKeys(ctx context.Context) ([]SponsorKey, error)
 	ListActiveSponsors(ctx context.Context) ([]Sponsor, error)
@@ -92,6 +98,9 @@ type Querier interface {
 	// auth (LLMS-049)
 	// ============================================================
 	UpsertUser(ctx context.Context, email string) (User, error)
+	// Returns 24 hourly buckets for the given provider, oldest first.
+	// Buckets with zero reports are included via generate_series.
+	UserReportHistogram(ctx context.Context, providerID string) ([]UserReportHistogramRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/store/postgres/gen/queries.sql.go
+++ b/internal/store/postgres/gen/queries.sql.go
@@ -573,6 +573,33 @@ func (q *Queries) IsDigestSent(ctx context.Context, arg IsDigestSentParams) (boo
 	return sent, err
 }
 
+const insertUserReport = `-- name: InsertUserReport :exec
+
+INSERT INTO user_reports (provider_id, ip_hash)
+SELECT $1, $2
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_reports
+    WHERE provider_id = $1
+      AND ip_hash     = $2
+      AND created_at  > NOW() - INTERVAL '5 minutes'
+)
+`
+
+type InsertUserReportParams struct {
+	ProviderID string `json:"provider_id"`
+	IpHash     string `json:"ip_hash"`
+}
+
+// ============================================================
+// user_reports (LLMS-048)
+// ============================================================
+// Inserts a report only when no report from the same ip_hash exists for the
+// same provider within the last 5 minutes (server-side dedup).
+func (q *Queries) InsertUserReport(ctx context.Context, arg InsertUserReportParams) error {
+	_, err := q.db.Exec(ctx, insertUserReport, arg.ProviderID, arg.IpHash)
+	return err
+}
+
 const listActiveProviders = `-- name: ListActiveProviders :many
 SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config, probe_scope FROM providers
 WHERE active = TRUE
@@ -1702,4 +1729,47 @@ func (q *Queries) UpsertUser(ctx context.Context, email string) (User, error) {
 		&i.VerifiedAt,
 	)
 	return i, err
+}
+
+const userReportHistogram = `-- name: UserReportHistogram :many
+SELECT
+    gs.bucket,
+    COALESCE(COUNT(r.id), 0)::BIGINT AS count
+FROM generate_series(
+    date_trunc('hour', NOW() - INTERVAL '23 hours'),
+    date_trunc('hour', NOW()),
+    INTERVAL '1 hour'
+) AS gs(bucket)
+LEFT JOIN user_reports r
+    ON r.provider_id = $1
+    AND date_trunc('hour', r.created_at) = gs.bucket
+GROUP BY gs.bucket
+ORDER BY gs.bucket
+`
+
+type UserReportHistogramRow struct {
+	Bucket interface{} `json:"bucket"`
+	Count  int64       `json:"count"`
+}
+
+// Returns 24 hourly buckets for the given provider, oldest first.
+// Buckets with zero reports are included via generate_series.
+func (q *Queries) UserReportHistogram(ctx context.Context, providerID string) ([]UserReportHistogramRow, error) {
+	rows, err := q.db.Query(ctx, userReportHistogram, providerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserReportHistogramRow{}
+	for rows.Next() {
+		var i UserReportHistogramRow
+		if err := rows.Scan(&i.Bucket, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/internal/store/postgres/queries.sql
+++ b/internal/store/postgres/queries.sql
@@ -142,6 +142,39 @@ SET description    = $2,
 WHERE id = $1;
 
 -- ============================================================
+-- user_reports (LLMS-048)
+-- ============================================================
+
+-- name: InsertUserReport :exec
+-- Inserts a report only when no report from the same ip_hash exists for the
+-- same provider within the last 5 minutes (server-side dedup).
+INSERT INTO user_reports (provider_id, ip_hash)
+SELECT $1, $2
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_reports
+    WHERE provider_id = $1
+      AND ip_hash     = $2
+      AND created_at  > NOW() - INTERVAL '5 minutes'
+);
+
+-- name: UserReportHistogram :many
+-- Returns 24 hourly buckets for the given provider, oldest first.
+-- Buckets with zero reports are included via generate_series.
+SELECT
+    gs.bucket,
+    COALESCE(COUNT(r.id), 0)::BIGINT AS count
+FROM generate_series(
+    date_trunc('hour', NOW() - INTERVAL '23 hours'),
+    date_trunc('hour', NOW()),
+    INTERVAL '1 hour'
+) AS gs(bucket)
+LEFT JOIN user_reports r
+    ON r.provider_id = $1
+    AND date_trunc('hour', r.created_at) = gs.bucket
+GROUP BY gs.bucket
+ORDER BY gs.bucket;
+
+-- ============================================================
 -- auth (LLMS-049)
 -- ============================================================
 

--- a/store/migrations/0003_user_reports.down.sql
+++ b/store/migrations/0003_user_reports.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_reports;

--- a/store/migrations/0003_user_reports.up.sql
+++ b/store/migrations/0003_user_reports.up.sql
@@ -1,0 +1,17 @@
+-- 0003_user_reports.sql — anonymous user report counts per provider (LLMS-048)
+--
+-- ip_hash stores SHA-256(client_ip) — no raw IPs ever written.
+-- The 5-minute dedup is enforced at the application layer via NOT EXISTS.
+
+BEGIN;
+
+CREATE TABLE user_reports (
+    id          BIGSERIAL   PRIMARY KEY,
+    provider_id TEXT        NOT NULL REFERENCES providers(id),
+    ip_hash     TEXT        NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_user_reports_provider_time ON user_reports (provider_id, created_at DESC);
+
+COMMIT;

--- a/web/app/providers/[id]/actions.ts
+++ b/web/app/providers/[id]/actions.ts
@@ -2,6 +2,15 @@
 
 import { getProviderHistory, type HistoryBucket, type HistoryWindow } from "@/lib/api";
 
+const API_URL = process.env.API_URL ?? "http://localhost:8081";
+
+export async function postReport(providerId: string): Promise<void> {
+  await fetch(`${API_URL}/v1/providers/${encodeURIComponent(providerId)}/report`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 export async function fetchProviderHistory(
   providerId: string,
   window: HistoryWindow,

--- a/web/app/providers/[id]/page.tsx
+++ b/web/app/providers/[id]/page.tsx
@@ -2,10 +2,12 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 
-import { getProvider, getProviderHistory, ApiNotFoundError } from "@/lib/api";
+import { getProvider, getProviderHistory, getReportHistogram, ApiNotFoundError } from "@/lib/api";
 import { StatusPill } from "@/components/StatusPill";
 import { IncidentCard } from "@/components/IncidentCard";
 import { ModelStatsTable } from "@/components/ModelStatsTable";
+import { UserReportHistogram } from "@/components/UserReportHistogram";
+import { ReportButton } from "@/components/ReportButton";
 import { HistorySection } from "./HistorySection";
 
 export const revalidate = 60;
@@ -47,6 +49,7 @@ export default async function ProviderPage({ params }: Props) {
 
   // History is best-effort — the client component handles empty state.
   const history = await getProviderHistory(id, "30d").catch(() => null);
+  const reportBuckets = await getReportHistogram(id).catch(() => null);
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -115,6 +118,21 @@ export default async function ProviderPage({ params }: Props) {
           </div>
         </section>
       )}
+
+      {/* Community reports */}
+      <section className="mb-8 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--ink-300)]">
+            User Reports
+          </h2>
+          <ReportButton providerId={id} providerName={provider.name} />
+        </div>
+        {reportBuckets && reportBuckets.length > 0 ? (
+          <UserReportHistogram buckets={reportBuckets} />
+        ) : (
+          <p className="text-xs text-[var(--ink-500)]">No report data available.</p>
+        )}
+      </section>
 
       {/* History charts with window selector (client component) */}
       <HistorySection providerId={id} initialHistory={history} />

--- a/web/components/ReportButton.tsx
+++ b/web/components/ReportButton.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState, useEffect, useTransition } from "react";
+import { postReport } from "@/app/providers/[id]/actions";
+
+const COOLDOWN_MS = 5 * 60 * 1000;
+
+function storageKey(id: string) {
+  return `llms_report_${id}`;
+}
+
+function isCoolingDown(id: string): boolean {
+  if (typeof window === "undefined") return false;
+  const raw = localStorage.getItem(storageKey(id));
+  if (!raw) return false;
+  return Date.now() - Number(raw) < COOLDOWN_MS;
+}
+
+interface Props {
+  providerId: string;
+  providerName: string;
+}
+
+export function ReportButton({ providerId, providerName }: Props) {
+  const [reported, setReported] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setReported(isCoolingDown(providerId));
+  }, [providerId]);
+
+  function handleClick() {
+    if (reported || pending) return;
+    startTransition(async () => {
+      await postReport(providerId);
+      localStorage.setItem(storageKey(providerId), String(Date.now()));
+      setReported(true);
+    });
+  }
+
+  const xText = encodeURIComponent(
+    `Having issues with ${providerName} API? Report and discuss at llmstatus.io`,
+  );
+  const xUrl = encodeURIComponent(`https://llmstatus.io/providers/${providerId}`);
+  const xHref = `https://twitter.com/intent/tweet?text=${xText}&url=${xUrl}`;
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <button
+        onClick={handleClick}
+        disabled={reported || pending}
+        className={[
+          "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+          reported || pending
+            ? "cursor-default bg-[var(--ink-700)] text-[var(--ink-500)]"
+            : "bg-[var(--signal-down)]/15 text-[var(--signal-down)] hover:bg-[var(--signal-down)]/25",
+        ].join(" ")}
+      >
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-current" />
+        {reported ? "Reported — thanks" : pending ? "Reporting…" : "Report an issue"}
+      </button>
+
+      <a
+        href={xHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-[var(--ink-400)] hover:text-[var(--ink-200)] transition-colors"
+      >
+        Discuss on X →
+      </a>
+    </div>
+  );
+}

--- a/web/components/UserReportHistogram.tsx
+++ b/web/components/UserReportHistogram.tsx
@@ -1,0 +1,53 @@
+import type { ReportHistogramBucket } from "@/lib/api";
+
+interface Props {
+  buckets: ReportHistogramBucket[];
+}
+
+export function UserReportHistogram({ buckets }: Props) {
+  const max = Math.max(...buckets.map((b) => b.count), 1);
+  const total = buckets.reduce((s, b) => s + b.count, 0);
+
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between text-[10px] text-[var(--ink-500)]">
+        <span>Community reports — last 24 hours</span>
+        <span>{total} total</span>
+      </div>
+      <div className="flex h-10 items-end gap-px">
+        {buckets.map((b) => {
+          const pct = Math.round((b.count / max) * 100);
+          const hour = new Date(b.hour).toLocaleTimeString("en-US", {
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+            timeZone: "UTC",
+          });
+          return (
+            <div
+              key={b.hour}
+              title={`${hour} UTC — ${b.count} report${b.count !== 1 ? "s" : ""}`}
+              className="group relative flex flex-1 flex-col justify-end"
+            >
+              <div
+                className={[
+                  "w-full rounded-sm transition-colors",
+                  b.count === 0
+                    ? "bg-[var(--ink-700)]"
+                    : b.count >= max * 0.6
+                    ? "bg-[var(--signal-down)]"
+                    : "bg-[var(--signal-warn)]",
+                ].join(" ")}
+                style={{ height: `${Math.max(pct, 4)}%` }}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-1 flex justify-between text-[9px] text-[var(--ink-600)]">
+        <span>24h ago</span>
+        <span>now</span>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -120,6 +120,18 @@ export function getProviderHistory(id: string, window: HistoryWindow = "30d"): P
   );
 }
 
+export interface ReportHistogramBucket {
+  hour: string;
+  count: number;
+}
+
+export function getReportHistogram(id: string): Promise<ReportHistogramBucket[]> {
+  return apiFetch<ReportHistogramBucket[]>(
+    `/v1/providers/${encodeURIComponent(id)}/reports/histogram`,
+    60,
+  );
+}
+
 export function listIncidents(status = "all", limit = 50): Promise<IncidentDetail[]> {
   return apiFetch<IncidentDetail[]>(`/v1/incidents?status=${status}&limit=${limit}`, 30);
 }


### PR DESCRIPTION
## Summary
- Add `ProbeQuality`, `ProbeEmbedding`, `ProbeStreaming` for OpenAI and Anthropic
- Add `User-Agent: llmstatus.io/1.0` header to all probe requests
- Add `user_reports` table (migration 0003) with 5-min IP-hash server-side dedup
- Add `POST /v1/providers/{id}/report` and `GET .../reports/histogram` API endpoints
- Add `ReportButton` client component (localStorage cooldown, "Discuss on X" link)
- Add `UserReportHistogram` 24-bucket CSS bar chart on provider detail page

## Test plan
- [ ] `go test ./internal/...` passes
- [ ] `POST /v1/providers/openai/report` returns 204; second call within 5 min still 204 (dedup)
- [ ] `GET /v1/providers/openai/reports/histogram` returns 24 buckets
- [ ] Provider detail page shows User Reports section with histogram
- [ ] Report button grays out after click, shows "Reported — thanks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)