### PR TITLE
feat LLMS-051: notifier — incident alerts via email + webhook

### DIFF
--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -1,0 +1,83 @@
+// Command notifier polls for incident changes and delivers alerts via email and webhook.
+//
+// Required environment variables:
+//
+//	DATABASE_URL      Postgres DSN
+//	RESEND_API_KEY    Resend email API key
+//
+// Optional:
+//
+//	EMAIL_FROM              Sender address (default "noreply@llmstatus.io")
+//	SITE_URL                Public site URL (default "https://llmstatus.io")
+//	NOTIFIER_POLL_INTERVAL  Poll cadence (default "30s")
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/llmstatus/llmstatus/internal/email"
+	"github.com/llmstatus/llmstatus/internal/notifier"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+func main() {
+	dbURL := requireEnv("DATABASE_URL")
+	resendKey := requireEnv("RESEND_API_KEY")
+	emailFrom := envOr("EMAIL_FROM", "noreply@llmstatus.io")
+	siteURL := envOr("SITE_URL", "https://llmstatus.io")
+	interval := envDuration("NOTIFIER_POLL_INTERVAL", 30*time.Second)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		slog.Error("notifier: cannot connect to postgres", "err", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	n := notifier.New(notifier.Config{
+		Store:    pgstore.New(pool),
+		Email:    email.New(resendKey, emailFrom),
+		SiteURL:  siteURL,
+		Interval: interval,
+	})
+
+	slog.Info("notifier: starting", "interval", interval)
+	n.Run(ctx)
+	slog.Info("notifier: stopped")
+}
+
+func requireEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		slog.Error("notifier: required env var not set", "key", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+		slog.Warn("notifier: invalid duration, using default", "key", key, "default", def)
+	}
+	return def
+}

