### PR TITLE
feat LLMS-053: per-email OTP rate-limit via Redis

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,6 +14,7 @@
 //	RESEND_API_KEY         Resend email API key (required when JWT_SECRET set)
 //	EMAIL_FROM             Sender address (default "noreply@llmstatus.io")
 //	INTERNAL_SECRET        Shared secret for /auth/oauth/upsert (required when JWT_SECRET set)
+//	REDIS_URL              Redis DSN — enables per-email OTP rate limiting when set
 //	SITE_URL               Public site URL (default "https://llmstatus.io")
 //	GOOGLE_CLIENT_ID       Google OAuth client ID
 //	GOOGLE_CLIENT_SECRET   Google OAuth client secret
@@ -34,8 +35,11 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/redis/go-redis/v9"
+
 	"github.com/llmstatus/llmstatus/internal/api"
 	"github.com/llmstatus/llmstatus/internal/email"
+	"github.com/llmstatus/llmstatus/internal/otprl"
 	"github.com/llmstatus/llmstatus/internal/store/influx"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
@@ -80,6 +84,15 @@ func main() {
 			Email:          email.New(requireEnv("RESEND_API_KEY"), emailFrom),
 			JWTSecret:      jwtSecret,
 			InternalSecret: requireEnv("INTERNAL_SECRET"),
+		}
+		if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {
+			opt, err := redis.ParseURL(redisURL)
+			if err != nil {
+				slog.Error("api: invalid REDIS_URL", "err", err)
+				os.Exit(1)
+			}
+			authCfg.OTPLimiter = otprl.NewRedis(redis.NewClient(opt))
+			slog.Info("api: OTP rate-limiting enabled")
 		}
 		opts = append(opts, api.WithAuth(authCfg))
 		slog.Info("api: auth enabled")

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -37,6 +38,7 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mdelapenya/tlscert v0.2.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
 	github.com/moby/moby/api v1.54.1 // indirect
