### PR TITLE
feat LLMS-054: wire end-to-end pipeline — livekeys build, provider seed, notifier in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,12 +22,24 @@ DATABASE_URL=pgx5://llmstatus:llmstatus@localhost:15432/llmstatus?sslmode=disabl
 # ── Public API (cmd/api) ─────────────────────────────────────────────────────
 API_ADDR=:8081
 API_RATE_LIMIT=60
+# REQUIRED for auth endpoints:
+JWT_SECRET=change-me-in-production
+INTERNAL_SECRET=change-me-in-production
+# Optional — enables OTP rate-limiting (3 requests per 10 min per email):
+# REDIS_URL=redis://localhost:6379
 
 # ── Ingest API (cmd/ingest) ──────────────────────────────────────────────────
 INGEST_ADDR=:8080
 
 # ── Detector (cmd/detector) ──────────────────────────────────────────────────
 DETECTOR_INTERVAL=60s
+
+# ── Notifier (cmd/notifier) ──────────────────────────────────────────────────
+# REQUIRED for email delivery:
+RESEND_API_KEY=
+EMAIL_FROM=noreply@llmstatus.io
+SITE_URL=https://llmstatus.io
+NOTIFIER_POLL_INTERVAL=30s
 
 # ── Prober (cmd/prober) ──────────────────────────────────────────────────────
 REGION_ID=local-dev
@@ -36,10 +48,11 @@ PROBE_TIMEOUT=30s
 PROBE_CONCURRENCY=4
 INGEST_URL=http://localhost:18080
 
-# ── Provider API keys ────────────────────────────────────────────────────────
-OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
-GOOGLE_API_KEY=
+# ── Provider API keys (REQUIRED for prober to fire live requests) ─────────────
+# These must match the env var names read by each adapter's init() in
+# internal/probes/adapters/*_register_livekeys.go.
+LLMS_OPENAI_API_KEY=
+LLMS_ANTHROPIC_API_KEY=
 
 # ── Frontend (web/) ───────────────────────────────────────────────────────────
 # Used by Next.js SSR. Set in web/.env.local for local dev (see web/.env.local.example).

--- a/deploy/docker/Dockerfile.golang
+++ b/deploy/docker/Dockerfile.golang
@@ -13,7 +13,12 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /bin/service ./cmd/${CMD}
+# prober must include live-API adapter registration; other services do not.
+RUN if [ "$CMD" = "prober" ]; then \
+      CGO_ENABLED=0 GOOS=linux go build -tags livekeys -ldflags="-s -w" -o /bin/service ./cmd/${CMD}; \
+    else \
+      CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /bin/service ./cmd/${CMD}; \
+    fi
 
 # ---- runtime ----------------------------------------------------------------
 FROM alpine:3.21 AS runtime

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,24 @@ services:
       timeout: 5s
       retries: 5
 
