### PR TITLE
feat LLMS-055: DeepSeek, Gemini, Mistral adapters + livekeys fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,9 @@ INGEST_URL=http://localhost:18080
 # internal/probes/adapters/*_register_livekeys.go.
 LLMS_OPENAI_API_KEY=
 LLMS_ANTHROPIC_API_KEY=
+LLMS_DEEPSEEK_API_KEY=
+LLMS_GEMINI_API_KEY=
+LLMS_MISTRAL_API_KEY=
 
 # ── Frontend (web/) ───────────────────────────────────────────────────────────
 # Used by Next.js SSR. Set in web/.env.local for local dev (see web/.env.local.example).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,6 +207,9 @@ services:
       INGEST_URL: http://ingest:8080
       LLMS_OPENAI_API_KEY: ${LLMS_OPENAI_API_KEY:-}
       LLMS_ANTHROPIC_API_KEY: ${LLMS_ANTHROPIC_API_KEY:-}
+      LLMS_DEEPSEEK_API_KEY: ${LLMS_DEEPSEEK_API_KEY:-}
+      LLMS_GEMINI_API_KEY: ${LLMS_GEMINI_API_KEY:-}
+      LLMS_MISTRAL_API_KEY: ${LLMS_MISTRAL_API_KEY:-}
     depends_on:
       db:
         condition: service_healthy