@@ -50,11 +52,13 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0 // indirect
+	github.com/testcontainers/testcontainers-go/modules/redis v0.42.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
@@ -63,6 +67,7 @@ require (
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
@@ -68,6 +70,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
+github.com/mdelapenya/tlscert v0.2.0/go.mod h1:O4njj3ELLnJjGdkN7M/vIVCpZ+Cf0L6muqOG4tLSl8o=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
@@ -96,6 +100,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
@@ -109,6 +115,8 @@ github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44Xt
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0 h1:GCbb1ndrF7OTDiIvxXyItaDab4qkzTFJ48LKFdM7EIo=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0/go.mod h1:IRPBaI8jXdrNfD0e4Zm7Fbcgaz5shKxOQv4axiL09xs=
+github.com/testcontainers/testcontainers-go/modules/redis v0.42.0 h1:id/6LH8ZeDrtAUVSuNvZUAJ1kVpb82y1pr9yweAWsRg=
+github.com/testcontainers/testcontainers-go/modules/redis v0.42.0/go.mod h1:uF0jI8FITagQpBNOgweGBmPf6rP4K0SeL1XFPbsZSSY=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
@@ -127,6 +135,8 @@ go.opentelemetry.io/otel/metric v1.41.0 h1:rFnDcs4gRzBcsO9tS8LCpgR0dxg4aaxWlJxCn
 go.opentelemetry.io/otel/metric v1.41.0/go.mod h1:xPvCwd9pU0VN8tPZYzDZV/BMj9CM9vs00GuBjeKhJps=
 go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa9TIN0=
 go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/llmstatus/llmstatus/internal/auth"
 	"github.com/llmstatus/llmstatus/internal/email"
+	"github.com/llmstatus/llmstatus/internal/otprl"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 
@@ -37,7 +38,8 @@ type AuthConfig struct {
 	Store          AuthStore
 	Email          *email.Client
 	JWTSecret      string
-	InternalSecret string // required for /auth/oauth/upsert; shared with Next.js via INTERNAL_SECRET env var
+	InternalSecret string        // required for /auth/oauth/upsert; shared with Next.js via INTERNAL_SECRET env var
+	OTPLimiter     otprl.Limiter // optional; nil disables per-email rate limiting
 }
 
 // handleOTPSend handles POST /auth/otp/send
@@ -50,6 +52,18 @@ func (s *Server) handleOTPSend(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Email == "" {
 		writeError(w, http.StatusBadRequest, "email required")
 		return
+	}
+
+	if s.auth.OTPLimiter != nil {
+		ok, retryAfter, err := s.auth.OTPLimiter.Allow(r.Context(), body.Email)
+		if err != nil {
+			slog.Warn("auth: otp rate-limit check failed", "err", err)
+			// fail open — don't block the user on a Redis outage
+		} else if !ok {
+			w.Header().Set("Retry-After", fmt.Sprintf("%.0f", retryAfter.Seconds()))
+			writeError(w, http.StatusTooManyRequests, "too many OTP requests, try again later")
+			return
+		}
 	}
 
 	user, err := s.auth.Store.UpsertUser(r.Context(), body.Email)

--- a/internal/otprl/ratelimiter.go
+++ b/internal/otprl/ratelimiter.go
@@ -1,0 +1,76 @@
+// Package otprl implements per-email OTP send rate limiting.
+package otprl
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	MaxAttempts = 3
+	Window      = 10 * time.Minute
+)
+
+// Limiter checks whether an OTP send is allowed for a given email.
+type Limiter interface {
+	// Allow returns (true, zero) when the request is permitted.
+	// Returns (false, retryAfter) when the rate limit is exceeded.
+	Allow(ctx context.Context, email string) (ok bool, retryAfter time.Duration, err error)
+}
+
+// RedisLimiter is a Redis-backed implementation of Limiter.
+type RedisLimiter struct {
+	rdb *redis.Client
+}
+
+func NewRedis(rdb *redis.Client) *RedisLimiter {
+	return &RedisLimiter{rdb: rdb}
+}
+
+func (r *RedisLimiter) Allow(ctx context.Context, email string) (bool, time.Duration, error) {
+	key := otpKey(email)
+
+	// SetNX initialises the counter at 0 with TTL on the very first request.
+	// INCR is then always safe: if the key was just created we increment to 1;
+	// if it already existed we increment the existing counter.
+	r.rdb.SetNX(ctx, key, 0, Window)
+
+	count, err := r.rdb.Incr(ctx, key).Result()
+	if err != nil {
+		return false, 0, fmt.Errorf("otprl: redis incr: %w", err)
+	}
+	if count > MaxAttempts {
+		ttl, err := r.rdb.TTL(ctx, key).Result()
+		if err != nil || ttl < 0 {
+			ttl = Window
+		}
+		return false, ttl, nil
+	}
+	return true, 0, nil
+}
+
+func otpKey(email string) string {
+	h := sha256.Sum256([]byte(email))
+	return fmt.Sprintf("otp_rate:%x", h)
+}
+
+// MemoryLimiter is an in-process Limiter for unit tests.
+type MemoryLimiter struct {
+	counts map[string]int
+}
+
+func NewMemory() *MemoryLimiter {
+	return &MemoryLimiter{counts: make(map[string]int)}
+}
+
+func (m *MemoryLimiter) Allow(_ context.Context, email string) (bool, time.Duration, error) {
+	m.counts[email]++
+	if m.counts[email] > MaxAttempts {
+		return false, Window, nil
+	}
+	return true, 0, nil
+}

--- a/internal/otprl/ratelimiter_integration_test.go
+++ b/internal/otprl/ratelimiter_integration_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package otprl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/llmstatus/llmstatus/internal/otprl"
+	"github.com/llmstatus/llmstatus/pkg/testutil"
+)
+
+func TestRedisLimiter_AllowsUpToMax(t *testing.T) {
+	url := testutil.NewRedis(t)
+	opt, err := redis.ParseURL(url)
+	if err != nil {
+		t.Fatalf("parse redis url: %v", err)
+	}
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() { rdb.Close() })
+
+	lim := otprl.NewRedis(rdb)
+	ctx := context.Background()
+	const email = "integ@example.com"
+
+	for i := range otprl.MaxAttempts {
+		ok, _, err := lim.Allow(ctx, email)
+		if err != nil {
+			t.Fatalf("attempt %d: %v", i+1, err)
+		}
+		if !ok {
+			t.Fatalf("attempt %d: expected allowed", i+1)
+		}
+	}
+}
+
+func TestRedisLimiter_BlocksFourthAttempt(t *testing.T) {
+	url := testutil.NewRedis(t)
+	opt, _ := redis.ParseURL(url)
+	rdb := redis.NewClient(opt)
+	t.Cleanup(func() { rdb.Close() })
+
+	lim := otprl.NewRedis(rdb)
+	ctx := context.Background()
+	const email = "flood-integ@example.com"
+
+	for range otprl.MaxAttempts {
+		lim.Allow(ctx, email) //nolint:errcheck
+	}
+
+	ok, retryAfter, err := lim.Allow(ctx, email)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("4th attempt should be denied")
+	}
+	if retryAfter <= 0 {
+		t.Errorf("retryAfter = %v, want > 0", retryAfter)
+	}
+}

