### PR TITLE
feat: Terraform infra — AWS (4 nodes) + Azure (1 EU probe)

### DIFF
--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -1,0 +1,8 @@
+# Local state and overrides — never commit
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.backup
+terraform.tfvars
+*.auto.tfvars
+crash.log

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,75 @@
+# Terraform — llmstatus.io production infrastructure
+
+Provisions 1 main server (AWS us-west-2) + 3 AWS probe nodes + 1 Azure probe node.
+
+## Prerequisites
+
+- Terraform >= 1.9
+- AWS CLI configured (`aws configure`) with credentials that have EC2/S3/DynamoDB permissions
+- Azure CLI logged in (`az login`) with an active subscription
+
+## First-time setup
+
+### 1. Bootstrap remote state (once only)
+
+```bash
+cd deploy/terraform/bootstrap
+terraform init
+terraform apply
+```
+
+This creates the S3 bucket and DynamoDB lock table used by all subsequent runs.
+
+### 2. Configure variables
+
+```bash
+cd deploy/terraform/prod
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — add your SSH public key
+```
+
+Generate a key if needed:
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/llmstatus-prod -C "llmstatus-prod"
+```
+
+### 3. Init and apply
+
+```bash
+cd deploy/terraform/prod
+terraform init
+terraform plan
+terraform apply
+```
+
+### 4. Note the outputs
+
+```
+terraform output
+```
+
+- `main_server_ip` → add as Cloudflare A record for `llmstatus.io` + `www` (proxy OFF)
+- `ansible_inventory_hint` → paste IPs into `deploy/ansible/inventories/prod/hosts.yml`
+
+## Directory layout
+
+```
+bootstrap/      one-time S3 + DynamoDB for TF state
+modules/
+  aws-main-server/   EC2 t3.small + 80GB EBS + EIP (us-west-2)
+  aws-probe/         EC2 t3.micro + EIP (reused for 3 regions)
+  azure-probe/       Azure VM Standard_B1s + static IP (Germany West Central)
+prod/           root module — instantiates all modules
+```
+
+## Cost estimate (~$61/mo)
+
+| Node | Type | Region | $/mo |
+|---|---|---|---|
+| Main server | EC2 t3.small + 80GB EBS | us-west-2 | ~$23 |
+| Probe | EC2 t3.micro | us-east-1 | ~$8 |
+| Probe | EC2 t3.micro | ap-northeast-1 | ~$9 |
+| Probe | EC2 t3.micro | ap-southeast-1 | ~$9 |
+| Probe EU | Azure Standard_B1s + SSD | Germany West Central | ~$12 |
+
+China nodes (Aliyun Shanghai + Tencent Guangzhou) are provisioned separately.

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -1,0 +1,85 @@
+# One-time bootstrap: creates S3 bucket + DynamoDB table for Terraform remote state.
+#
+# Run ONCE before anything else:
+#   cd deploy/terraform/bootstrap
+#   terraform init
+#   terraform apply
+#
+# After apply, configure prod/backend.tf and run `terraform init` in prod/.
+
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "llmstatus-tfstate-prod"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Project     = "llmstatus"
+    Environment = "prod"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket                  = aws_s3_bucket.tfstate.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "tflock" {
+  name         = "llmstatus-tfstate-lock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Project     = "llmstatus"
+    Environment = "prod"
+    ManagedBy   = "terraform"
+  }
+}
+
+output "state_bucket" {
+  value = aws_s3_bucket.tfstate.bucket
+}
+
+output "lock_table" {
+  value = aws_dynamodb_table.tflock.name
+}

--- a/deploy/terraform/modules/aws-main-server/main.tf
+++ b/deploy/terraform/modules/aws-main-server/main.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_key_pair" "this" {
+  key_name   = "${var.project}-${var.environment}-main"
+  public_key = var.ssh_public_key
+}
+
+resource "aws_security_group" "this" {
+  name        = "${var.project}-${var.environment}-main"
+  description = "llmstatus main server: HTTP/HTTPS/SSH inbound"
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-main"
+  })
+}
+
+resource "aws_instance" "this" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = "t3.small"
+  key_name               = aws_key_pair.this.key_name
+  vpc_security_group_ids = [aws_security_group.this.id]
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20
+    encrypted   = true
+
+    tags = merge(var.tags, {
+      Name = "${var.project}-${var.environment}-main-root"
+    })
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-main"
+    Role = "main"
+  })
+}
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = aws_instance.this.availability_zone
+  size              = var.data_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-data"
+  })
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name  = "/dev/sdf"
+  volume_id    = aws_ebs_volume.data.id
+  instance_id  = aws_instance.this.id
+  force_detach = false
+}
+
+resource "aws_eip" "this" {
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-main"
+  })
+}
+
+resource "aws_eip_association" "this" {
+  instance_id   = aws_instance.this.id
+  allocation_id = aws_eip.this.id
+}

--- a/deploy/terraform/modules/aws-main-server/outputs.tf
+++ b/deploy/terraform/modules/aws-main-server/outputs.tf
@@ -1,0 +1,12 @@
+output "public_ip" {
+  description = "Elastic IP of the main server"
+  value       = aws_eip.this.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.this.id
+}
+
+output "availability_zone" {
+  value = aws_instance.this.availability_zone
+}

--- a/deploy/terraform/modules/aws-main-server/variables.tf
+++ b/deploy/terraform/modules/aws-main-server/variables.tf
@@ -1,0 +1,25 @@
+variable "project" {
+  type    = string
+  default = "llmstatus"
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key content"
+  type        = string
+}
+
+variable "data_volume_size_gb" {
+  description = "EBS data volume size in GB (PostgreSQL + InfluxDB)"
+  type        = number
+  default     = 80
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/deploy/terraform/modules/aws-probe/main.tf
+++ b/deploy/terraform/modules/aws-probe/main.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_key_pair" "this" {
+  key_name   = "${var.project}-${var.environment}-probe-${var.node_name}"
+  public_key = var.ssh_public_key
+}
+
+resource "aws_security_group" "this" {
+  name        = "${var.project}-${var.environment}-probe-${var.node_name}"
+  description = "llmstatus probe ${var.node_name}: SSH inbound, all outbound"
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-probe-${var.node_name}"
+  })
+}
+
+resource "aws_instance" "this" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = "t3.micro"
+  key_name               = aws_key_pair.this.key_name
+  vpc_security_group_ids = [aws_security_group.this.id]
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20
+    encrypted   = true
+
+    tags = merge(var.tags, {
+      Name = "${var.project}-${var.environment}-probe-${var.node_name}-root"
+    })
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-probe-${var.node_name}"
+    Role = "probe"
+    Node = var.node_name
+  })
+}
+
+resource "aws_eip" "this" {
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${var.project}-${var.environment}-probe-${var.node_name}"
+  })
+}
+
+resource "aws_eip_association" "this" {
+  instance_id   = aws_instance.this.id
+  allocation_id = aws_eip.this.id
+}

--- a/deploy/terraform/modules/aws-probe/outputs.tf
+++ b/deploy/terraform/modules/aws-probe/outputs.tf
@@ -1,0 +1,8 @@
+output "public_ip" {
+  description = "Elastic IP of this probe node"
+  value       = aws_eip.this.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.this.id
+}

--- a/deploy/terraform/modules/aws-probe/variables.tf
+++ b/deploy/terraform/modules/aws-probe/variables.tf
@@ -1,0 +1,24 @@
+variable "project" {
+  type    = string
+  default = "llmstatus"
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}
+
+variable "node_name" {
+  description = "Short name for this probe node, e.g. us-east-1, ap-northeast-1"
+  type        = string
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key content"
+  type        = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/deploy/terraform/modules/azure-probe/main.tf
+++ b/deploy/terraform/modules/azure-probe/main.tf
@@ -1,0 +1,109 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = "${var.project}-${var.environment}-${var.node_name}"
+  location = var.location
+  tags     = var.tags
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "${var.project}-${var.environment}-${var.node_name}-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "this" {
+  name                 = "default"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "this" {
+  name                = "${var.project}-${var.environment}-${var.node_name}-pip"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_group" "this" {
+  name                = "${var.project}-${var.environment}-${var.node_name}-nsg"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  security_rule {
+    name                       = "SSH"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_network_interface" "this" {
+  name                = "${var.project}-${var.environment}-${var.node_name}-nic"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.this.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.this.id
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "this" {
+  network_interface_id      = azurerm_network_interface.this.id
+  network_security_group_id = azurerm_network_security_group.this.id
+}
+
+resource "azurerm_linux_virtual_machine" "this" {
+  name                = "${var.project}-${var.environment}-${var.node_name}"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  size                = var.vm_size
+  admin_username      = "ubuntu"
+
+  network_interface_ids = [azurerm_network_interface.this.id]
+
+  admin_ssh_key {
+    username   = "ubuntu"
+    public_key = var.ssh_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "StandardSSD_LRS"
+    disk_size_gb         = 30
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+
+  tags = merge(var.tags, {
+    Role = "probe"
+    Node = var.node_name
+  })
+}

--- a/deploy/terraform/modules/azure-probe/outputs.tf
+++ b/deploy/terraform/modules/azure-probe/outputs.tf
@@ -1,0 +1,8 @@
+output "public_ip" {
+  description = "Static public IP of this Azure probe node"
+  value       = azurerm_public_ip.this.ip_address
+}
+
+output "vm_id" {
+  value = azurerm_linux_virtual_machine.this.id
+}

--- a/deploy/terraform/modules/azure-probe/variables.tf
+++ b/deploy/terraform/modules/azure-probe/variables.tf
@@ -1,0 +1,36 @@
+variable "project" {
+  type    = string
+  default = "llmstatus"
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}
+
+variable "node_name" {
+  description = "Short name for this probe node"
+  type        = string
+  default     = "eu-west"
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+  default     = "Germany West Central"
+}
+
+variable "vm_size" {
+  type    = string
+  default = "Standard_B1s"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key content"
+  type        = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/deploy/terraform/prod/backend.tf
+++ b/deploy/terraform/prod/backend.tf
@@ -1,0 +1,10 @@
+# Remote state in S3. Run bootstrap/ first to create this bucket.
+terraform {
+  backend "s3" {
+    bucket         = "llmstatus-tfstate-prod"
+    key            = "prod/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "llmstatus-tfstate-lock"
+    encrypt        = true
+  }
+}

--- a/deploy/terraform/prod/main.tf
+++ b/deploy/terraform/prod/main.tf
@@ -1,0 +1,77 @@
+locals {
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# ── Main server (us-west-2) ─────────────────────────────────────────────────
+# Runs: PostgreSQL, InfluxDB, Go API, ingest, detector, Next.js frontend.
+# Also acts as the us-west-2 probe node (prober process runs locally).
+module "main_server" {
+  source = "../modules/aws-main-server"
+
+  project             = var.project
+  environment         = var.environment
+  ssh_public_key      = var.ssh_public_key
+  data_volume_size_gb = 80
+  tags                = local.tags
+}
+
+# ── AWS probe: us-east-1 (near Google / AWS Bedrock) ────────────────────────
+module "probe_us_east_1" {
+  source = "../modules/aws-probe"
+
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  project        = var.project
+  environment    = var.environment
+  node_name      = "us-east-1"
+  ssh_public_key = var.ssh_public_key
+  tags           = local.tags
+}
+
+# ── AWS probe: ap-northeast-1 (Tokyo) ───────────────────────────────────────
+module "probe_ap_northeast_1" {
+  source = "../modules/aws-probe"
+
+  providers = {
+    aws = aws.ap_northeast_1
+  }
+
+  project        = var.project
+  environment    = var.environment
+  node_name      = "ap-northeast-1"
+  ssh_public_key = var.ssh_public_key
+  tags           = local.tags
+}
+
+# ── AWS probe: ap-southeast-1 (Singapore) ───────────────────────────────────
+module "probe_ap_southeast_1" {
+  source = "../modules/aws-probe"
+
+  providers = {
+    aws = aws.ap_southeast_1
+  }
+
+  project        = var.project
+  environment    = var.environment
+  node_name      = "ap-southeast-1"
+  ssh_public_key = var.ssh_public_key
+  tags           = local.tags
+}
+
+# ── Azure probe: Germany West Central (EU) ──────────────────────────────────
+module "probe_eu" {
+  source = "../modules/azure-probe"
+
+  project        = var.project
+  environment    = var.environment
+  node_name      = "eu-west"
+  location       = "Germany West Central"
+  ssh_public_key = var.ssh_public_key
+  tags           = local.tags
+}

--- a/deploy/terraform/prod/outputs.tf
+++ b/deploy/terraform/prod/outputs.tf
@@ -1,0 +1,43 @@
+output "main_server_ip" {
+  description = "Main server Elastic IP — set as Cloudflare A record for llmstatus.io + www"
+  value       = module.main_server.public_ip
+}
+
+output "probe_us_east_1_ip" {
+  description = "Probe node: us-east-1"
+  value       = module.probe_us_east_1.public_ip
+}
+
+output "probe_ap_northeast_1_ip" {
+  description = "Probe node: ap-northeast-1 (Tokyo)"
+  value       = module.probe_ap_northeast_1.public_ip
+}
+
+output "probe_ap_southeast_1_ip" {
+  description = "Probe node: ap-southeast-1 (Singapore)"
+  value       = module.probe_ap_southeast_1.public_ip
+}
+
+output "probe_eu_ip" {
+  description = "Probe node: Germany West Central (EU)"
+  value       = module.probe_eu.public_ip
+}
+
+output "cloudflare_records" {
+  description = "Add these A records in Cloudflare (proxy OFF for direct IP access)"
+  value = {
+    "llmstatus.io"     = module.main_server.public_ip
+    "www.llmstatus.io" = module.main_server.public_ip
+  }
+}
+
+output "ansible_inventory_hint" {
+  description = "Node IPs for deploy/ansible/inventories/prod/hosts.yml"
+  value = {
+    main        = module.main_server.public_ip
+    us_east_1   = module.probe_us_east_1.public_ip
+    ap_ne_1     = module.probe_ap_northeast_1.public_ip
+    ap_se_1     = module.probe_ap_southeast_1.public_ip
+    eu_west     = module.probe_eu.public_ip
+  }
+}

--- a/deploy/terraform/prod/providers.tf
+++ b/deploy/terraform/prod/providers.tf
@@ -1,0 +1,24 @@
+# AWS — default provider (no alias) is us-west-2, used by the main server.
+provider "aws" {
+  region = "us-west-2"
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "ap_northeast_1"
+  region = "ap-northeast-1"
+}
+
+provider "aws" {
+  alias  = "ap_southeast_1"
+  region = "ap-southeast-1"
+}
+
+# Azure — authenticates via `az login` or ARM_* env vars.
+provider "azurerm" {
+  features {}
+}

--- a/deploy/terraform/prod/terraform.tfvars.example
+++ b/deploy/terraform/prod/terraform.tfvars.example
@@ -1,0 +1,6 @@
+# Copy to terraform.tfvars and fill in values.
+# terraform.tfvars is gitignored — never commit it.
+
+# Your SSH public key (ed25519 recommended).
+# Generate with: ssh-keygen -t ed25519 -C "llmstatus-prod"
+ssh_public_key = "ssh-ed25519 AAAA... your-key-comment"

--- a/deploy/terraform/prod/variables.tf
+++ b/deploy/terraform/prod/variables.tf
@@ -1,0 +1,14 @@
+variable "ssh_public_key" {
+  description = "SSH public key content for all nodes (EC2 key pairs + Azure admin_ssh_key)"
+  type        = string
+}
+
+variable "project" {
+  type    = string
+  default = "llmstatus"
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}

--- a/deploy/terraform/prod/versions.tf
+++ b/deploy/terraform/prod/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `bootstrap/`: one-time S3 bucket + DynamoDB table for remote state
- `modules/aws-main-server/`: EC2 t3.small + 80GB EBS gp3 + Elastic IP (us-west-2 main server)
- `modules/aws-probe/`: reusable EC2 t3.micro + EIP; instantiated for us-east-1, ap-northeast-1, ap-southeast-1
- `modules/azure-probe/`: Azure Standard_B1s + static IP + NSG (Germany West Central EU probe)
- `prod/`: root module wiring all above with multi-region AWS provider aliases
- DNS output → Cloudflare A records; Ansible inventory hint in outputs

## Nodes provisioned
| Node | Type | Region |
|---|---|---|
| Main server | EC2 t3.small + 80GB EBS | us-west-2 |
| Probe | EC2 t3.micro | us-east-1 |
| Probe | EC2 t3.micro | ap-northeast-1 (Tokyo) |
| Probe | EC2 t3.micro | ap-southeast-1 (Singapore) |
| Probe EU | Azure Standard_B1s | Germany West Central |

China nodes (Aliyun/Tencent) out of scope — require ICP compliance, handled separately.

## Test plan
- [ ] `cd deploy/terraform/bootstrap && terraform init && terraform plan` — no errors
- [ ] `cd deploy/terraform/prod && terraform init && terraform plan` — no errors
- [ ] `terraform apply` provisions all 5 nodes
- [ ] `terraform output` shows IPs for Cloudflare + Ansible