--- a/internal/probes/adapters/anthropic_register_livekeys.go
+++ b/internal/probes/adapters/anthropic_register_livekeys.go
@@ -12,9 +12,8 @@ import "os"
 
 func init() {
 	apiKey := os.Getenv("LLMS_ANTHROPIC_API_KEY")
-	region := os.Getenv("LLMS_REGION_ID")
-	if apiKey == "" || region == "" {
+	if apiKey == "" {
 		return
 	}
-	Register(NewAnthropicProvider(apiKey, region))
+	Register(NewAnthropicProvider(apiKey, ""))
 }

--- a/internal/probes/adapters/deepseek.go
+++ b/internal/probes/adapters/deepseek.go
@@ -1,0 +1,123 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/httpclient"
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+const (
+	deepseekDefaultBaseURL = "https://api.deepseek.com/v1"
+	deepseekProviderID     = "deepseek"
+	deepseekLightModel     = "deepseek-chat"
+	deepseekLightProbeType = "light_inference"
+	deepseekErrorDetailMax = 200
+)
+
+// DeepSeekOption configures a DeepSeek provider at construction time.
+type DeepSeekOption func(*deepseekProvider)
+
+// WithDeepSeekBaseURL overrides the base URL. Intended for tests.
+func WithDeepSeekBaseURL(u string) DeepSeekOption {
+	return func(p *deepseekProvider) { p.baseURL = u }
+}
+
+// WithDeepSeekHTTPClient overrides the HTTP client. Intended for tests.
+func WithDeepSeekHTTPClient(c *http.Client) DeepSeekOption {
+	return func(p *deepseekProvider) { p.client = c }
+}
+
+// NewDeepSeekProvider returns a probes.Provider backed by api.deepseek.com.
+// DeepSeek exposes an OpenAI-compatible Chat Completions API.
+func NewDeepSeekProvider(apiKey, region string, opts ...DeepSeekOption) probes.Provider {
+	p := &deepseekProvider{
+		baseURL: deepseekDefaultBaseURL,
+		apiKey:  apiKey,
+		region:  region,
+		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+type deepseekProvider struct {
+	baseURL string
+	apiKey  string
+	region  string
+	client  *http.Client
+}
+
+func (p *deepseekProvider) ID() string       { return deepseekProviderID }
+func (p *deepseekProvider) Models() []string { return []string{deepseekLightModel} }
+
+func (p *deepseekProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: deepseekProviderID,
+		Model:      model,
+		ProbeType:  deepseekLightProbeType,
+		StartedAt:  started.UTC(),
+		RegionID:   p.region,
+	}
+
+	req, err := p.buildRequest(ctx, model)
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), deepseekErrorDetailMax)
+		return r, err
+	}
+
+	resp, err := p.client.Do(req)
+	r.DurationMs = time.Since(started).Milliseconds()
+	if err != nil {
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), deepseekErrorDetailMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	body, _ := io.ReadAll(resp.Body)
+	// DeepSeek uses the same response envelope as OpenAI.
+	classifyOpenAIResponse(&r, resp.StatusCode, body)
+	return r, nil
+}
+
+func (p *deepseekProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: deepseekProviderID, ProbeType: "quality"}
+}
+
+func (p *deepseekProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: deepseekProviderID, ProbeType: "embedding"}
+}
+
+func (p *deepseekProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: deepseekProviderID, ProbeType: "streaming"}
+}
+
+func (p *deepseekProvider) buildRequest(ctx context.Context, model string) (*http.Request, error) {
+	body, err := json.Marshal(openaiChatRequest{
+		Model:     model,
+		Messages:  []openaiChatMessage{{Role: "user", Content: "ping"}},
+		MaxTokens: 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}

--- a/internal/probes/adapters/deepseek/testdata/chat_completions_200.json
+++ b/internal/probes/adapters/deepseek/testdata/chat_completions_200.json
@@ -1,0 +1,18 @@
+{
+  "id": "chatcmpl-deepseek-abc123",
+  "object": "chat.completion",
+  "created": 1714000000,
+  "model": "deepseek-chat",
+  "choices": [
+    {
+      "index": 0,
+      "message": {"role": "assistant", "content": "pong"},
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 5,
+    "completion_tokens": 1,
+    "total_tokens": 6
+  }
+}

--- a/internal/probes/adapters/deepseek/testdata/chat_completions_401.json
+++ b/internal/probes/adapters/deepseek/testdata/chat_completions_401.json
@@ -1,0 +1,1 @@
+{"error": {"message": "Invalid API key", "type": "authentication_error", "code": "invalid_api_key"}}

--- a/internal/probes/adapters/deepseek/testdata/chat_completions_429.json
+++ b/internal/probes/adapters/deepseek/testdata/chat_completions_429.json
@@ -1,0 +1,1 @@
+{"error": {"message": "Rate limit exceeded", "type": "requests", "code": "rate_limit_exceeded"}}

--- a/internal/probes/adapters/deepseek/testdata/chat_completions_500.json
+++ b/internal/probes/adapters/deepseek/testdata/chat_completions_500.json
@@ -1,0 +1,1 @@
+{"error": {"message": "Internal server error", "type": "server_error"}}

--- a/internal/probes/adapters/deepseek_register_livekeys.go
+++ b/internal/probes/adapters/deepseek_register_livekeys.go
@@ -1,0 +1,13 @@
+//go:build livekeys
+
+package adapters
+
+import "os"
+
+func init() {
+	apiKey := os.Getenv("LLMS_DEEPSEEK_API_KEY")
+	if apiKey == "" {
+		return
+	}
+	Register(NewDeepSeekProvider(apiKey, ""))
+}

--- a/internal/probes/adapters/deepseek_test.go
+++ b/internal/probes/adapters/deepseek_test.go
@@ -1,0 +1,114 @@
+package adapters
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+func mustReadDeepSeekFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("deepseek", "testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}
+
+func TestDeepSeek_Identity(t *testing.T) {
+	p := NewDeepSeekProvider("sk-fake", "node-1")
+	if got := p.ID(); got != "deepseek" {
+		t.Errorf("ID: got %q, want deepseek", got)
+	}
+	if got := p.Models(); len(got) == 0 || got[0] != "deepseek-chat" {
+		t.Errorf("Models: got %v", got)
+	}
+}
+
+func TestDeepSeek_ProbeLightInference(t *testing.T) {
+	cases := []struct {
+		name         string
+		httpStatus   int
+		fixture      string
+		wantSuccess  bool
+		wantErrClass probes.ErrorClass
+	}{
+		{"success", http.StatusOK, "chat_completions_200.json", true, probes.ErrorClassNone},
+		{"auth", http.StatusUnauthorized, "chat_completions_401.json", false, probes.ErrorClassAuth},
+		{"rate_limit", http.StatusTooManyRequests, "chat_completions_429.json", false, probes.ErrorClassRateLimit},
+		{"server_5xx", http.StatusInternalServerError, "chat_completions_500.json", false, probes.ErrorClassServer5xx},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustReadDeepSeekFixture(t, tc.fixture)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/chat/completions" {
+					t.Errorf("path: got %q, want /chat/completions", r.URL.Path)
+				}
+				w.WriteHeader(tc.httpStatus)
+				_, _ = w.Write(body)
+			}))
+			t.Cleanup(srv.Close)
+
+			p := NewDeepSeekProvider("sk-fake", "node-1", WithDeepSeekBaseURL(srv.URL))
+			r, err := p.ProbeLightInference(context.Background(), "deepseek-chat")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.ProviderID != "deepseek" {
+				t.Errorf("ProviderID: got %q, want deepseek", r.ProviderID)
+			}
+			if r.Success != tc.wantSuccess {
+				t.Errorf("Success: got %v, want %v", r.Success, tc.wantSuccess)
+			}
+			if r.ErrorClass != tc.wantErrClass {
+				t.Errorf("ErrorClass: got %q, want %q", r.ErrorClass, tc.wantErrClass)
+			}
+			if tc.wantSuccess && r.TokensIn == 0 {
+				t.Error("expected non-zero tokens_in on success")
+			}
+		})
+	}
+}
+
+func TestDeepSeek_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewDeepSeekProvider("sk-fake", "node-1",
+		WithDeepSeekBaseURL(srv.URL),
+		WithDeepSeekHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}),
+	)
+	r, err := p.ProbeLightInference(context.Background(), "deepseek-chat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.ErrorClass != probes.ErrorClassTimeout {
+		t.Errorf("ErrorClass: got %q, want timeout", r.ErrorClass)
+	}
+}
+
+func TestDeepSeek_UnsupportedProbes(t *testing.T) {
+	p := NewDeepSeekProvider("sk-fake", "node-1")
+	var ns *probes.ErrNotSupported
+	for _, fn := range []func() error{
+		func() error { _, err := p.ProbeQuality(context.Background(), "m"); return err },
+		func() error { _, err := p.ProbeEmbedding(context.Background(), "m"); return err },
+		func() error { _, err := p.ProbeStreaming(context.Background(), "m"); return err },
+	} {
+		if err := fn(); !errors.As(err, &ns) {
+			t.Errorf("want ErrNotSupported, got %T: %v", err, err)
+		}
+	}
+}