+  notifier:
+    build:
+      context: .
+      dockerfile: deploy/docker/Dockerfile.golang
+      args:
+        CMD: notifier
+    container_name: llmstatus-notifier
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgres://llmstatus:llmstatus@db:5432/llmstatus?sslmode=disable
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      EMAIL_FROM: ${EMAIL_FROM:-noreply@llmstatus.io}
+      SITE_URL: ${SITE_URL:-https://llmstatus.io}
+      NOTIFIER_POLL_INTERVAL: ${NOTIFIER_POLL_INTERVAL:-30s}
+    depends_on:
+      db:
+        condition: service_healthy
+
   # ── frontend ───────────────────────────────────────────────────────────────
 
   web:
@@ -187,9 +205,8 @@ services:
       PROBE_TIMEOUT: ${PROBE_TIMEOUT:-30s}
       PROBE_CONCURRENCY: ${PROBE_CONCURRENCY:-4}
       INGEST_URL: http://ingest:8080
-    env_file:
-      - path: .env
-        required: false
+      LLMS_OPENAI_API_KEY: ${LLMS_OPENAI_API_KEY:-}
+      LLMS_ANTHROPIC_API_KEY: ${LLMS_ANTHROPIC_API_KEY:-}
     depends_on:
       db:
         condition: service_healthy

--- a/internal/probes/adapters/anthropic.go
+++ b/internal/probes/adapters/anthropic.go
@@ -23,12 +23,6 @@ const (
 	anthropicStatusOverloaded = 529
 )
 
-func init() {
-	// Register a zero-key placeholder so the adapter appears in the registry.
-	// cmd/prober replaces this with a keyed instance loaded from the environment.
-	Register(NewAnthropicProvider("", ""))
-}
-
 // AnthropicOption configures an Anthropic provider at construction time.
 type AnthropicOption func(*anthropicProvider)
 

--- a/internal/probes/adapters/anthropic_register_livekeys.go
+++ b/internal/probes/adapters/anthropic_register_livekeys.go
@@ -1,0 +1,20 @@
+//go:build livekeys
+
+// This file wires the Anthropic adapter into the global registry only when
+// the binary is built with `-tags livekeys`. See openai_register_livekeys.go
+// for rationale.
+//
+// Build with: `go build -tags livekeys ./cmd/prober`
+
+package adapters
+
+import "os"
+
+func init() {
+	apiKey := os.Getenv("LLMS_ANTHROPIC_API_KEY")
+	region := os.Getenv("LLMS_REGION_ID")
+	if apiKey == "" || region == "" {
+		return
+	}
+	Register(NewAnthropicProvider(apiKey, region))
+}

--- a/store/migrations/0008_seed_providers.down.sql
+++ b/store/migrations/0008_seed_providers.down.sql
@@ -1,0 +1,6 @@
+-- Removes seed rows added by 0008_seed_providers.up.sql.
+-- Cascades via FK will clean up models rows automatically.
+
+BEGIN;
+DELETE FROM providers WHERE id IN ('openai', 'anthropic');
+COMMIT;

--- a/store/migrations/0008_seed_providers.up.sql
+++ b/store/migrations/0008_seed_providers.up.sql
@@ -1,0 +1,25 @@
+-- 0008_seed_providers.sql — initial provider and model seed data (LLMS-054)
+--
+-- Only providers with working adapters and registered livekeys init() are
+-- included here. Add rows for each new adapter via a subsequent migration.
+
+BEGIN;
+
+INSERT INTO providers (id, name, category, base_url, auth_type, status_page_url, documentation_url, region, active)
+VALUES
+    ('openai',    'OpenAI',    'official', 'https://api.openai.com',         'bearer', 'https://status.openai.com',    'https://platform.openai.com/docs',          'global', TRUE),
+    ('anthropic', 'Anthropic', 'official', 'https://api.anthropic.com',      'bearer', 'https://status.anthropic.com', 'https://docs.anthropic.com',                 'global', TRUE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO models (provider_id, model_id, display_name, model_type, active)
+VALUES
+    -- OpenAI
+    ('openai', 'gpt-4o-mini',           'GPT-4o mini',          'chat',      TRUE),
+    ('openai', 'gpt-4o',                'GPT-4o',               'chat',      TRUE),
+    ('openai', 'text-embedding-3-small', 'text-embedding-3-small', 'embedding', TRUE),
+    -- Anthropic
+    ('anthropic', 'claude-haiku-4-5-20251001', 'Claude Haiku 4.5', 'chat', TRUE),
+    ('anthropic', 'claude-sonnet-4-6',         'Claude Sonnet 4.6', 'chat', TRUE)
+ON CONFLICT (provider_id, model_id) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **Dockerfile**: prober CMD now builds with `-tags livekeys` so adapter `init()` functions that register live API clients are included; all other services build without the tag (no accidental live calls)
- **Migration 0008**: seeds `providers` and `models` rows for OpenAI (gpt-4o-mini, gpt-4o, text-embedding-3-small) and Anthropic (claude-haiku-4-5, claude-sonnet-4-6) — prober's `ListActiveProviders` was returning empty and exiting immediately
- **Anthropic livekeys**: removed the zero-key `init()` from `anthropic.go`; added `anthropic_register_livekeys.go` (same pattern as OpenAI) reading `LLMS_ANTHROPIC_API_KEY` + `LLMS_REGION_ID`
- **docker-compose.yml**: added `notifier` service; prober service now forwards `LLMS_OPENAI_API_KEY` / `LLMS_ANTHROPIC_API_KEY` into the container
- **.env.example**: documents all required vars across all 5 services; fixes `OPENAI_API_KEY` → `LLMS_OPENAI_API_KEY` naming mismatch

## Test plan

- [ ] `go build ./...` and `go build -tags livekeys ./cmd/prober` both pass
- [ ] `go test ./...` all green
- [ ] `docker compose up -d db influx && docker compose run --rm migrate` applies all 8 migrations cleanly
- [ ] With `LLMS_OPENAI_API_KEY` set: `docker compose --profile prober up -d prober` → logs show successful probe results within 60s

Closes #122