### PR TITLE
fix LLMS-062: badge proxy forwards style param + SVG polish

### DIFF
--- a/internal/api/badge.go
+++ b/internal/api/badge.go
@@ -103,9 +103,17 @@ func renderBadge(label, message, color string) string {
 	return fmt.Sprintf(
 		`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" role="img" aria-label="%s: %s">`+
 			`<title>%s: %s</title>`+
-			`<g shape-rendering="crispEdges">`+
+			`<linearGradient id="s" x2="0" y2="1">`+
+			`<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>`+
+			`<stop offset="1" stop-opacity=".1"/>`+
+			`</linearGradient>`+
+			`<clipPath id="r">`+
+			`<rect width="%d" height="%d" rx="3" fill="#fff"/>`+
+			`</clipPath>`+
+			`<g clip-path="url(#r)">`+
 			`<rect width="%d" height="%d" fill="#555"/>`+
 			`<rect x="%d" width="%d" height="%d" fill="%s"/>`+
+			`<rect width="%d" height="%d" fill="url(#s)"/>`+
 			`</g>`+
 			`<g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="110">`+
 			`<text x="%d" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="%d" lengthAdjust="spacing">%s</text>`+
@@ -118,7 +126,9 @@ func renderBadge(label, message, color string) string {
 		l, m,
 		l, m,
 		totalPx, hPx,
+		totalPx, hPx,
 		(labelU)/10, (msgU)/10, hPx, color,
+		totalPx, hPx,
 		labelCX, labelU-padU*2, l,
 		labelCX, labelU-padU*2, l,
 		msgCX, msgU-padU*2, m,

--- a/web/app/api/badge/[id]/route.ts
+++ b/web/app/api/badge/[id]/route.ts
@@ -2,19 +2,19 @@ import { type NextRequest, NextResponse } from "next/server";
 
 const API_URL = process.env.API_URL ?? "http://localhost:8081";
 
-// Proxies /api/badge/{id} → Go API /badge/{id}.svg.
-// Allows the Next.js app to serve badge previews without exposing
-// the internal API_URL to the browser.
+// Proxies /api/badge/{id} → Go API /badge/{id}.svg, forwarding ?style=.
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
-  const upstream = `${API_URL}/badge/${encodeURIComponent(id)}.svg`;
+  const style = req.nextUrl.searchParams.get("style");
+  const qs = style ? `?style=${encodeURIComponent(style)}` : "";
+  const upstream = `${API_URL}/badge/${encodeURIComponent(id)}.svg${qs}`;
 
   let res: Response;
   try {
-    res = await fetch(upstream, { next: { revalidate: 60 } });
+    res = await fetch(upstream, { cache: "no-store" });
   } catch {
     return new NextResponse("upstream unavailable", { status: 502 });
   }


### PR DESCRIPTION
## Bug fix
`/api/badge/[id]` proxy discarded `?style=detailed` query param — upstream Go API never received it, so the "Detailed" badge preview on the badges page showed identical output to "Simple".

**Fix**: read `req.nextUrl.searchParams.get("style")` and append to upstream URL.

Also switched the badge proxy from `revalidate: 60` to `cache: "no-store"` since badge content changes as often as 30s — caching in the proxy layer caused stale previews.

## SVG improvement
Added shields.io-style flat badge rendering:
- `clipPath` with `rx="3"` for rounded corners
- Subtle `linearGradient` overlay (top-to-bottom, 10% opacity black) for depth

## Test plan
- [x] `go test ./...` green (including `TestGetBadge_DetailedStyle_NoLiveStats_FallsBack`)
- [x] `npm run build` green
- [x] Badge proxy now forwards `?style=detailed` to upstream