--- a/internal/probes/adapters/gemini.go
+++ b/internal/probes/adapters/gemini.go
@@ -1,0 +1,200 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/httpclient"
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+const (
+	geminiDefaultBaseURL = "https://generativelanguage.googleapis.com"
+	geminiProviderID     = "google_gemini"
+	geminiLightModel     = "gemini-2.0-flash"
+	geminiLightProbeType = "light_inference"
+	geminiErrorDetailMax = 200
+)
+
+// GeminiOption configures a Gemini provider at construction time.
+type GeminiOption func(*geminiProvider)
+
+// WithGeminiBaseURL overrides the base URL. Intended for tests.
+func WithGeminiBaseURL(u string) GeminiOption {
+	return func(p *geminiProvider) { p.baseURL = u }
+}
+
+// WithGeminiHTTPClient overrides the HTTP client. Intended for tests.
+func WithGeminiHTTPClient(c *http.Client) GeminiOption {
+	return func(p *geminiProvider) { p.client = c }
+}
+
+// NewGeminiProvider returns a probes.Provider backed by the Google Gemini API.
+func NewGeminiProvider(apiKey, region string, opts ...GeminiOption) probes.Provider {
+	p := &geminiProvider{
+		baseURL: geminiDefaultBaseURL,
+		apiKey:  apiKey,
+		region:  region,
+		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+type geminiProvider struct {
+	baseURL string
+	apiKey  string
+	region  string
+	client  *http.Client
+}
+
+func (p *geminiProvider) ID() string       { return geminiProviderID }
+func (p *geminiProvider) Models() []string { return []string{geminiLightModel} }
+
+func (p *geminiProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: geminiProviderID,
+		Model:      model,
+		ProbeType:  geminiLightProbeType,
+		StartedAt:  started.UTC(),
+		RegionID:   p.region,
+	}
+
+	req, err := p.buildRequest(ctx, model)
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), geminiErrorDetailMax)
+		return r, err
+	}
+
+	resp, err := p.client.Do(req)
+	r.DurationMs = time.Since(started).Milliseconds()
+	if err != nil {
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), geminiErrorDetailMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	body, _ := io.ReadAll(resp.Body)
+	classifyGeminiResponse(&r, resp.StatusCode, body)
+	return r, nil
+}
+
+func (p *geminiProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: geminiProviderID, ProbeType: "quality"}
+}
+
+func (p *geminiProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: geminiProviderID, ProbeType: "embedding"}
+}
+
+func (p *geminiProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: geminiProviderID, ProbeType: "streaming"}
+}
+
+// gemini request/response types
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+	Role  string       `json:"role,omitempty"`
+}
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiGenerateRequest struct {
+	Contents         []geminiContent  `json:"contents"`
+	GenerationConfig geminiGenConfig  `json:"generationConfig"`
+}
+
+type geminiGenConfig struct {
+	MaxOutputTokens int `json:"maxOutputTokens"`
+}
+
+type geminiGenerateResponse struct {
+	Candidates []struct {
+		Content geminiContent `json:"content"`
+	} `json:"candidates"`
+	UsageMetadata struct {
+		PromptTokenCount     int `json:"promptTokenCount"`
+		CandidatesTokenCount int `json:"candidatesTokenCount"`
+	} `json:"usageMetadata"`
+}
+
+type geminiErrorEnvelope struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+func (p *geminiProvider) buildRequest(ctx context.Context, model string) (*http.Request, error) {
+	payload := geminiGenerateRequest{
+		Contents:         []geminiContent{{Parts: []geminiPart{{Text: "ping"}}, Role: "user"}},
+		GenerationConfig: geminiGenConfig{MaxOutputTokens: 1},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/v1beta/models/%s:generateContent?key=%s", p.baseURL, model, p.apiKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+func classifyGeminiResponse(r *probes.ProbeResult, status int, body []byte) {
+	if status >= 200 && status < 300 {
+		var cr geminiGenerateResponse
+		if err := json.Unmarshal(body, &cr); err != nil || len(cr.Candidates) == 0 {
+			r.ErrorClass = probes.ErrorClassMalformedBody
+			r.ErrorDetail = truncate(string(body), geminiErrorDetailMax)
+			return
+		}
+		r.Success = true
+		r.TokensIn = cr.UsageMetadata.PromptTokenCount
+		r.TokensOut = cr.UsageMetadata.CandidatesTokenCount
+		return
+	}
+	r.ErrorClass = classifyGeminiStatus(status)
+	r.ErrorDetail = parseGeminiError(body)
+}
+
+func classifyGeminiStatus(status int) probes.ErrorClass {
+	switch {
+	case status == http.StatusUnauthorized, status == http.StatusForbidden:
+		return probes.ErrorClassAuth
+	case status == http.StatusTooManyRequests:
+		return probes.ErrorClassRateLimit
+	case status >= 500:
+		return probes.ErrorClassServer5xx
+	case status >= 400:
+		return probes.ErrorClassClient4xx
+	default:
+		return probes.ErrorClassUnknown
+	}
+}
+
+func parseGeminiError(body []byte) string {
+	var e geminiErrorEnvelope
+	if err := json.Unmarshal(body, &e); err == nil && e.Error.Message != "" {
+		return truncate(e.Error.Message, geminiErrorDetailMax)
+	}
+	return truncate(string(body), geminiErrorDetailMax)
+}

--- a/internal/probes/adapters/gemini/testdata/generate_content_200.json
+++ b/internal/probes/adapters/gemini/testdata/generate_content_200.json
@@ -1,0 +1,17 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [{"text": "pong"}],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 5,
+    "candidatesTokenCount": 1,
+    "totalTokenCount": 6
+  }
+}

