### PR TITLE
chore: untrack api binary, add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ pnpm-debug.log*
 
 # Docker
 docker-compose.override.yml
+api


### PR DESCRIPTION
Compiled Go binary was accidentally tracked in git, causing dirty working tree on every build. Removed from tracking and added to .gitignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)