### PR TITLE
feat: probe_scope — CN nodes only probe accessible providers

### DIFF
--- a/cmd/prober/main.go
+++ b/cmd/prober/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -47,7 +48,7 @@ func main() {
 	}
 	defer pool.Close()
 
-	configs, err := loadProviderConfigs(ctx, pool)
+	configs, err := loadProviderConfigs(ctx, pool, regionID)
 	if err != nil {
 		slog.Error("prober: cannot load providers", "err", err)
 		os.Exit(1)
@@ -84,13 +85,24 @@ func main() {
 	}
 }
 
-func loadProviderConfigs(ctx context.Context, pool *pgxpool.Pool) ([]probes.ProviderConfig, error) {
+// nodeScope maps a REGION_ID to the probe_scope value used in the DB query.
+// Regions prefixed "cn-" are China nodes; everything else is international.
+func nodeScope(regionID string) string {
+	if strings.HasPrefix(regionID, "cn-") {
+		return "cn"
+	}
+	return "intl"
+}
+
+func loadProviderConfigs(ctx context.Context, pool *pgxpool.Pool, regionID string) ([]probes.ProviderConfig, error) {
 	q := pgstore.New(pool)
 
-	providers, err := q.ListActiveProviders(ctx)
+	scope := nodeScope(regionID)
+	providers, err := q.ListProvidersForScope(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
+	slog.Info("prober: provider scope filter", "region", regionID, "scope", scope, "providers", len(providers))
 
 	var configs []probes.ProviderConfig
 	for _, p := range providers {

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -22,6 +22,7 @@ type providerSummary struct {
 	Name             string      `json:"name"`
 	Category         string      `json:"category"`
 	Region           string      `json:"region"`
+	ProbeScope       string      `json:"probe_scope"`
 	CurrentStatus    string      `json:"current_status"`
 	ActiveIncidentID *string     `json:"active_incident_id,omitempty"`
 	Uptime24h        *float64    `json:"uptime_24h,omitempty"`
@@ -253,6 +254,7 @@ func toProviderSummary(p pgstore.Provider, incMap map[string]pgstore.Incident) p
 		Name:             p.Name,
 		Category:         p.Category,
 		Region:           p.Region,
+		ProbeScope:       p.ProbeScope,
 		CurrentStatus:    status,
 		ActiveIncidentID: activeID,
 	}

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -12,6 +12,7 @@ import (
 // pgstore.Queries satisfies this interface at compile time (see server.go).
 type Store interface {
 	ListActiveProviders(ctx context.Context) ([]pgstore.Provider, error)
+	ListProvidersForScope(ctx context.Context, probeScope string) ([]pgstore.Provider, error)
 	GetProvider(ctx context.Context, id string) (pgstore.Provider, error)
 	ListModelsByProvider(ctx context.Context, providerID string) ([]pgstore.Model, error)
 	ListIncidents(ctx context.Context, arg pgstore.ListIncidentsParams) ([]pgstore.Incident, error)

--- a/internal/store/postgres/gen/models.go
+++ b/internal/store/postgres/gen/models.go
@@ -86,6 +86,7 @@ type Provider struct {
 	AddedAt          pgtype.Timestamptz `json:"added_at"`
 	Active           bool               `json:"active"`
 	Config           json.RawMessage    `json:"config"`
+	ProbeScope       string             `json:"probe_scope"`
 }
 
 type Sponsor struct {

--- a/internal/store/postgres/gen/querier.go
+++ b/internal/store/postgres/gen/querier.go
@@ -55,6 +55,9 @@ type Querier interface {
 	ListIncidentsUpdatedSince(ctx context.Context, updatedAt pgtype.Timestamptz) ([]Incident, error)
 	ListModelsByProvider(ctx context.Context, providerID string) ([]Model, error)
 	ListProviders(ctx context.Context) ([]Provider, error)
+	// Returns active providers visible to a probe node with the given scope.
+	// 'global' providers are probed by every node; 'intl'/'cn' are scope-specific.
+	ListProvidersForScope(ctx context.Context, probeScope string) ([]Provider, error)
 	// Incidents opened or updated within the last 24 hours for a provider.
 	ListRecentIncidentsByProvider(ctx context.Context, providerID string) ([]Incident, error)
 	ListSponsorKeys(ctx context.Context, sponsorID string) ([]SponsorKey, error)
@@ -74,6 +77,7 @@ type Querier interface {
 	ResolveIncident(ctx context.Context, arg ResolveIncidentParams) error
 	SetIncidentDescription(ctx context.Context, arg SetIncidentDescriptionParams) error
 	SetProviderActive(ctx context.Context, arg SetProviderActiveParams) error
+	SetProviderProbeScope(ctx context.Context, arg SetProviderProbeScopeParams) error
 	UpdateIncidentStatus(ctx context.Context, arg UpdateIncidentStatusParams) error
 	UpdateSponsor(ctx context.Context, arg UpdateSponsorParams) (Sponsor, error)
 	UpdateSponsorKeyVerification(ctx context.Context, arg UpdateSponsorKeyVerificationParams) error

--- a/internal/store/postgres/gen/queries.sql.go
+++ b/internal/store/postgres/gen/queries.sql.go
@@ -375,7 +375,7 @@ func (q *Queries) GetOngoingByProviderAndRule(ctx context.Context, arg GetOngoin
 const getProvider = `-- name: GetProvider :one
 
 
-SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config FROM providers
+SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config, probe_scope FROM providers
 WHERE id = $1
 `
 
@@ -398,6 +398,7 @@ func (q *Queries) GetProvider(ctx context.Context, id string) (Provider, error) 
 		&i.AddedAt,
 		&i.Active,
 		&i.Config,
+		&i.ProbeScope,
 	)
 	return i, err
 }
@@ -573,7 +574,7 @@ func (q *Queries) IsDigestSent(ctx context.Context, arg IsDigestSentParams) (boo
 }
 
 const listActiveProviders = `-- name: ListActiveProviders :many
-SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config FROM providers
+SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config, probe_scope FROM providers
 WHERE active = TRUE
 ORDER BY name
 `
@@ -599,6 +600,7 @@ func (q *Queries) ListActiveProviders(ctx context.Context) ([]Provider, error) {
 			&i.AddedAt,
 			&i.Active,
 			&i.Config,
+			&i.ProbeScope,
 		); err != nil {
 			return nil, err
 		}
@@ -958,7 +960,7 @@ func (q *Queries) ListModelsByProvider(ctx context.Context, providerID string) (
 }
 
 const listProviders = `-- name: ListProviders :many
-SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config FROM providers
+SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config, probe_scope FROM providers
 ORDER BY name
 `
 
@@ -983,6 +985,49 @@ func (q *Queries) ListProviders(ctx context.Context) ([]Provider, error) {
 			&i.AddedAt,
 			&i.Active,
 			&i.Config,
+			&i.ProbeScope,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listProvidersForScope = `-- name: ListProvidersForScope :many
+SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config, probe_scope FROM providers
+WHERE active = TRUE
+  AND (probe_scope = 'global' OR probe_scope = $1)
+ORDER BY name
+`
+
+// Returns active providers visible to a probe node with the given scope.
+// 'global' providers are probed by every node; 'intl'/'cn' are scope-specific.
+func (q *Queries) ListProvidersForScope(ctx context.Context, probeScope string) ([]Provider, error) {
+	rows, err := q.db.Query(ctx, listProvidersForScope, probeScope)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Provider{}
+	for rows.Next() {
+		var i Provider
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Category,
+			&i.BaseUrl,
+			&i.AuthType,
+			&i.StatusPageUrl,
+			&i.DocumentationUrl,
+			&i.Region,
+			&i.AddedAt,
+			&i.Active,
+			&i.Config,
+			&i.ProbeScope,
 		); err != nil {
 			return nil, err
 		}
@@ -1319,6 +1364,20 @@ func (q *Queries) SetProviderActive(ctx context.Context, arg SetProviderActivePa
 	return err
 }
 
+const setProviderProbeScope = `-- name: SetProviderProbeScope :exec
+UPDATE providers SET probe_scope = $2 WHERE id = $1
+`
+
+type SetProviderProbeScopeParams struct {
+	ID         string `json:"id"`
+	ProbeScope string `json:"probe_scope"`
+}
+
+func (q *Queries) SetProviderProbeScope(ctx context.Context, arg SetProviderProbeScopeParams) error {
+	_, err := q.db.Exec(ctx, setProviderProbeScope, arg.ID, arg.ProbeScope)
+	return err
+}
+
 const updateIncidentStatus = `-- name: UpdateIncidentStatus :exec
 UPDATE incidents
 SET status     = $2,
@@ -1528,9 +1587,9 @@ func (q *Queries) UpsertOAuthAccount(ctx context.Context, arg UpsertOAuthAccount
 const upsertProvider = `-- name: UpsertProvider :exec
 INSERT INTO providers (
     id, name, category, base_url, auth_type,
-    status_page_url, documentation_url, region, active, config
+    status_page_url, documentation_url, region, active, config, probe_scope
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 ON CONFLICT (id) DO UPDATE SET
     name              = EXCLUDED.name,
@@ -1541,7 +1600,8 @@ ON CONFLICT (id) DO UPDATE SET
     documentation_url = EXCLUDED.documentation_url,
     region            = EXCLUDED.region,
     active            = EXCLUDED.active,
-    config            = EXCLUDED.config
+    config            = EXCLUDED.config,
+    probe_scope       = EXCLUDED.probe_scope
 `
 
 type UpsertProviderParams struct {
@@ -1555,6 +1615,7 @@ type UpsertProviderParams struct {
 	Region           string          `json:"region"`
 	Active           bool            `json:"active"`
 	Config           json.RawMessage `json:"config"`
+	ProbeScope       string          `json:"probe_scope"`
 }
 
 func (q *Queries) UpsertProvider(ctx context.Context, arg UpsertProviderParams) error {
@@ -1569,6 +1630,7 @@ func (q *Queries) UpsertProvider(ctx context.Context, arg UpsertProviderParams) 
 		arg.Region,
 		arg.Active,
 		arg.Config,
+		arg.ProbeScope,
 	)
 	return err
 }

--- a/internal/store/postgres/queries.sql
+++ b/internal/store/postgres/queries.sql
@@ -17,12 +17,20 @@ SELECT * FROM providers
 WHERE active = TRUE
 ORDER BY name;
 
+-- name: ListProvidersForScope :many
+-- Returns active providers visible to a probe node with the given scope.
+-- 'global' providers are probed by every node; 'intl'/'cn' are scope-specific.
+SELECT * FROM providers
+WHERE active = TRUE
+  AND (probe_scope = 'global' OR probe_scope = $1)
+ORDER BY name;
+
 -- name: UpsertProvider :exec
 INSERT INTO providers (
     id, name, category, base_url, auth_type,
-    status_page_url, documentation_url, region, active, config
+    status_page_url, documentation_url, region, active, config, probe_scope
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 ON CONFLICT (id) DO UPDATE SET
     name              = EXCLUDED.name,
@@ -33,7 +41,11 @@ ON CONFLICT (id) DO UPDATE SET
     documentation_url = EXCLUDED.documentation_url,
     region            = EXCLUDED.region,
     active            = EXCLUDED.active,
-    config            = EXCLUDED.config;
+    config            = EXCLUDED.config,
+    probe_scope       = EXCLUDED.probe_scope;
+
+-- name: SetProviderProbeScope :exec
+UPDATE providers SET probe_scope = $2 WHERE id = $1;
 
 -- name: SetProviderActive :exec
 UPDATE providers SET active = $2 WHERE id = $1;

--- a/store/migrations/0015_provider_probe_scope.down.sql
+++ b/store/migrations/0015_provider_probe_scope.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE providers DROP COLUMN IF EXISTS probe_scope;

--- a/store/migrations/0015_provider_probe_scope.up.sql
+++ b/store/migrations/0015_provider_probe_scope.up.sql
@@ -1,0 +1,18 @@
+-- Add probe_scope to providers so each prober node only runs probes it can reach.
+-- Values: 'global' (all nodes), 'intl' (non-CN nodes only), 'cn' (CN nodes only).
+
+ALTER TABLE providers
+    ADD COLUMN probe_scope TEXT NOT NULL DEFAULT 'global'
+    CHECK (probe_scope IN ('global', 'intl', 'cn'));
+
+-- International providers are blocked from China probe nodes.
+UPDATE providers
+SET probe_scope = 'intl'
+WHERE id IN (
+    'ai21', 'anthropic', 'azure_openai', 'cohere', 'fireworks',
+    'google', 'google_gemini', 'groq', 'huggingface', 'mistral',
+    'openai', 'perplexity', 'together', 'together_ai', 'xai'
+);
+
+-- Chinese domestic providers are accessible from all regions (probe_scope stays 'global').
+-- deepseek, doubao, minimax, moonshot, qwen, zeroone_ai, zhipu — no change needed.


### PR DESCRIPTION
## Summary

- Adds `probe_scope TEXT ('global'|'intl'|'cn')` to the `providers` table
- CN probe nodes (`REGION_ID` prefix `cn-`) only probe `global` + `cn` providers
- International probe nodes only probe `global` + `intl` providers
- 15 international providers backfilled to `intl`; Chinese providers stay `global`
- New `SetProviderProbeScope` query for operator one-off adjustments
- `probe_scope` exposed in API response so the frontend can show it

## Test plan

- [ ] Migration 0015 applied (verified locally: `up: applied to version 15`)
- [ ] `go build ./...` passes
- [ ] CN prober: `REGION_ID=cn-shanghai` → only probes deepseek, doubao, moonshot, etc.
- [ ] Intl prober: `REGION_ID=us-east-1` → only probes openai, anthropic, etc. + global
- [ ] `GET /v1/providers` response includes `"probe_scope"` field
- [ ] Adding a new CN-only relay: `UPDATE providers SET probe_scope = 'cn' WHERE id = 'relay-xyz'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)