--- a/internal/probes/adapters/gemini/testdata/generate_content_401.json
+++ b/internal/probes/adapters/gemini/testdata/generate_content_401.json
@@ -1,0 +1,1 @@
+{"error": {"code": 401, "message": "API key not valid. Please pass a valid API key.", "status": "UNAUTHENTICATED"}}

--- a/internal/probes/adapters/gemini/testdata/generate_content_429.json
+++ b/internal/probes/adapters/gemini/testdata/generate_content_429.json
@@ -1,0 +1,1 @@
+{"error": {"code": 429, "message": "Resource has been exhausted (e.g. check quota).", "status": "RESOURCE_EXHAUSTED"}}

--- a/internal/probes/adapters/gemini/testdata/generate_content_500.json
+++ b/internal/probes/adapters/gemini/testdata/generate_content_500.json
@@ -1,0 +1,1 @@
+{"error": {"code": 500, "message": "An internal error has occurred.", "status": "INTERNAL"}}

--- a/internal/probes/adapters/gemini_register_livekeys.go
+++ b/internal/probes/adapters/gemini_register_livekeys.go
@@ -1,0 +1,13 @@
+//go:build livekeys
+
+package adapters
+
+import "os"
+
+func init() {
+	apiKey := os.Getenv("LLMS_GEMINI_API_KEY")
+	if apiKey == "" {
+		return
+	}
+	Register(NewGeminiProvider(apiKey, ""))
+}