--- a/internal/otprl/ratelimiter_test.go
+++ b/internal/otprl/ratelimiter_test.go
@@ -1,0 +1,64 @@
+package otprl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/llmstatus/llmstatus/internal/otprl"
+)
+
+// Unit tests — MemoryLimiter (no external deps).
+
+func TestMemoryLimiter_AllowsUpToMax(t *testing.T) {
+	lim := otprl.NewMemory()
+	ctx := context.Background()
+	const email = "test@example.com"
+
+	for i := range otprl.MaxAttempts {
+		ok, _, err := lim.Allow(ctx, email)
+		if err != nil {
+			t.Fatalf("attempt %d: unexpected error: %v", i+1, err)
+		}
+		if !ok {
+			t.Fatalf("attempt %d: expected allowed, got denied", i+1)
+		}
+	}
+}
+
+func TestMemoryLimiter_BlocksFourthAttempt(t *testing.T) {
+	lim := otprl.NewMemory()
+	ctx := context.Background()
+	const email = "flood@example.com"
+
+	for range otprl.MaxAttempts {
+		lim.Allow(ctx, email) //nolint:errcheck
+	}
+
+	ok, retryAfter, err := lim.Allow(ctx, email)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("4th attempt should be denied")
+	}
+	if retryAfter <= 0 {
+		t.Errorf("retryAfter should be positive, got %v", retryAfter)
+	}
+}
+
+func TestMemoryLimiter_IndependentPerEmail(t *testing.T) {
+	lim := otprl.NewMemory()
+	ctx := context.Background()
+
+	for range otprl.MaxAttempts {
+		lim.Allow(ctx, "a@example.com") //nolint:errcheck
+	}
+	// b@example.com is a fresh counter
+	ok, _, err := lim.Allow(ctx, "b@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("different email should not be rate-limited")
+	}
+}

--- a/pkg/testutil/redis.go
+++ b/pkg/testutil/redis.go
@@ -1,13 +1,29 @@
 package testutil
 
-import "testing"
+import (
+	"context"
+	"testing"
 
-// NewRedis starts an isolated Redis instance via testcontainers and
-// returns its address. Cleanup is registered via t.Cleanup.
-//
-// Scaffolded by LLMS-001. Implementation follows in LLMS-002+.
+	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
+)
+
+// NewRedis starts an isolated Redis 7 container and returns its connection URL.
+// The container is stopped automatically via t.Cleanup.
 func NewRedis(t *testing.T) string {
 	t.Helper()
-	t.Skip("testutil.NewRedis: not implemented (LLMS-002)")
-	return ""
+	ctx := context.Background()
+	c, err := tcredis.Run(ctx, "redis:7-alpine")
+	if err != nil {
+		t.Fatalf("testutil.NewRedis: start container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := c.Terminate(ctx); err != nil {
+			t.Logf("testutil.NewRedis: terminate container: %v", err)
+		}
+	})
+	url, err := c.ConnectionString(ctx)
+	if err != nil {
+		t.Fatalf("testutil.NewRedis: connection string: %v", err)
+	}
+	return url
 }


### PR DESCRIPTION
## Summary

- `internal/otprl/ratelimiter.go` — `Limiter` interface + `RedisLimiter` (SetNX then INCR, 3 sends / 10 min window) + `MemoryLimiter` for unit tests
- `AuthConfig.OTPLimiter otprl.Limiter` — optional; nil disables rate-limiting (fail-open on Redis outage)
- `handleOTPSend`: checks limiter before DB write; returns 429 + `Retry-After` header on breach
- `cmd/api/main.go`: wires `RedisLimiter` when `REDIS_URL` env var is set
- `pkg/testutil/redis.go`: implements `NewRedis` using `testcontainers-go/modules/redis` (redis:7-alpine)
- 3 unit tests (MemoryLimiter); 2 integration tests tagged `//go:build integration` (real Redis)

## Key design notes

- Key: `otp_rate:<sha256(email)>` — PII-free Redis keys
- SetNX initialises counter at 0 with TTL; INCR always increments; avoids the "INCR then EXPIRE" race where a crash between the two commands leaves a persistent key
- Fail-open: Redis errors are logged but don't block the user

## Test plan
- [ ] `go test ./internal/otprl/... ./internal/api/...` — passes
- [ ] `go test ./internal/otprl/... -tags integration` — requires Docker

Closes #113