--- a/internal/email/client.go
+++ b/internal/email/client.go
@@ -11,17 +11,34 @@ import (
 
 const resendAPI = "https://api.resend.com/emails"
 
+// Sender is the interface satisfied by *Client; useful for test mocking.
+type Sender interface {
+	Send(ctx context.Context, msg Message) error
+}
+
 type Client struct {
-	apiKey string
-	from   string
-	http   *http.Client
+	apiKey  string
+	from    string
+	baseURL string
+	http    *http.Client
 }
 
 func New(apiKey, from string) *Client {
 	return &Client{
-		apiKey: apiKey,
-		from:   from,
-		http:   &http.Client{Timeout: 10 * time.Second},
+		apiKey:  apiKey,
+		from:    from,
+		baseURL: resendAPI,
+		http:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// NewWithBaseURL creates a Client pointing at a custom URL (for tests).
+func NewWithBaseURL(baseURL, apiKey, from string) *Client {
+	return &Client{
+		apiKey:  apiKey,
+		from:    from,
+		baseURL: baseURL,
+		http:    &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
@@ -44,7 +61,7 @@ func (c *Client) Send(ctx context.Context, msg Message) error {
 	if err != nil {
 		return fmt.Errorf("email: marshal payload: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resendAPI, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("email: build request: %w", err)
 	}

--- a/internal/notifier/email.go
+++ b/internal/notifier/email.go
@@ -1,0 +1,76 @@
+package notifier
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/email"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+func (n *Notifier) sendEmail(ctx context.Context, to string, inc pgstore.Incident, event string) error {
+	subj, text, html := buildEmail(inc, event, n.cfg.SiteURL)
+	return n.cfg.Email.Send(ctx, email.Message{
+		To:      to,
+		Subject: subj,
+		Text:    text,
+		HTML:    html,
+	})
+}
+
+func buildEmail(inc pgstore.Incident, event, siteURL string) (subject, text, html string) {
+	incURL := siteURL + "/incidents/" + inc.Slug
+	unsubURL := siteURL + "/account/subscriptions"
+	ts := inc.StartedAt.Time.UTC().Format(time.RFC3339)
+
+	if event == eventResolved {
+		subject = fmt.Sprintf("[llmstatus] Resolved: %s %s incident — %s", inc.ProviderID, inc.Severity, inc.Title)
+		text = fmt.Sprintf("The following incident has been resolved:\n\n%s\nSeverity: %s\nStarted: %s\n\nDetails: %s\n\nManage alerts: %s",
+			inc.Title, inc.Severity, ts, incURL, unsubURL)
+		html = incidentEmailHTML(inc, event, incURL, unsubURL, ts)
+		return
+	}
+
+	subject = fmt.Sprintf("[llmstatus] %s %s incident — %s", inc.ProviderID, inc.Severity, inc.Title)
+	text = fmt.Sprintf("A new incident has been detected:\n\n%s\nProvider: %s\nSeverity: %s\nStarted: %s\n\nDetails: %s\n\nManage alerts: %s",
+		inc.Title, inc.ProviderID, inc.Severity, ts, incURL, unsubURL)
+	html = incidentEmailHTML(inc, event, incURL, unsubURL, ts)
+	return
+}
+
+func incidentEmailHTML(inc pgstore.Incident, event, incURL, unsubURL, ts string) string {
+	badge := `<span style="color:#f5a623">` + inc.Severity + `</span>`
+	title := inc.Title
+	statusLine := "Status: <strong>ongoing</strong>"
+	if event == eventResolved {
+		badge = `<span style="color:#4caf50">resolved</span>`
+		statusLine = "Status: <strong>resolved</strong>"
+	}
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html><body style="font-family:monospace;background:#0d0d0d;color:#e0e0e0;padding:40px;max-width:600px">
+<h2 style="color:#e0e0e0;margin-bottom:4px">[llmstatus] incident alert</h2>
+<p style="margin:0 0 20px;color:#888;font-size:12px">%s · %s</p>
+
+<div style="border:1px solid #333;border-radius:6px;padding:20px;margin-bottom:20px">
+  <p style="margin:0 0 8px;font-size:18px;color:#e0e0e0">%s</p>
+  <p style="margin:0 0 4px;color:#888;font-size:13px">Provider: <strong style="color:#e0e0e0">%s</strong></p>
+  <p style="margin:0 0 4px;color:#888;font-size:13px">Severity: %s</p>
+  <p style="margin:0 0 4px;color:#888;font-size:13px">%s</p>
+  <p style="margin:0;color:#888;font-size:13px">Started: <strong style="color:#e0e0e0">%s</strong></p>
+</div>
+
+<p><a href="%s" style="color:#f5a623;text-decoration:none">View incident details →</a></p>
+
+<p style="margin-top:40px;font-size:11px;color:#555">
+  You received this because you subscribed to %s alerts on llmstatus.io.<br>
+  <a href="%s" style="color:#555">Manage subscriptions</a>
+</p>
+</body></html>`,
+		ts, inc.ProviderID,
+		title,
+		inc.ProviderID, badge, statusLine, ts,
+		incURL,
+		inc.ProviderID, unsubURL)
+}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -1,0 +1,193 @@
+// Package notifier polls for incident changes and delivers alerts via email and webhook.
+package notifier
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/llmstatus/llmstatus/internal/email"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// compile-time check that *email.Client satisfies email.Sender.
+var _ email.Sender = (*email.Client)(nil)
+
+const (
+	eventCreated  = "incident.created"
+	eventResolved = "incident.resolved"
+)
+
+var severityLevel = map[string]int{"minor": 1, "major": 2, "critical": 3}
+
+// Store is the DB subset required by the notifier.
+type Store interface {
+	ListIncidentsUpdatedSince(ctx context.Context, updatedAt pgtype.Timestamptz) ([]pgstore.Incident, error)
+	ListSubscriptionsForProvider(ctx context.Context, providerID string) ([]pgstore.ListSubscriptionsForProviderRow, error)
+	IsAlertSent(ctx context.Context, arg pgstore.IsAlertSentParams) (bool, error)
+	LogAlert(ctx context.Context, arg pgstore.LogAlertParams) error
+}
+
+// Config holds all dependencies for the Notifier.
+type Config struct {
+	Store    Store
+	Email    email.Sender
+	SiteURL  string
+	Interval time.Duration
+}
+
+// Notifier polls for incident changes and sends alerts.
+type Notifier struct {
+	cfg Config
+}
+
+func New(cfg Config) *Notifier {
+	if cfg.Interval <= 0 {
+		cfg.Interval = 30 * time.Second
+	}
+	if cfg.SiteURL == "" {
+		cfg.SiteURL = "https://llmstatus.io"
+	}
+	return &Notifier{cfg: cfg}
+}
+
+// Run blocks until ctx is cancelled, polling on cfg.Interval.
+func (n *Notifier) Run(ctx context.Context) {
+	// Use a small lookback so events at tick boundaries aren't missed.
+	const lookback = 10 * time.Second
+	lastCheck := time.Now().UTC().Add(-lookback)
+
+	ticker := time.NewTicker(n.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t := <-ticker.C:
+			since := lastCheck.Add(-lookback)
+			lastCheck = t.UTC()
+			n.poll(ctx, since)
+		}
+	}
+}
+
+func (n *Notifier) poll(ctx context.Context, since time.Time) {
+	incidents, err := n.cfg.Store.ListIncidentsUpdatedSince(ctx, pgtype.Timestamptz{Time: since, Valid: true})
+	if err != nil {
+		slog.Error("notifier: list incidents", "err", err)
+		return
+	}
+	for _, inc := range incidents {
+		n.processIncident(ctx, inc)
+	}
+}
+
+func (n *Notifier) processIncident(ctx context.Context, inc pgstore.Incident) {
+	event := incidentEvent(inc.Status)
+	if event == "" {
+		return
+	}
+
+	subs, err := n.cfg.Store.ListSubscriptionsForProvider(ctx, inc.ProviderID)
+	if err != nil {
+		slog.Error("notifier: list subscriptions", "provider", inc.ProviderID, "err", err)
+		return
+	}
+
+	for _, sub := range subs {
+		if severityLevel[inc.Severity] < severityLevel[sub.MinSeverity] {
+			continue
+		}
+		if sub.EmailAlerts {
+			n.deliver(ctx, sub, inc, "email", event)
+		}
+		if sub.WebhookUrl.Valid && sub.WebhookUrl.String != "" {
+			n.deliver(ctx, sub, inc, "webhook", event)
+		}
+	}
+}
+
+func (n *Notifier) deliver(ctx context.Context, sub pgstore.ListSubscriptionsForProviderRow, inc pgstore.Incident, channel, event string) {
+	sent, err := n.cfg.Store.IsAlertSent(ctx, pgstore.IsAlertSentParams{
+		SubscriptionID: sub.ID,
+		IncidentID:     inc.ID,
+		Channel:        channel,
+		Event:          event,
+	})
+	if err != nil {
+		slog.Error("notifier: check alert_log", "err", err)
+		return
+	}
+	if sent {
+		return
+	}
+
+	var sendErr error
+	switch channel {
+	case "email":
+		sendErr = n.sendEmail(ctx, sub.UserEmail, inc, event)
+	case "webhook":
+		sendErr = deliverWebhook(ctx, sub.WebhookUrl.String, buildPayload(inc, event, n.cfg.SiteURL))
+	}
+	if sendErr != nil {
+		slog.Error("notifier: send failed", "channel", channel, "event", event,
+			"incident", inc.ID, "err", sendErr)
+		return
+	}
+
+	if err := n.cfg.Store.LogAlert(ctx, pgstore.LogAlertParams{
+		SubscriptionID: sub.ID,
+		IncidentID:     inc.ID,
+		Channel:        channel,
+		Event:          event,
+	}); err != nil {
+		slog.Error("notifier: log alert", "err", err)
+	}
+}
+
+// incidentEvent maps incident status to the event name we send.
+// Returns "" for statuses we don't notify on.
+func incidentEvent(status string) string {
+	switch status {
+	case "ongoing":
+		return eventCreated
+	case "resolved":
+		return eventResolved
+	default:
+		return ""
+	}
+}
+
+type webhookPayload struct {
+	Event      string  `json:"event"`
+	ProviderID string  `json:"provider_id"`
+	IncidentID uuid.UUID `json:"incident_id"`
+	Severity   string  `json:"severity"`
+	Title      string  `json:"title"`
+	Status     string  `json:"status"`
+	StartedAt  string  `json:"started_at"`
+	ResolvedAt *string `json:"resolved_at,omitempty"`
+	URL        string  `json:"url"`
+}
+
+func buildPayload(inc pgstore.Incident, event, siteURL string) webhookPayload {
+	p := webhookPayload{
+		Event:      event,
+		ProviderID: inc.ProviderID,
+		IncidentID: inc.ID,
+		Severity:   inc.Severity,
+		Title:      inc.Title,
+		Status:     inc.Status,
+		StartedAt:  inc.StartedAt.Time.UTC().Format(time.RFC3339),
+		URL:        siteURL + "/incidents/" + inc.Slug,
+	}
+	if inc.ResolvedAt.Valid {
+		s := inc.ResolvedAt.Time.UTC().Format(time.RFC3339)
+		p.ResolvedAt = &s
+	}
+	return p
+}

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -1,0 +1,242 @@
+package notifier
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/llmstatus/llmstatus/internal/email"
+	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
+)
+
+// fakeStore implements Store for unit tests.
+type fakeStore struct {
+	mu        sync.Mutex
+	incidents []pgstore.Incident
+	subs      []pgstore.ListSubscriptionsForProviderRow
+	logged    []pgstore.LogAlertParams
+	sent      map[string]bool
+}
+
+func alertKey(subID int64, incID uuid.UUID, ch, ev string) string {
+	return incID.String() + ":" + ch + ":" + ev
+}
+
+func (f *fakeStore) ListIncidentsUpdatedSince(_ context.Context, _ pgtype.Timestamptz) ([]pgstore.Incident, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.incidents, nil
+}
+func (f *fakeStore) ListSubscriptionsForProvider(_ context.Context, _ string) ([]pgstore.ListSubscriptionsForProviderRow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.subs, nil
+}
+func (f *fakeStore) IsAlertSent(_ context.Context, arg pgstore.IsAlertSentParams) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sent[alertKey(arg.SubscriptionID, arg.IncidentID, arg.Channel, arg.Event)], nil
+}
+func (f *fakeStore) LogAlert(_ context.Context, arg pgstore.LogAlertParams) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.logged = append(f.logged, arg)
+	if f.sent == nil {
+		f.sent = make(map[string]bool)
+	}
+	f.sent[alertKey(arg.SubscriptionID, arg.IncidentID, arg.Channel, arg.Event)] = true
+	return nil
+}
+
+func incidentFixture(providerID, status, severity string) pgstore.Incident {
+	now := time.Now().UTC()
+	return pgstore.Incident{
+		ID:         uuid.New(),
+		Slug:       providerID + "-test",
+		ProviderID: providerID,
+		Severity:   severity,
+		Title:      "Test incident",
+		Status:     status,
+		StartedAt:  pgtype.Timestamptz{Time: now, Valid: true},
+		UpdatedAt:  pgtype.Timestamptz{Time: now, Valid: true},
+	}
+}
+
+func subFixture(providerID, minSev, userEmail string, emailAlerts bool, webhookURL string) pgstore.ListSubscriptionsForProviderRow {
+	row := pgstore.ListSubscriptionsForProviderRow{
+		ID:           1,
+		UserID:       1,
+		ProviderID:   providerID,
+		MinSeverity:  minSev,
+		EmailAlerts:  emailAlerts,
+		EmailDigest:  true,
+		UserEmail:    userEmail,
+		ProviderName: providerID,
+	}
+	if webhookURL != "" {
+		row.WebhookUrl = pgtype.Text{String: webhookURL, Valid: true}
+	}
+	return row
+}
+
+// newTestNotifier creates a Notifier wired to a fake Resend server.
+// Returns the notifier and a pointer to the list of received requests.
+func newTestNotifier(t *testing.T, store *fakeStore) *Notifier {
+	t.Helper()
+	resend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ok"}`))
+	}))
+	t.Cleanup(resend.Close)
+	return New(Config{
+		Store:   store,
+		Email:   email.NewWithBaseURL(resend.URL, "key", "from@test.com"),
+		SiteURL: "https://test.local",
+	})
+}
+
+func TestPoll_SendsEmailOnNewIncident(t *testing.T) {
+	inc := incidentFixture("openai", "ongoing", "major")
+	store := &fakeStore{
+		incidents: []pgstore.Incident{inc},
+		subs:      []pgstore.ListSubscriptionsForProviderRow{subFixture("openai", "major", "u@test.com", true, "")},
+	}
+	newTestNotifier(t, store).poll(context.Background(), time.Now().Add(-time.Minute))
+
+	store.mu.Lock()
+	logged := store.logged
+	store.mu.Unlock()
+
+	if len(logged) != 1 {
+		t.Fatalf("logged %d alerts, want 1", len(logged))
+	}
+	if logged[0].Event != eventCreated {
+		t.Errorf("event = %q, want %q", logged[0].Event, eventCreated)
+	}
+	if logged[0].Channel != "email" {
+		t.Errorf("channel = %q, want email", logged[0].Channel)
+	}
+}
+
+func TestPoll_SeverityBelowMinSkipped(t *testing.T) {
+	inc := incidentFixture("openai", "ongoing", "minor")
+	store := &fakeStore{
+		incidents: []pgstore.Incident{inc},
+		subs:      []pgstore.ListSubscriptionsForProviderRow{subFixture("openai", "major", "u@test.com", true, "")},
+	}
+	newTestNotifier(t, store).poll(context.Background(), time.Now().Add(-time.Minute))
+
+	store.mu.Lock()
+	n := len(store.logged)
+	store.mu.Unlock()
+	if n != 0 {
+		t.Errorf("logged %d, want 0 (minor below major threshold)", n)
+	}
+}
+
+func TestPoll_NoDuplicateOnSecondPoll(t *testing.T) {
+	inc := incidentFixture("openai", "ongoing", "major")
+	store := &fakeStore{
+		incidents: []pgstore.Incident{inc},
+		subs:      []pgstore.ListSubscriptionsForProviderRow{subFixture("openai", "minor", "u@test.com", true, "")},
+	}
+	n := newTestNotifier(t, store)
+	ctx := context.Background()
+	since := time.Now().Add(-time.Minute)
+	n.poll(ctx, since)
+	n.poll(ctx, since)
+
+	store.mu.Lock()
+	total := len(store.logged)
+	store.mu.Unlock()
+	if total != 1 {
+		t.Errorf("logged %d across 2 polls, want 1 (dedup)", total)
+	}
+}
+
+func TestPoll_ResolvedEventDistinctFromCreated(t *testing.T) {
+	inc := incidentFixture("openai", "resolved", "major")
+	inc.ResolvedAt = pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}
+	store := &fakeStore{
+		incidents: []pgstore.Incident{inc},
+		subs:      []pgstore.ListSubscriptionsForProviderRow{subFixture("openai", "minor", "u@test.com", true, "")},
+	}
+	newTestNotifier(t, store).poll(context.Background(), time.Now().Add(-time.Minute))
+
+	store.mu.Lock()
+	logged := store.logged
+	store.mu.Unlock()
+	if len(logged) != 1 {
+		t.Fatalf("logged %d, want 1", len(logged))
+	}
+	if logged[0].Event != eventResolved {
+		t.Errorf("event = %q, want %q", logged[0].Event, eventResolved)
+	}
+}
+
+func TestPoll_WebhookDelivered(t *testing.T) {
+	var hits int
+	wh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer wh.Close()
+
+	inc := incidentFixture("anthropic", "ongoing", "critical")
+	store := &fakeStore{
+		incidents: []pgstore.Incident{inc},
+		subs:      []pgstore.ListSubscriptionsForProviderRow{subFixture("anthropic", "critical", "u@test.com", false, wh.URL)},
+	}
+	newTestNotifier(t, store).poll(context.Background(), time.Now().Add(-time.Minute))
+
+	if hits != 1 {
+		t.Errorf("webhook hit %d times, want 1", hits)
+	}
+	store.mu.Lock()
+	n := len(store.logged)
+	store.mu.Unlock()
+	if n != 1 {
+		t.Errorf("logged %d webhook alerts, want 1", n)
+	}
+}
+
+func TestWebhookRetry(t *testing.T) {
+	var hits int
+	wh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		if hits < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer wh.Close()
+
+	payload := webhookPayload{Event: "test", Title: "t"}
+	if err := deliverWebhook(context.Background(), wh.URL, payload); err != nil {
+		t.Fatalf("unexpected error after retries: %v", err)
+	}
+	if hits != 3 {
+		t.Errorf("expected 3 attempts, got %d", hits)
+	}
+}
+
+func TestIncidentEvent(t *testing.T) {
+	cases := []struct{ status, want string }{
+		{"ongoing", eventCreated},
+		{"resolved", eventResolved},
+		{"investigating", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := incidentEvent(tc.status); got != tc.want {
+			t.Errorf("incidentEvent(%q) = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}

--- a/internal/notifier/webhook.go
+++ b/internal/notifier/webhook.go
@@ -1,0 +1,60 @@
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var webhookClient = &http.Client{Timeout: 10 * time.Second}
+
+// deliverWebhook POSTs payload to url with 3 attempts and exponential backoff (1s, 4s, 16s).
+func deliverWebhook(ctx context.Context, url string, payload webhookPayload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("webhook: marshal: %w", err)
+	}
+
+	delays := []time.Duration{0, time.Second, 4 * time.Second, 16 * time.Second}
+	var lastErr error
+	for attempt, delay := range delays {
+		if delay > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		lastErr = postWebhook(ctx, url, body)
+		if lastErr == nil {
+			return nil
+		}
+		if attempt < len(delays)-1 {
+			// log transient failure; will retry
+			_ = lastErr
+		}
+	}
+	return fmt.Errorf("webhook: all attempts failed: %w", lastErr)
+}
+
+func postWebhook(ctx context.Context, url string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "llmstatus-notifier/1")
+
+	resp, err := webhookClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("remote returned %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/store/postgres/gen/models.go
+++ b/internal/store/postgres/gen/models.go
@@ -17,6 +17,7 @@ type AlertLog struct {
 	IncidentID     uuid.UUID          `json:"incident_id"`
 	Channel        string             `json:"channel"`
 	SentAt         pgtype.Timestamptz `json:"sent_at"`
+	Event          string             `json:"event"`
 }
 
 type Incident struct {

--- a/internal/store/postgres/gen/querier.go
+++ b/internal/store/postgres/gen/querier.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type Querier interface {
@@ -36,17 +37,20 @@ type Querier interface {
 	GetUserByEmail(ctx context.Context, email string) (User, error)
 	GetUserByID(ctx context.Context, id int64) (User, error)
 	GetUserByOAuth(ctx context.Context, arg GetUserByOAuthParams) (User, error)
+	IsAlertSent(ctx context.Context, arg IsAlertSentParams) (bool, error)
 	ListActiveProviders(ctx context.Context) ([]Provider, error)
 	ListIncidents(ctx context.Context, arg ListIncidentsParams) ([]Incident, error)
 	ListIncidentsByProvider(ctx context.Context, arg ListIncidentsByProviderParams) ([]Incident, error)
 	ListIncidentsByStatus(ctx context.Context, arg ListIncidentsByStatusParams) ([]Incident, error)
+	ListIncidentsUpdatedSince(ctx context.Context, updatedAt pgtype.Timestamptz) ([]Incident, error)
 	ListModelsByProvider(ctx context.Context, providerID string) ([]Model, error)
 	ListProviders(ctx context.Context) ([]Provider, error)
 	// ============================================================
 	// subscriptions (LLMS-050)
 	// ============================================================
 	ListSubscriptionsByUser(ctx context.Context, userID int64) ([]ListSubscriptionsByUserRow, error)
-	LogAlert(ctx context.Context, arg LogAlertParams) (AlertLog, error)
+	ListSubscriptionsForProvider(ctx context.Context, providerID string) ([]ListSubscriptionsForProviderRow, error)
+	LogAlert(ctx context.Context, arg LogAlertParams) error
 	MarkUserVerified(ctx context.Context, id int64) error
 	ResolveIncident(ctx context.Context, arg ResolveIncidentParams) error
 	SetIncidentDescription(ctx context.Context, arg SetIncidentDescriptionParams) error

--- a/internal/store/postgres/gen/queries.sql.go
+++ b/internal/store/postgres/gen/queries.sql.go
@@ -431,6 +431,35 @@ func (q *Queries) GetUserByOAuth(ctx context.Context, arg GetUserByOAuthParams) 
 	return i, err
 }
 
+const isAlertSent = `-- name: IsAlertSent :one
+SELECT EXISTS(
+    SELECT 1 FROM alert_log
+    WHERE subscription_id = $1
+      AND incident_id      = $2
+      AND channel          = $3
+      AND event            = $4
+) AS sent
+`
+
+type IsAlertSentParams struct {
+	SubscriptionID int64     `json:"subscription_id"`
+	IncidentID     uuid.UUID `json:"incident_id"`
+	Channel        string    `json:"channel"`
+	Event          string    `json:"event"`
+}
+
+func (q *Queries) IsAlertSent(ctx context.Context, arg IsAlertSentParams) (bool, error) {
+	row := q.db.QueryRow(ctx, isAlertSent,
+		arg.SubscriptionID,
+		arg.IncidentID,
+		arg.Channel,
+		arg.Event,
+	)
+	var sent bool
+	err := row.Scan(&sent)
+	return sent, err
+}
+
 const listActiveProviders = `-- name: ListActiveProviders :many
 SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config FROM providers
 WHERE active = TRUE
@@ -620,6 +649,50 @@ func (q *Queries) ListIncidentsByStatus(ctx context.Context, arg ListIncidentsBy
 	return items, nil
 }
 
+const listIncidentsUpdatedSince = `-- name: ListIncidentsUpdatedSince :many
+SELECT id, slug, provider_id, severity, title, description, status, affected_models, affected_regions, started_at, resolved_at, detection_method, detection_rule, metrics_snapshot, human_reviewed, created_at, updated_at FROM incidents
+WHERE updated_at > $1
+ORDER BY updated_at
+`
+
+func (q *Queries) ListIncidentsUpdatedSince(ctx context.Context, updatedAt pgtype.Timestamptz) ([]Incident, error) {
+	rows, err := q.db.Query(ctx, listIncidentsUpdatedSince, updatedAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Incident{}
+	for rows.Next() {
+		var i Incident
+		if err := rows.Scan(
+			&i.ID,
+			&i.Slug,
+			&i.ProviderID,
+			&i.Severity,
+			&i.Title,
+			&i.Description,
+			&i.Status,
+			&i.AffectedModels,
+			&i.AffectedRegions,
+			&i.StartedAt,
+			&i.ResolvedAt,
+			&i.DetectionMethod,
+			&i.DetectionRule,
+			&i.MetricsSnapshot,
+			&i.HumanReviewed,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listModelsByProvider = `-- name: ListModelsByProvider :many
 SELECT id, provider_id, model_id, display_name, model_type, active FROM models
 WHERE provider_id = $1
@@ -744,30 +817,80 @@ func (q *Queries) ListSubscriptionsByUser(ctx context.Context, userID int64) ([]
 	return items, nil
 }
 
-const logAlert = `-- name: LogAlert :one
-INSERT INTO alert_log (subscription_id, incident_id, channel)
-VALUES ($1, $2, $3)
-ON CONFLICT (subscription_id, incident_id, channel) DO UPDATE SET sent_at = alert_log.sent_at
-RETURNING id, subscription_id, incident_id, channel, sent_at
+const listSubscriptionsForProvider = `-- name: ListSubscriptionsForProvider :many
+SELECT s.id, s.user_id, s.provider_id, s.min_severity, s.email_alerts, s.email_digest, s.webhook_url, s.created_at, u.email AS user_email, p.name AS provider_name
+FROM subscriptions s
+JOIN users u ON u.id = s.user_id
+JOIN providers p ON p.id = s.provider_id
+WHERE s.provider_id = $1
+ORDER BY s.id
+`
+
+type ListSubscriptionsForProviderRow struct {
+	ID           int64              `json:"id"`
+	UserID       int64              `json:"user_id"`
+	ProviderID   string             `json:"provider_id"`
+	MinSeverity  string             `json:"min_severity"`
+	EmailAlerts  bool               `json:"email_alerts"`
+	EmailDigest  bool               `json:"email_digest"`
+	WebhookUrl   pgtype.Text        `json:"webhook_url"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UserEmail    string             `json:"user_email"`
+	ProviderName string             `json:"provider_name"`
+}
+
+func (q *Queries) ListSubscriptionsForProvider(ctx context.Context, providerID string) ([]ListSubscriptionsForProviderRow, error) {
+	rows, err := q.db.Query(ctx, listSubscriptionsForProvider, providerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSubscriptionsForProviderRow{}
+	for rows.Next() {
+		var i ListSubscriptionsForProviderRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.ProviderID,
+			&i.MinSeverity,
+			&i.EmailAlerts,
+			&i.EmailDigest,
+			&i.WebhookUrl,
+			&i.CreatedAt,
+			&i.UserEmail,
+			&i.ProviderName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const logAlert = `-- name: LogAlert :exec
+INSERT INTO alert_log (subscription_id, incident_id, channel, event)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (subscription_id, incident_id, channel, event) DO NOTHING
 `
 
 type LogAlertParams struct {
 	SubscriptionID int64     `json:"subscription_id"`
 	IncidentID     uuid.UUID `json:"incident_id"`
 	Channel        string    `json:"channel"`
+	Event          string    `json:"event"`
 }
 
-func (q *Queries) LogAlert(ctx context.Context, arg LogAlertParams) (AlertLog, error) {
-	row := q.db.QueryRow(ctx, logAlert, arg.SubscriptionID, arg.IncidentID, arg.Channel)
-	var i AlertLog
-	err := row.Scan(
-		&i.ID,
-		&i.SubscriptionID,
-		&i.IncidentID,
-		&i.Channel,
-		&i.SentAt,
+func (q *Queries) LogAlert(ctx context.Context, arg LogAlertParams) error {
+	_, err := q.db.Exec(ctx, logAlert,
+		arg.SubscriptionID,
+		arg.IncidentID,
+		arg.Channel,
+		arg.Event,
 	)
-	return i, err
+	return err
 }
 
 const markUserVerified = `-- name: MarkUserVerified :exec

--- a/internal/store/postgres/queries.sql
+++ b/internal/store/postgres/queries.sql
@@ -216,8 +216,29 @@ RETURNING *;
 -- name: DeleteSubscription :exec
 DELETE FROM subscriptions WHERE id = $1 AND user_id = $2;
 
--- name: LogAlert :one
-INSERT INTO alert_log (subscription_id, incident_id, channel)
-VALUES ($1, $2, $3)
-ON CONFLICT (subscription_id, incident_id, channel) DO UPDATE SET sent_at = alert_log.sent_at
-RETURNING *;
+-- name: ListIncidentsUpdatedSince :many
+SELECT * FROM incidents
+WHERE updated_at > $1
+ORDER BY updated_at;
+
+-- name: ListSubscriptionsForProvider :many
+SELECT s.*, u.email AS user_email, p.name AS provider_name
+FROM subscriptions s
+JOIN users u ON u.id = s.user_id
+JOIN providers p ON p.id = s.provider_id
+WHERE s.provider_id = $1
+ORDER BY s.id;
+
+-- name: IsAlertSent :one
+SELECT EXISTS(
+    SELECT 1 FROM alert_log
+    WHERE subscription_id = $1
+      AND incident_id      = $2
+      AND channel          = $3
+      AND event            = $4
+) AS sent;
+
+-- name: LogAlert :exec
+INSERT INTO alert_log (subscription_id, incident_id, channel, event)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (subscription_id, incident_id, channel, event) DO NOTHING;

--- a/store/migrations/0006_alert_log_event.down.sql
+++ b/store/migrations/0006_alert_log_event.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE alert_log DROP CONSTRAINT alert_log_unique;
+ALTER TABLE alert_log DROP COLUMN event;
+ALTER TABLE alert_log ADD CONSTRAINT alert_log_subscription_id_incident_id_channel_key
+    UNIQUE (subscription_id, incident_id, channel);

--- a/store/migrations/0006_alert_log_event.up.sql
+++ b/store/migrations/0006_alert_log_event.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE alert_log
+    ADD COLUMN event TEXT NOT NULL DEFAULT 'incident.created'
+        CHECK (event IN ('incident.created', 'incident.resolved'));
+
+ALTER TABLE alert_log
+    DROP CONSTRAINT alert_log_subscription_id_incident_id_channel_key;
+
+ALTER TABLE alert_log
+    ADD CONSTRAINT alert_log_unique
+        UNIQUE (subscription_id, incident_id, channel, event);


### PR DESCRIPTION
## Summary

- `store/migrations/0006_alert_log_event` — adds `event` column to `alert_log`; updates unique constraint to `(subscription_id, incident_id, channel, event)` so created and resolved notifications are distinct entries
- sqlc: `ListIncidentsUpdatedSince`, `ListSubscriptionsForProvider`, `IsAlertSent`, `LogAlert` (updated to `:exec` with new `event` param)
- `internal/email`: added `Sender` interface + `NewWithBaseURL` for test injection
- `internal/notifier/notifier.go` — `Notifier.Run()` ticker loop; `poll()` finds updated incidents, fans out to matching subscriptions, checks dedup via `IsAlertSent`, delivers, then `LogAlert`
- `internal/notifier/email.go` — HTML + plain text templates for `incident.created` / `incident.resolved`
- `internal/notifier/webhook.go` — HTTP POST with 3 retries, exponential backoff (0s, 1s, 4s, 16s), 10s timeout per attempt
- `cmd/notifier/main.go` — binary reading `DATABASE_URL`, `RESEND_API_KEY`, `NOTIFIER_POLL_INTERVAL`

## Dedup strategy
`IsAlertSent` is checked BEFORE delivery. `LogAlert` is written AFTER confirmed delivery. Failed sends are retried on the next poll — no silent suppression.

## Test plan
- [ ] `go test ./... -timeout 60s` — all pass (7 new notifier tests)
- [ ] `TestWebhookRetry` verifies 3 attempts on 500s then success
- [ ] `TestPoll_NoDuplicateOnSecondPoll` verifies dedup across poll cycles

Closes #110