--- a/internal/probes/adapters/gemini_test.go
+++ b/internal/probes/adapters/gemini_test.go
@@ -1,0 +1,124 @@
+package adapters
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+func mustReadGeminiFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("gemini", "testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}
+
+func TestGemini_Identity(t *testing.T) {
+	p := NewGeminiProvider("fake-key", "node-1")
+	if got := p.ID(); got != "google_gemini" {
+		t.Errorf("ID: got %q, want google_gemini", got)
+	}
+	if got := p.Models(); len(got) == 0 || got[0] != "gemini-2.0-flash" {
+		t.Errorf("Models: got %v", got)
+	}
+}
+
+func TestGemini_ProbeLightInference(t *testing.T) {
+	cases := []struct {
+		name         string
+		httpStatus   int
+		fixture      string
+		wantSuccess  bool
+		wantErrClass probes.ErrorClass
+	}{
+		{"success", http.StatusOK, "generate_content_200.json", true, probes.ErrorClassNone},
+		{"auth", http.StatusUnauthorized, "generate_content_401.json", false, probes.ErrorClassAuth},
+		{"rate_limit", http.StatusTooManyRequests, "generate_content_429.json", false, probes.ErrorClassRateLimit},
+		{"server_5xx", http.StatusInternalServerError, "generate_content_500.json", false, probes.ErrorClassServer5xx},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustReadGeminiFixture(t, tc.fixture)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Gemini path includes model name and action.
+				if !strings.Contains(r.URL.Path, "generateContent") {
+					t.Errorf("path %q missing generateContent", r.URL.Path)
+				}
+				w.WriteHeader(tc.httpStatus)
+				_, _ = w.Write(body)
+			}))
+			t.Cleanup(srv.Close)
+
+			p := NewGeminiProvider("fake-key", "node-1", WithGeminiBaseURL(srv.URL))
+			r, err := p.ProbeLightInference(context.Background(), "gemini-2.0-flash")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.ProviderID != "google_gemini" {
+				t.Errorf("ProviderID: got %q, want google_gemini", r.ProviderID)
+			}
+			if r.Success != tc.wantSuccess {
+				t.Errorf("Success: got %v, want %v", r.Success, tc.wantSuccess)
+			}
+			if r.ErrorClass != tc.wantErrClass {
+				t.Errorf("ErrorClass: got %q, want %q", r.ErrorClass, tc.wantErrClass)
+			}
+			if tc.wantSuccess && r.TokensIn == 0 {
+				t.Error("expected non-zero tokens_in on success")
+			}
+		})
+	}
+}
+
+func TestGemini_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewGeminiProvider("fake-key", "node-1",
+		WithGeminiBaseURL(srv.URL),
+		WithGeminiHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}),
+	)
+	r, err := p.ProbeLightInference(context.Background(), "gemini-2.0-flash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.ErrorClass != probes.ErrorClassTimeout {
+		t.Errorf("ErrorClass: got %q, want timeout", r.ErrorClass)
+	}
+}
+
+func TestGemini_UnsupportedProbes(t *testing.T) {
+	p := NewGeminiProvider("fake-key", "node-1")
+	var ns *probes.ErrNotSupported
+	for _, fn := range []func() error{
+		func() error { _, err := p.ProbeQuality(context.Background(), "m"); return err },
+		func() error { _, err := p.ProbeEmbedding(context.Background(), "m"); return err },
+		func() error { _, err := p.ProbeStreaming(context.Background(), "m"); return err },
+	} {
+		if err := fn(); !errors.As(err, &ns) {
+			t.Errorf("want ErrNotSupported, got %T: %v", err, err)
+		}
+	}
+}
+
+func TestParseGeminiError(t *testing.T) {
+	body := mustReadGeminiFixture(t, "generate_content_429.json")
+	got := parseGeminiError(body)
+	if !strings.Contains(got, "exhausted") {
+		t.Errorf("parseGeminiError: got %q, want 'exhausted' substring", got)
+	}
+}

--- a/internal/probes/adapters/mistral.go
+++ b/internal/probes/adapters/mistral.go
@@ -1,0 +1,155 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/httpclient"
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+const (
+	mistralDefaultBaseURL = "https://api.mistral.ai/v1"
+	mistralProviderID     = "mistral"
+	mistralLightModel     = "mistral-small-latest"
+	mistralLightProbeType = "light_inference"
+	mistralErrorDetailMax = 200
+)
+
+// MistralOption configures a Mistral provider at construction time.
+type MistralOption func(*mistralProvider)
+
+// WithMistralBaseURL overrides the base URL. Intended for tests.
+func WithMistralBaseURL(u string) MistralOption {
+	return func(p *mistralProvider) { p.baseURL = u }
+}
+
+// WithMistralHTTPClient overrides the HTTP client. Intended for tests.
+func WithMistralHTTPClient(c *http.Client) MistralOption {
+	return func(p *mistralProvider) { p.client = c }
+}
+
+// NewMistralProvider returns a probes.Provider backed by api.mistral.ai.
+// Mistral exposes an OpenAI-compatible Chat Completions API.
+func NewMistralProvider(apiKey, region string, opts ...MistralOption) probes.Provider {
+	p := &mistralProvider{
+		baseURL: mistralDefaultBaseURL,
+		apiKey:  apiKey,
+		region:  region,
+		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+type mistralProvider struct {
+	baseURL string
+	apiKey  string
+	region  string
+	client  *http.Client
+}
+
+func (p *mistralProvider) ID() string       { return mistralProviderID }
+func (p *mistralProvider) Models() []string { return []string{mistralLightModel} }
+
+func (p *mistralProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: mistralProviderID,
+		Model:      model,
+		ProbeType:  mistralLightProbeType,
+		StartedAt:  started.UTC(),
+		RegionID:   p.region,
+	}
+
+	req, err := p.buildRequest(ctx, model)
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), mistralErrorDetailMax)
+		return r, err
+	}
+
+	resp, err := p.client.Do(req)
+	r.DurationMs = time.Since(started).Milliseconds()
+	if err != nil {
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), mistralErrorDetailMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	body, _ := io.ReadAll(resp.Body)
+	// Mistral uses OpenAI-compatible response envelope for 2xx; errors are a
+	// flat {"message": "..."} object (see docs/known-quirks.md).
+	classifyMistralResponse(&r, resp.StatusCode, body)
+	return r, nil
+}
+
+func (p *mistralProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: mistralProviderID, ProbeType: "quality"}
+}
+
+func (p *mistralProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: mistralProviderID, ProbeType: "embedding"}
+}
+
+func (p *mistralProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: mistralProviderID, ProbeType: "streaming"}
+}
+
+func (p *mistralProvider) buildRequest(ctx context.Context, model string) (*http.Request, error) {
+	body, err := json.Marshal(openaiChatRequest{
+		Model:     model,
+		Messages:  []openaiChatMessage{{Role: "user", Content: "ping"}},
+		MaxTokens: 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// mistralErrorEnvelope covers Mistral's flat error format: {"message": "..."}.
+type mistralErrorEnvelope struct {
+	Message string `json:"message"`
+}
+
+func classifyMistralResponse(r *probes.ProbeResult, status int, body []byte) {
+	if status >= 200 && status < 300 {
+		// 2xx uses the standard OpenAI chat completion envelope.
+		var cr openaiChatResponse
+		if err := json.Unmarshal(body, &cr); err != nil {
+			r.ErrorClass = probes.ErrorClassMalformedBody
+			r.ErrorDetail = truncate(string(body), mistralErrorDetailMax)
+			return
+		}
+		r.Success = true
+		r.TokensIn = cr.Usage.PromptTokens
+		r.TokensOut = cr.Usage.CompletionTokens
+		return
+	}
+	r.ErrorClass = classifyOpenAIStatus(status)
+	r.ErrorDetail = parseMistralError(body)
+}
+
+func parseMistralError(body []byte) string {
+	var e mistralErrorEnvelope
+	if err := json.Unmarshal(body, &e); err == nil && e.Message != "" {
+		return truncate(e.Message, mistralErrorDetailMax)
+	}
+	return truncate(string(body), mistralErrorDetailMax)
+}

--- a/internal/probes/adapters/mistral/testdata/chat_completions_200.json
+++ b/internal/probes/adapters/mistral/testdata/chat_completions_200.json
@@ -1,0 +1,18 @@
+{
+  "id": "chatcmpl-mistral-abc123",
+  "object": "chat.completion",
+  "created": 1714000000,
+  "model": "mistral-small-latest",
+  "choices": [
+    {
+      "index": 0,
+      "message": {"role": "assistant", "content": "pong"},
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 5,
+    "completion_tokens": 1,
+    "total_tokens": 6
+  }
+}

--- a/internal/probes/adapters/mistral/testdata/chat_completions_401.json
+++ b/internal/probes/adapters/mistral/testdata/chat_completions_401.json
@@ -1,0 +1,1 @@
+{"message": "Unauthorized", "request_id": "req-abc123"}

--- a/internal/probes/adapters/mistral/testdata/chat_completions_429.json
+++ b/internal/probes/adapters/mistral/testdata/chat_completions_429.json
@@ -1,0 +1,1 @@
+{"message": "Too many requests", "request_id": "req-abc123"}

--- a/internal/probes/adapters/mistral/testdata/chat_completions_500.json
+++ b/internal/probes/adapters/mistral/testdata/chat_completions_500.json
@@ -1,0 +1,1 @@
+{"message": "Internal server error", "request_id": "req-abc123"}

--- a/internal/probes/adapters/mistral_register_livekeys.go
+++ b/internal/probes/adapters/mistral_register_livekeys.go
@@ -1,0 +1,13 @@
+//go:build livekeys
+
+package adapters
+
+import "os"
+
+func init() {
+	apiKey := os.Getenv("LLMS_MISTRAL_API_KEY")
+	if apiKey == "" {
+		return
+	}
+	Register(NewMistralProvider(apiKey, ""))
+}

--- a/internal/probes/adapters/mistral_test.go
+++ b/internal/probes/adapters/mistral_test.go
@@ -1,0 +1,123 @@
+package adapters
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+func mustReadMistralFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("mistral", "testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}
+
+func TestMistral_Identity(t *testing.T) {
+	p := NewMistralProvider("fake-key", "node-1")
+	if got := p.ID(); got != "mistral" {
+		t.Errorf("ID: got %q, want mistral", got)
+	}
+	if got := p.Models(); len(got) == 0 || got[0] != "mistral-small-latest" {
+		t.Errorf("Models: got %v", got)
+	}
+}
+
+func TestMistral_ProbeLightInference(t *testing.T) {
+	cases := []struct {
+		name         string
+		httpStatus   int
+		fixture      string
+		wantSuccess  bool
+		wantErrClass probes.ErrorClass
+	}{
+		{"success", http.StatusOK, "chat_completions_200.json", true, probes.ErrorClassNone},
+		{"auth", http.StatusUnauthorized, "chat_completions_401.json", false, probes.ErrorClassAuth},
+		{"rate_limit", http.StatusTooManyRequests, "chat_completions_429.json", false, probes.ErrorClassRateLimit},
+		{"server_5xx", http.StatusInternalServerError, "chat_completions_500.json", false, probes.ErrorClassServer5xx},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustReadMistralFixture(t, tc.fixture)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/chat/completions" {
+					t.Errorf("path: got %q, want /chat/completions", r.URL.Path)
+				}
+				w.WriteHeader(tc.httpStatus)
+				_, _ = w.Write(body)
+			}))
+			t.Cleanup(srv.Close)
+
+			p := NewMistralProvider("fake-key", "node-1", WithMistralBaseURL(srv.URL))
+			r, err := p.ProbeLightInference(context.Background(), "mistral-small-latest")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.ProviderID != "mistral" {
+				t.Errorf("ProviderID: got %q, want mistral", r.ProviderID)
+			}
+			if r.Success != tc.wantSuccess {
+				t.Errorf("Success: got %v, want %v", r.Success, tc.wantSuccess)
+			}
+			if r.ErrorClass != tc.wantErrClass {
+				t.Errorf("ErrorClass: got %q, want %q", r.ErrorClass, tc.wantErrClass)
+			}
+			if tc.wantSuccess && r.TokensIn == 0 {
+				t.Error("expected non-zero tokens_in on success")
+			}
+		})
+	}
+}
+
+func TestMistral_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewMistralProvider("fake-key", "node-1",
+		WithMistralBaseURL(srv.URL),
+		WithMistralHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}),
+	)
+	r, err := p.ProbeLightInference(context.Background(), "mistral-small-latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.ErrorClass != probes.ErrorClassTimeout {
+		t.Errorf("ErrorClass: got %q, want timeout", r.ErrorClass)
+	}
+}
+
+func TestMistral_UnsupportedProbes(t *testing.T) {
+	p := NewMistralProvider("fake-key", "node-1")
+	var ns *probes.ErrNotSupported
+	for _, fn := range []func() error{
+		func() error { _, err := p.ProbeQuality(context.Background(), "m"); return err },
+		func() error { _, err := p.ProbeEmbedding(context.Background(), "m"); return err },
+		func() error { _, err := p.ProbeStreaming(context.Background(), "m"); return err },
+	} {
+		if err := fn(); !errors.As(err, &ns) {
+			t.Errorf("want ErrNotSupported, got %T: %v", err, err)
+		}
+	}
+}
+
+func TestParseMistralError(t *testing.T) {
+	body := mustReadMistralFixture(t, "chat_completions_401.json")
+	got := parseMistralError(body)
+	if !strings.Contains(got, "Unauthorized") {
+		t.Errorf("parseMistralError: got %q, want 'Unauthorized' substring", got)
+	}
+}

--- a/internal/probes/adapters/openai_register_livekeys.go
+++ b/internal/probes/adapters/openai_register_livekeys.go
@@ -13,9 +13,10 @@ import "os"
 
 func init() {
 	apiKey := os.Getenv("LLMS_OPENAI_API_KEY")
-	region := os.Getenv("LLMS_REGION_ID")
-	if apiKey == "" || region == "" {
+	if apiKey == "" {
 		return
 	}
-	Register(NewOpenAIProvider(apiKey, region))
+	// Region is overwritten by the runner (probes.Runner.dispatchProbe) from
+	// REGION_ID; pass empty string here to avoid requiring LLMS_REGION_ID.
+	Register(NewOpenAIProvider(apiKey, ""))
 }

--- a/store/migrations/0009_providers_deepseek_gemini_mistral.down.sql
+++ b/store/migrations/0009_providers_deepseek_gemini_mistral.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DELETE FROM providers WHERE id IN ('deepseek', 'google_gemini', 'mistral');
+COMMIT;

--- a/store/migrations/0009_providers_deepseek_gemini_mistral.up.sql
+++ b/store/migrations/0009_providers_deepseek_gemini_mistral.up.sql
@@ -1,0 +1,22 @@
+-- 0009_providers_deepseek_gemini_mistral.sql — seed rows for new adapters (LLMS-055)
+
+BEGIN;
+
+INSERT INTO providers (id, name, category, base_url, auth_type, status_page_url, documentation_url, region, active)
+VALUES
+    ('deepseek',     'DeepSeek',     'official', 'https://api.deepseek.com',                    'bearer', NULL,                               'https://platform.deepseek.com/docs',           'global', TRUE),
+    ('google_gemini','Google Gemini','official', 'https://generativelanguage.googleapis.com',   'api_key_header', NULL,                       'https://ai.google.dev/gemini-api/docs',         'global', TRUE),
+    ('mistral',      'Mistral AI',   'official', 'https://api.mistral.ai',                      'bearer', 'https://status.mistral.ai',        'https://docs.mistral.ai',                       'global', TRUE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO models (provider_id, model_id, display_name, model_type, active)
+VALUES
+    ('deepseek',      'deepseek-chat',        'DeepSeek Chat',         'chat', TRUE),
+    ('deepseek',      'deepseek-reasoner',    'DeepSeek Reasoner',     'chat', TRUE),
+    ('google_gemini', 'gemini-2.0-flash',     'Gemini 2.0 Flash',      'chat', TRUE),
+    ('google_gemini', 'gemini-1.5-pro',       'Gemini 1.5 Pro',        'chat', TRUE),
+    ('mistral',       'mistral-small-latest', 'Mistral Small',         'chat', TRUE),
+    ('mistral',       'mistral-large-latest', 'Mistral Large',         'chat', TRUE)
+ON CONFLICT (provider_id, model_id) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **DeepSeek adapter** — OpenAI-compatible `/v1/chat/completions`; reuses `classifyOpenAIResponse` and `openaiChatRequest` types; model `deepseek-chat`
- **Google Gemini adapter** — custom `POST /v1beta/models/{model}:generateContent?key={apikey}`; own request/response types; model `gemini-2.0-flash`
- **Mistral adapter** — OpenAI-compatible `/v1/chat/completions`; flat `{"message":"..."}` error envelope (not nested `error.message`); model `mistral-small-latest`
- **livekeys fix** — removed `LLMS_REGION_ID` guard from all 5 livekeys init() files; `Runner.dispatchProbe` already overwrites `RegionID` from `REGION_ID` env var, so the guard was silently preventing registration
- **Migration 0009** — seeds provider + model rows for all 3 new providers
- **docker-compose + .env.example** — `LLMS_{DEEPSEEK,GEMINI,MISTRAL}_API_KEY` vars added to prober service

## Tests

12 new tests across 3 adapters (identity, 4 fixture cases each, timeout, unsupported probes, error parsing). All adapters pass `go test ./internal/probes/adapters/...`.

## Test plan

- [ ] `go test ./...` all green
- [ ] `go build -tags livekeys ./cmd/prober` compiles
- [ ] Set one provider key + run migrate → prober probes that provider within 60s

Closes #124