### PR TITLE
fix: resolve all golangci-lint and eslint CI failures on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ public APIs must add an entry under `## [Unreleased]`.
 ### Fixed
 - Add missing `internal/api/websocket.go` (WebSocket Hub/Client types) omitted from prior commits, causing all PR CI runs to fail with undefined symbols
 - Fix `otprl.RedisLimiter.Allow`: use `SetArgs` method instead of incorrect `Set` call for NX+TTL semantics
+- Fix `FixtureProvider` missing `ProbeScope: "global"` field, causing all integration tests to fail with `providers_probe_scope_check` constraint violation
+- Fix all `gofmt`/`goimports` formatting issues across 20+ Go files
+- Add `statusOngoing`, `statusOperational`, `statusDown`, `statusDegraded`, `severityMajor` constants in `providers.go` to satisfy `goconst`
+- Fix `errcheck` violations in `websocket.go`/`websocket_test.go`: handle `conn.Close` and deadline error returns
+- Fix `errcheck` violations in `auth/oauth.go`, `email/client.go`, `notifier/webhook.go`: `defer resp.Body.Close()` annotated
+- Add `//nolint:gosec` for G706 log-injection false positives (structured logging, not string formatting) and G115 int32 conversion
+- Add `//nolint:unparam` for test helper functions where fixed-value params are intentional
+- Remove always-nil `error` return from `handleSubscription` in `realtime.go`
+- Add package-level and exported-symbol doc comments to satisfy `revive` across 8 packages
+- Fix TypeScript `no-explicit-any` errors in `lib/types.ts`, `lib/optimistic-updates.ts`, `lib/performance.ts`, `lib/swr-config.tsx`, `__tests__/lib/websocket.test.ts`, `tests/e2e/real-time-updates.spec.ts`
+- Fix `jest.setup.js` to use ES module import instead of `require()`
+- Fix `react/no-unescaped-entities` in `app/methodology/page.tsx`
+- Add `eslint-disable` for intentional `setState` in `ProbeTimestamp.tsx` effect
 
 ### Added (LLMS-045)
 - Fixed host port assignments for all dev services (avoid conflicts on this host): db→15432, influx→18086, ingest→18080, api→18081, Next.js dev→13000

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -110,8 +110,8 @@ func main() {
 	}
 
 	srv := &http.Server{
-		Addr:    addr,
-		Handler: api.New(store, opts...),
+		Addr:         addr,
+		Handler:      api.New(store, opts...),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/cmd/prober/main.go
+++ b/cmd/prober/main.go
@@ -61,7 +61,7 @@ func main() {
 	var sink probes.ResultSink = probes.LogSink{}
 	if ingestURL := os.Getenv("INGEST_URL"); ingestURL != "" {
 		sink = probes.NewHTTPSink(ingestURL)
-		slog.Info("prober: using HTTP sink", "url", ingestURL)
+		slog.Info("prober: using HTTP sink", "url", ingestURL) //nolint:gosec
 	}
 
 	r := probes.New(
@@ -151,7 +151,7 @@ func envDuration(key string, def time.Duration) time.Duration {
 	}
 	d, err := time.ParseDuration(v)
 	if err != nil {
-		slog.Warn("prober: invalid duration, using default", "key", key, "value", v, "default", def)
+		slog.Warn("prober: invalid duration, using default", "key", key, "value", v, "default", def) //nolint:gosec
 		return def
 	}
 	return d
@@ -164,7 +164,7 @@ func envInt(key string, def int) int {
 	}
 	n, err := strconv.Atoi(v)
 	if err != nil || n < 1 {
-		slog.Warn("prober: invalid int, using default", "key", key, "value", v, "default", def)
+		slog.Warn("prober: invalid int, using default", "key", key, "value", v, "default", def) //nolint:gosec
 		return def
 	}
 	return n

--- a/internal/api/badge.go
+++ b/internal/api/badge.go
@@ -82,8 +82,8 @@ func statusColor(status string) string {
 // x/y/width values here are in 10× units (1 SVG unit = 10 displayed pixels).
 func renderBadge(label, message, color string) string {
 	const (
-		hPx  = 20  // badge height in display pixels
-		padU = 50  // horizontal padding in 10× units (= 5px each side)
+		hPx  = 20 // badge height in display pixels
+		padU = 50 // horizontal padding in 10× units (= 5px each side)
 	)
 
 	labelU := badgeTextWidth(label) + padU*2

--- a/internal/api/feed.go
+++ b/internal/api/feed.go
@@ -1,13 +1,13 @@
 package api
 
 import (
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"text/template"
 	"time"
-	"encoding/xml"
 
 	"github.com/jackc/pgx/v5"
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -70,7 +70,7 @@ func accessLogMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(rw, r)
 
 		id, _ := r.Context().Value(ctxKeyRequestID).(string)
-		slog.Info("api: request",
+		slog.Info("api: request", //nolint:gosec
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", rw.status,

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -155,7 +155,7 @@ func TestMiddlewareOrdering_RateLimitBeforeApplication(t *testing.T) {
 	// Rate limiter fires at limit=1. Second request should be 429.
 	// CORS and request-ID headers should still appear on the 429 response
 	// because they are added by the outer middleware layers.
-	rl := api.NewRateLimiter(1, 0) // window=0 means every call resets (use window=1min)
+	rl := api.NewRateLimiter(1, 0)               // window=0 means every call resets (use window=1min)
 	rl2 := api.NewRateLimiter(1, 60_000_000_000) // 1 req per minute
 	srv := api.New(&fakeStore{}, api.WithRateLimiter(rl2))
 

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -7,6 +7,15 @@ import (
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 
+// Incident and severity values used across multiple handlers.
+const (
+	statusOngoing     = "ongoing"
+	statusOperational = "operational"
+	statusDown        = "down"
+	statusDegraded    = "degraded"
+	severityMajor     = "major"
+)
+
 // ---- response types ---------------------------------------------------------
 
 type modelStat struct {
@@ -71,7 +80,7 @@ func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ongoing, err := s.store.ListIncidentsByStatus(r.Context(), pgstore.ListIncidentsByStatusParams{
-		Status: "ongoing",
+		Status: statusOngoing,
 		Limit:  200,
 		Offset: 0,
 	})
@@ -98,9 +107,9 @@ func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
 
 	// Fetch all InfluxDB stats in parallel (three queries, all non-fatal).
 	var (
-		liveByProvider = make(map[string][2]float64)       // provider_id → [uptime, p95]
-		modelLiveStats = make(map[string][2]float64)       // "pid:model" → [uptime, p95]
-		sparklines     = make(map[string][]float64)        // "pid:model" → [60]float64
+		liveByProvider = make(map[string][2]float64) // provider_id → [uptime, p95]
+		modelLiveStats = make(map[string][2]float64) // "pid:model" → [uptime, p95]
+		sparklines     = make(map[string][]float64)  // "pid:model" → [60]float64
 	)
 	if s.liveStats != nil {
 		ctx := r.Context()
@@ -190,7 +199,7 @@ func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) {
 	incMap := map[string]pgstore.Incident{}
 	if len(activeIncs) > 0 {
 		for _, inc := range activeIncs {
-			if inc.Status == "ongoing" {
+			if inc.Status == statusOngoing {
 				existing, seen := incMap[inc.ProviderID]
 				if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
 					incMap[inc.ProviderID] = inc
@@ -263,16 +272,16 @@ func toProviderSummary(p pgstore.Provider, incMap map[string]pgstore.Incident) p
 func deriveStatus(providerID string, incMap map[string]pgstore.Incident) (string, *string) {
 	inc, ok := incMap[providerID]
 	if !ok {
-		return "operational", nil
+		return statusOperational, nil
 	}
 	id := inc.ID.String()
 	switch inc.Severity {
 	case "critical":
-		return "down", &id
-	case "major":
-		return "degraded", &id
+		return statusDown, &id
+	case severityMajor:
+		return statusDegraded, &id
 	default:
-		return "degraded", &id
+		return statusDegraded, &id
 	}
 }
 
@@ -280,7 +289,7 @@ func severityRank(s string) int {
 	switch s {
 	case "critical":
 		return 3
-	case "major":
+	case severityMajor:
 		return 2
 	case "minor":
 		return 1
@@ -306,7 +315,7 @@ func toIncidentRefs(incidents []pgstore.Incident) []incidentRef {
 	// Filter to ongoing only for the "active_incidents" field.
 	out := make([]incidentRef, 0)
 	for _, inc := range incidents {
-		if inc.Status != "ongoing" {
+		if inc.Status != statusOngoing {
 			continue
 		}
 		out = append(out, incidentRef{

--- a/internal/api/realtime.go
+++ b/internal/api/realtime.go
@@ -153,7 +153,7 @@ func (rm *RealtimeManager) SubscriberCount(channel string) int {
 }
 
 // handleSubscription processes subscription and unsubscription requests.
-func handleSubscription(client *Client, msg SubscriptionMessage) error {
+func handleSubscription(client *Client, msg SubscriptionMessage) {
 	switch msg.Type {
 	case "subscribe":
 		client.subscriptions[msg.Topic] = true
@@ -162,7 +162,6 @@ func handleSubscription(client *Client, msg SubscriptionMessage) error {
 		delete(client.subscriptions, msg.Topic)
 		slog.Info("client unsubscribed", "topic", msg.Topic)
 	}
-	return nil
 }
 
 // BroadcastToTopic sends a message to all clients subscribed to a specific topic.

--- a/internal/api/realtime_test.go
+++ b/internal/api/realtime_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestProviderSubscription(t *testing.T) {
@@ -19,8 +18,7 @@ func TestProviderSubscription(t *testing.T) {
 		Topic: "provider:openai",
 	}
 
-	err := handleSubscription(client, msg)
-	require.NoError(t, err)
+	handleSubscription(client, msg)
 	assert.True(t, client.subscriptions["provider:openai"])
 }
 
@@ -36,8 +34,7 @@ func TestProviderUnsubscription(t *testing.T) {
 		Type:  "subscribe",
 		Topic: "provider:openai",
 	}
-	err := handleSubscription(client, subMsg)
-	require.NoError(t, err)
+	handleSubscription(client, subMsg)
 	assert.True(t, client.subscriptions["provider:openai"])
 
 	// Unsubscribe
@@ -45,8 +42,7 @@ func TestProviderUnsubscription(t *testing.T) {
 		Type:  "unsubscribe",
 		Topic: "provider:openai",
 	}
-	err = handleSubscription(client, unsubMsg)
-	require.NoError(t, err)
+	handleSubscription(client, unsubMsg)
 	assert.False(t, client.subscriptions["provider:openai"])
 }
 
@@ -69,8 +65,7 @@ func TestBroadcastToTopic(t *testing.T) {
 		Type:  "subscribe",
 		Topic: "provider:openai",
 	}
-	err := handleSubscription(client, msg)
-	require.NoError(t, err)
+	handleSubscription(client, msg)
 
 	// Broadcast to topic
 	update := ProviderStatusUpdate{
@@ -102,8 +97,7 @@ func TestMultipleSubscriptions(t *testing.T) {
 			Type:  "subscribe",
 			Topic: topic,
 		}
-		err := handleSubscription(client, msg)
-		require.NoError(t, err)
+		handleSubscription(client, msg)
 	}
 
 	for _, topic := range topics {
@@ -123,9 +117,7 @@ func TestInvalidSubscriptionType(t *testing.T) {
 		Topic: "provider:openai",
 	}
 
-	// Spec requires ignoring invalid types and returning nil
-	err := handleSubscription(client, msg)
-	assert.NoError(t, err)
-	// Invalid type should be ignored, no subscription created
+	// Spec requires ignoring invalid types — no subscription created
+	handleSubscription(client, msg)
 	assert.False(t, client.subscriptions["provider:openai"])
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -28,13 +28,13 @@ type Pinger interface {
 // Server wires handlers to a ServeMux and owns the store reference.
 type Server struct {
 	store     Store
-	history   HistoryReader   // optional; nil → GET /history returns 503
-	liveStats LiveStatsReader // optional; nil → uptime24h/p95_ms omitted
-	pinger    Pinger          // optional; nil → /healthz always 200
-	limiter   *RateLimiter    // optional; nil → no rate limiting
-	auth      *AuthConfig     // optional; nil → auth routes return 501
+	history   HistoryReader     // optional; nil → GET /history returns 503
+	liveStats LiveStatsReader   // optional; nil → uptime24h/p95_ms omitted
+	pinger    Pinger            // optional; nil → /healthz always 200
+	limiter   *RateLimiter      // optional; nil → no rate limiting
+	auth      *AuthConfig       // optional; nil → auth routes return 501
 	keyEnc    *keyenc.Encrypter // optional; nil → sponsor key endpoints return 503
-	hub       *Hub            // WebSocket hub for real-time updates
+	hub       *Hub              // WebSocket hub for real-time updates
 	mux       *http.ServeMux
 	handler   http.Handler // mux optionally wrapped with limiter middleware
 }

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -50,7 +50,7 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.auth.Store.UpdateUserSettings(r.Context(), pgstore.UpdateUserSettingsParams{
 		ID:         claims.UserID,
-		DigestHour: int32(digestHour),
+		DigestHour: int32(digestHour), //nolint:gosec
 		Timezone:   timezone,
 	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "could not update settings")

--- a/internal/api/sponsors.go
+++ b/internal/api/sponsors.go
@@ -85,9 +85,9 @@ func (s *Server) registerSponsor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sp, err := s.store.CreateSponsor(r.Context(), pgstore.CreateSponsorParams{
-		ID:     body.ID,
-		UserID: claims.UserID,
-		Name:   body.Name,
+		ID:         body.ID,
+		UserID:     claims.UserID,
+		Name:       body.Name,
 		WebsiteUrl: nullText(body.WebsiteURL),
 		LogoUrl:    nullText(body.LogoURL),
 	})
@@ -121,11 +121,11 @@ func (s *Server) getSponsorMe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type keyOut struct {
-		ProviderID      string `json:"provider_id"`
-		KeyHint         string `json:"key_hint"`
-		Active          bool   `json:"active"`
-		LastVerifiedAt  any    `json:"last_verified_at"`
-		LastError       any    `json:"last_error"`
+		ProviderID     string `json:"provider_id"`
+		KeyHint        string `json:"key_hint"`
+		Active         bool   `json:"active"`
+		LastVerifiedAt any    `json:"last_verified_at"`
+		LastError      any    `json:"last_error"`
 	}
 	keyList := make([]keyOut, len(keys))
 	for i, k := range keys {

--- a/internal/api/status_test.go
+++ b/internal/api/status_test.go
@@ -129,7 +129,9 @@ func TestGetStatus_Empty(t *testing.T) {
 	}
 	mustDecode(t, rec.Body, &body)
 	// Should return operational when no providers configured.
-	var d struct{ Status string `json:"status"` }
+	var d struct {
+		Status string `json:"status"`
+	}
 	if err := json.Unmarshal(body.Data, &d); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}

--- a/internal/api/subscriptions.go
+++ b/internal/api/subscriptions.go
@@ -183,14 +183,14 @@ func (s *Server) handleDeleteSubscription(w http.ResponseWriter, r *http.Request
 // ---- helpers ---------------------------------------------------------------
 
 type subscriptionJSON struct {
-	ID          int64   `json:"id"`
-	ProviderID  string  `json:"provider_id"`
-	ProviderName string `json:"provider_name,omitempty"`
-	MinSeverity string  `json:"min_severity"`
-	EmailAlerts bool    `json:"email_alerts"`
-	EmailDigest bool    `json:"email_digest"`
-	WebhookURL  *string `json:"webhook_url"`
-	RSSURL      string  `json:"rss_url"`
+	ID           int64   `json:"id"`
+	ProviderID   string  `json:"provider_id"`
+	ProviderName string  `json:"provider_name,omitempty"`
+	MinSeverity  string  `json:"min_severity"`
+	EmailAlerts  bool    `json:"email_alerts"`
+	EmailDigest  bool    `json:"email_digest"`
+	WebhookURL   *string `json:"webhook_url"`
+	RSSURL       string  `json:"rss_url"`
 }
 
 func subscriptionResponse(s pgstore.Subscription, providerName string) subscriptionJSON {

--- a/internal/api/subscriptions_test.go
+++ b/internal/api/subscriptions_test.go
@@ -20,10 +20,10 @@ import (
 // fakeAuthStore implements api.AuthStore for unit tests.
 type fakeAuthStore struct {
 	fakeStore
-	subs          []pgstore.Subscription
-	subRows       []pgstore.ListSubscriptionsByUserRow
-	createErr     error
-	users         []pgstore.User
+	subs      []pgstore.Subscription
+	subRows   []pgstore.ListSubscriptionsByUserRow
+	createErr error
+	users     []pgstore.User
 }
 
 func (f *fakeAuthStore) UpsertUser(_ context.Context, e string) (pgstore.User, error) {
@@ -117,6 +117,7 @@ func newAuthServer(store *fakeAuthStore) *api.Server {
 	}))
 }
 
+//nolint:unparam
 func bearerHeader(t *testing.T, userID int64, email string) string {
 	t.Helper()
 	tok, err := auth.SignJWT(userID, email, testJWTSecret)

--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -122,7 +122,7 @@ func (h *Hub) Run() {
 			h.mu.Lock()
 			for client := range h.clients {
 				close(client.send)
-				client.conn.Close()
+				_ = client.conn.Close()
 			}
 			h.clients = make(map[*Client]bool)
 			h.mu.Unlock()
@@ -195,7 +195,7 @@ func HandleWebSocketWithHub(w http.ResponseWriter, r *http.Request, hub *Hub) {
 	confirmMsg := map[string]string{"type": "connected"}
 	if err := conn.WriteJSON(confirmMsg); err != nil {
 		slog.Error("websocket: failed to send connection confirmation", "err", err)
-		conn.Close()
+		_ = conn.Close()
 		hub.unregister <- client
 		return
 	}
@@ -209,12 +209,12 @@ func HandleWebSocketWithHub(w http.ResponseWriter, r *http.Request, hub *Hub) {
 func (c *Client) readPump() {
 	defer func() {
 		c.hub.unregister <- c
-		c.conn.Close()
+		_ = c.conn.Close()
 	}()
 
-	c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	_ = c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
 	c.conn.SetPongHandler(func(string) error {
-		c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+		return c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
 		return nil
 	})
 
@@ -256,15 +256,15 @@ func (c *Client) writePump() {
 	ticker := time.NewTicker(54 * time.Second)
 	defer func() {
 		ticker.Stop()
-		c.conn.Close()
+		_ = c.conn.Close()
 	}()
 
 	for {
 		select {
 		case message, ok := <-c.send:
-			c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 			if !ok {
-				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				_ = c.conn.WriteMessage(websocket.CloseMessage, []byte{})
 				return
 			}
 
@@ -273,7 +273,7 @@ func (c *Client) writePump() {
 			}
 
 		case <-ticker.C:
-			c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				return
 			}

--- a/internal/api/websocket_test.go
+++ b/internal/api/websocket_test.go
@@ -18,7 +18,7 @@ func TestWebSocketUpgrade(t *testing.T) {
 	url := "ws" + strings.TrimPrefix(server.URL, "http")
 	ws, _, err := websocket.DefaultDialer.Dial(url, nil)
 	require.NoError(t, err)
-	defer ws.Close()
+	defer ws.Close() //nolint:errcheck
 
 	// Should receive connection confirmation
 	var msg map[string]interface{}
@@ -39,7 +39,7 @@ func TestWebSocketClientRegistration(t *testing.T) {
 	url := "ws" + strings.TrimPrefix(server.URL, "http")
 	ws, _, err := websocket.DefaultDialer.Dial(url, nil)
 	require.NoError(t, err)
-	defer ws.Close()
+	defer ws.Close() //nolint:errcheck
 
 	// Receive connection confirmation
 	var msg map[string]interface{}
@@ -68,7 +68,7 @@ func TestWebSocketMultipleClients(t *testing.T) {
 	// Connect first client
 	ws1, _, err := websocket.DefaultDialer.Dial(url, nil)
 	require.NoError(t, err)
-	defer ws1.Close()
+	defer ws1.Close() //nolint:errcheck
 
 	var msg1 map[string]interface{}
 	err = ws1.ReadJSON(&msg1)
@@ -77,7 +77,7 @@ func TestWebSocketMultipleClients(t *testing.T) {
 	// Connect second client
 	ws2, _, err := websocket.DefaultDialer.Dial(url, nil)
 	require.NoError(t, err)
-	defer ws2.Close()
+	defer ws2.Close() //nolint:errcheck
 
 	var msg2 map[string]interface{}
 	err = ws2.ReadJSON(&msg2)
@@ -116,7 +116,7 @@ func TestWebSocketClientDisconnection(t *testing.T) {
 	assert.Equal(t, 1, initialCount)
 
 	// Close connection
-	ws.Close()
+	_ = ws.Close()
 
 	// Give hub time to process unregister
 	// In production, this would be handled by the client read loop detecting closure

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,3 +1,4 @@
+// Package auth provides JWT token generation and validation.
 package auth
 
 import (
@@ -7,9 +8,13 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+// TokenTTL is the duration a JWT token is valid.
 const TokenTTL = 30 * 24 * time.Hour
+
+// CookieName is the HTTP cookie name for the JWT token.
 const CookieName = "llms_session"
 
+// Claims holds the JWT payload fields.
 type Claims struct {
 	UserID int64  `json:"uid"`
 	Email  string `json:"email"`

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+// GoogleConfig returns OAuth2 config for Google provider.
 func GoogleConfig(clientID, clientSecret, redirectURL string) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     clientID,
@@ -22,6 +23,7 @@ func GoogleConfig(clientID, clientSecret, redirectURL string) *oauth2.Config {
 	}
 }
 
+// GitHubConfig returns OAuth2 config for GitHub provider.
 func GitHubConfig(clientID, clientSecret, redirectURL string) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     clientID,
@@ -43,7 +45,7 @@ func FetchGoogleUser(ctx context.Context, cfg *oauth2.Config, code string) (sub,
 	if err != nil {
 		return "", "", fmt.Errorf("google userinfo: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	var info struct {
 		Sub   string `json:"sub"`
 		Email string `json:"email"`
@@ -69,7 +71,7 @@ func FetchGitHubUser(ctx context.Context, cfg *oauth2.Config, code string) (sub,
 	if err != nil {
 		return "", "", fmt.Errorf("github user: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	var user struct {
 		ID    int64  `json:"id"`
 		Email string `json:"email"`
@@ -90,7 +92,7 @@ func FetchGitHubUser(ctx context.Context, cfg *oauth2.Config, code string) (sub,
 	if err != nil {
 		return sub, "", fmt.Errorf("github emails: %w", err)
 	}
-	defer resp2.Body.Close()
+	defer resp2.Body.Close() //nolint:errcheck
 	body, _ := io.ReadAll(resp2.Body)
 	var emails []struct {
 		Email   string `json:"email"`

--- a/internal/detector/reader.go
+++ b/internal/detector/reader.go
@@ -1,3 +1,4 @@
+// Package detector implements event detection rules and readers.
 package detector
 
 import (

--- a/internal/detector/rules.go
+++ b/internal/detector/rules.go
@@ -1,5 +1,6 @@
 package detector
 
+// Detection rule identifiers.
 const (
 	RuleProviderDown       = "provider_down"
 	RuleElevatedErrors     = "elevated_errors"

--- a/internal/detector/rules_test.go
+++ b/internal/detector/rules_test.go
@@ -180,7 +180,7 @@ func TestEvaluateLatencyRule_ZeroBaselineP95(t *testing.T) {
 
 func TestEvaluateRegionalRule_Fires(t *testing.T) {
 	regional := []RegionalStats{
-		{ProviderID: "openai", Region: "us-east-1", Total: 10, Errors: 6}, // 60%
+		{ProviderID: "openai", Region: "us-east-1", Total: 10, Errors: 6},  // 60%
 		{ProviderID: "openai", Region: "eu-central", Total: 10, Errors: 0}, // 0% — healthy
 	}
 	// Global stats show openai is NOT down overall.
@@ -235,9 +235,9 @@ func TestEvaluateRegionalRule_TooFewProbes(t *testing.T) {
 
 func TestEvaluateRegionalRule_MultipleRegions(t *testing.T) {
 	regional := []RegionalStats{
-		{ProviderID: "openai", Region: "us-east-1", Total: 10, Errors: 6}, // 60% — fire
+		{ProviderID: "openai", Region: "us-east-1", Total: 10, Errors: 6},      // 60% — fire
 		{ProviderID: "openai", Region: "ap-northeast-1", Total: 10, Errors: 9}, // 90% — fire
-		{ProviderID: "openai", Region: "eu-central", Total: 10, Errors: 0}, // healthy
+		{ProviderID: "openai", Region: "eu-central", Total: 10, Errors: 0},     // healthy
 	}
 	global := []ProbeStats{{ProviderID: "openai", Total: 30, Errors: 15}} // 50% — exactly at threshold, NOT > threshold
 	detections := EvaluateRegionalRule(regional, global)

--- a/internal/detector/runner_test.go
+++ b/internal/detector/runner_test.go
@@ -16,11 +16,11 @@ import (
 // ---- fake ProbeReader -------------------------------------------------------
 
 type fakeReader struct {
-	stats5m   []ProbeStats
-	stats10m  []ProbeStats
-	latency   []LatencyStats
-	regional  []RegionalStats
-	err       error
+	stats5m  []ProbeStats
+	stats10m []ProbeStats
+	latency  []LatencyStats
+	regional []RegionalStats
+	err      error
 }
 
 func (f *fakeReader) ErrorRateByProvider(_ context.Context, window time.Duration) ([]ProbeStats, error) {
@@ -44,13 +44,13 @@ func (f *fakeReader) RegionalErrorRateByProvider(_ context.Context, _ time.Durat
 // ---- fake IncidentStore -----------------------------------------------------
 
 type fakeIncidentStore struct {
-	incidents   []pgstore.Incident
-	created     []pgstore.CreateIncidentParams
-	resolved    []pgstore.ResolveIncidentParams
-	getErr      error // non-nil → GetOngoingByProviderAndRule returns this error
-	createErr   error // non-nil → CreateIncident returns this error
-	listErr     error // non-nil → ListIncidentsByStatus returns this error
-	resolveErr  error // non-nil → ResolveIncident returns this error
+	incidents  []pgstore.Incident
+	created    []pgstore.CreateIncidentParams
+	resolved   []pgstore.ResolveIncidentParams
+	getErr     error // non-nil → GetOngoingByProviderAndRule returns this error
+	createErr  error // non-nil → CreateIncident returns this error
+	listErr    error // non-nil → ListIncidentsByStatus returns this error
+	resolveErr error // non-nil → ResolveIncident returns this error
 }
 
 func (f *fakeIncidentStore) GetOngoingByProviderAndRule(_ context.Context, arg pgstore.GetOngoingByProviderAndRuleParams) (pgstore.Incident, error) {

--- a/internal/email/client.go
+++ b/internal/email/client.go
@@ -1,3 +1,4 @@
+// Package email provides a simple HTTP-based email sending client.
 package email
 
 import (
@@ -16,6 +17,7 @@ type Sender interface {
 	Send(ctx context.Context, msg Message) error
 }
 
+// Client sends transactional emails via HTTP.
 type Client struct {
 	apiKey  string
 	from    string
@@ -23,6 +25,7 @@ type Client struct {
 	http    *http.Client
 }
 
+// New creates an email client from environment config.
 func New(apiKey, from string) *Client {
 	return &Client{
 		apiKey:  apiKey,
@@ -42,6 +45,7 @@ func NewWithBaseURL(baseURL, apiKey, from string) *Client {
 	}
 }
 
+// Message holds the fields for an outbound email.
 type Message struct {
 	To      string
 	Subject string
@@ -49,6 +53,7 @@ type Message struct {
 	Text    string
 }
 
+// Send delivers a single email message.
 func (c *Client) Send(ctx context.Context, msg Message) error {
 	payload := map[string]any{
 		"from":    c.from,
@@ -72,7 +77,7 @@ func (c *Client) Send(ctx context.Context, msg Message) error {
 	if err != nil {
 		return fmt.Errorf("email: send: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("email: resend returned %d", resp.StatusCode)
 	}

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -84,7 +84,7 @@ func TestHandler_ValidProbe(t *testing.T) {
 
 func TestHandler_MissingFields(t *testing.T) {
 	cases := []struct {
-		name  string
+		name   string
 		mutate func(*probes.ProbeResult)
 	}{
 		{"missing provider_id", func(r *probes.ProbeResult) { r.ProviderID = "" }},

--- a/internal/notifier/digest_test.go
+++ b/internal/notifier/digest_test.go
@@ -75,6 +75,7 @@ func newDigestNotifier(t *testing.T, store *digestStore) *Notifier {
 	})
 }
 
+//nolint:unparam
 func userFixture(id int64, digestHour int, tz string) pgstore.User {
 	return pgstore.User{
 		ID:         id,

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -44,6 +44,7 @@ type Notifier struct {
 	cfg Config
 }
 
+// New creates a Notifier wired to the given dependencies.
 func New(cfg Config) *Notifier {
 	if cfg.Interval <= 0 {
 		cfg.Interval = 30 * time.Second
@@ -166,15 +167,15 @@ func incidentEvent(status string) string {
 }
 
 type webhookPayload struct {
-	Event      string  `json:"event"`
-	ProviderID string  `json:"provider_id"`
+	Event      string    `json:"event"`
+	ProviderID string    `json:"provider_id"`
 	IncidentID uuid.UUID `json:"incident_id"`
-	Severity   string  `json:"severity"`
-	Title      string  `json:"title"`
-	Status     string  `json:"status"`
-	StartedAt  string  `json:"started_at"`
-	ResolvedAt *string `json:"resolved_at,omitempty"`
-	URL        string  `json:"url"`
+	Severity   string    `json:"severity"`
+	Title      string    `json:"title"`
+	Status     string    `json:"status"`
+	StartedAt  string    `json:"started_at"`
+	ResolvedAt *string   `json:"resolved_at,omitempty"`
+	URL        string    `json:"url"`
 }
 
 func buildPayload(inc pgstore.Incident, event, siteURL string) webhookPayload {

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -24,6 +24,7 @@ type fakeStore struct {
 	sent      map[string]bool
 }
 
+//nolint:unparam
 func alertKey(subID int64, incID uuid.UUID, ch, ev string) string {
 	return incID.String() + ":" + ch + ":" + ev
 }
@@ -68,6 +69,7 @@ func incidentFixture(providerID, status, severity string) pgstore.Incident {
 	}
 }
 
+//nolint:unparam
 func subFixture(providerID, minSev, userEmail string, emailAlerts bool, webhookURL string) pgstore.ListSubscriptionsForProviderRow {
 	row := pgstore.ListSubscriptionsForProviderRow{
 		ID:           1,

--- a/internal/notifier/webhook.go
+++ b/internal/notifier/webhook.go
@@ -52,7 +52,7 @@ func postWebhook(ctx context.Context, url string, body []byte) error {
 	if err != nil {
 		return fmt.Errorf("send: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("remote returned %d", resp.StatusCode)
 	}

--- a/internal/otprl/ratelimiter.go
+++ b/internal/otprl/ratelimiter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// OTP rate-limit parameters.
 const (
 	MaxAttempts = 3
 	Window      = 10 * time.Minute
@@ -27,10 +28,12 @@ type RedisLimiter struct {
 	rdb *redis.Client
 }
 
+// NewRedis creates a Redis-backed rate limiter.
 func NewRedis(rdb *redis.Client) *RedisLimiter {
 	return &RedisLimiter{rdb: rdb}
 }
 
+// Allow checks and records an OTP attempt for the email address.
 func (r *RedisLimiter) Allow(ctx context.Context, email string) (bool, time.Duration, error) {
 	key := otpKey(email)
 
@@ -67,10 +70,12 @@ type MemoryLimiter struct {
 	counts map[string]int
 }
 
+// NewMemory creates an in-memory rate limiter for tests.
 func NewMemory() *MemoryLimiter {
 	return &MemoryLimiter{counts: make(map[string]int)}
 }
 
+// Allow checks and records an OTP attempt for the email address.
 func (m *MemoryLimiter) Allow(_ context.Context, email string) (bool, time.Duration, error) {
 	m.counts[email]++
 	if m.counts[email] > MaxAttempts {

--- a/internal/probes/adapters/anthropic.go
+++ b/internal/probes/adapters/anthropic.go
@@ -13,12 +13,12 @@ import (
 )
 
 const (
-	anthropicDefaultBaseURL  = "https://api.anthropic.com/v1"
-	anthropicProviderID      = "anthropic"
-	anthropicVersion         = "2023-06-01"
-	anthropicLightModel      = "claude-haiku-4-5-20251001"
-	anthropicLightProbeType  = "light_inference"
-	anthropicErrorDetailMax  = 200
+	anthropicDefaultBaseURL = "https://api.anthropic.com/v1"
+	anthropicProviderID     = "anthropic"
+	anthropicVersion        = "2023-06-01"
+	anthropicLightModel     = "claude-haiku-4-5-20251001"
+	anthropicLightProbeType = "light_inference"
+	anthropicErrorDetailMax = 200
 	// 529 is Anthropic's non-standard "overloaded" HTTP status (see docs/known-quirks.md).
 	anthropicStatusOverloaded = 529
 )

--- a/internal/probes/adapters/azure_openai.go
+++ b/internal/probes/adapters/azure_openai.go
@@ -14,11 +14,11 @@ import (
 )
 
 const (
-	azureOpenAIDefaultBaseURL   = "https://%s.openai.azure.com"
+	azureOpenAIDefaultBaseURL    = "https://%s.openai.azure.com"
 	azureOpenAIDefaultAPIVersion = "2024-10-21"
-	azureOpenAIProviderID       = "azure_openai"
-	azureOpenAILightProbeType   = "light_inference"
-	azureOpenAIErrorDetailMax   = 200
+	azureOpenAIProviderID        = "azure_openai"
+	azureOpenAILightProbeType    = "light_inference"
+	azureOpenAIErrorDetailMax    = 200
 )
 
 // AzureOpenAIOption configures an Azure OpenAI provider at construction time.

--- a/internal/probes/adapters/cn_fireworks_test.go
+++ b/internal/probes/adapters/cn_fireworks_test.go
@@ -43,14 +43,17 @@ func TestMoonshot_Identity(t *testing.T) {
 
 func TestMoonshot_ProbeLightInference(t *testing.T) {
 	testOpenAICompatAdapter(t, "moonshot", "moonshot",
-		func(base string) probes.Provider { return NewMoonshotProvider("k", "r", WithNewMoonshotProviderBaseURL(base)) },
+		func(base string) probes.Provider {
+			return NewMoonshotProvider("k", "r", WithNewMoonshotProviderBaseURL(base))
+		},
 		moonshotLightModel,
 	)
 }
 
 func TestMoonshot_Timeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(200 * time.Millisecond); w.WriteHeader(http.StatusOK)
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
 	p := NewMoonshotProvider("k", "r", WithNewMoonshotProviderBaseURL(srv.URL), WithNewMoonshotProviderHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}))
@@ -70,14 +73,17 @@ func TestZhipu_Identity(t *testing.T) {
 
 func TestZhipu_ProbeLightInference(t *testing.T) {
 	testOpenAICompatAdapter(t, "zhipu", "zhipu",
-		func(base string) probes.Provider { return NewZhipuProvider("k", "r", WithNewZhipuProviderBaseURL(base)) },
+		func(base string) probes.Provider {
+			return NewZhipuProvider("k", "r", WithNewZhipuProviderBaseURL(base))
+		},
 		zhipuLightModel,
 	)
 }
 
 func TestZhipu_Timeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(200 * time.Millisecond); w.WriteHeader(http.StatusOK)
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
 	p := NewZhipuProvider("k", "r", WithNewZhipuProviderBaseURL(srv.URL), WithNewZhipuProviderHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}))
@@ -97,14 +103,17 @@ func TestZeroOne_Identity(t *testing.T) {
 
 func TestZeroOne_ProbeLightInference(t *testing.T) {
 	testOpenAICompatAdapter(t, "zeroone_ai", "zeroone",
-		func(base string) probes.Provider { return NewZeroOneProvider("k", "r", WithNewZeroOneProviderBaseURL(base)) },
+		func(base string) probes.Provider {
+			return NewZeroOneProvider("k", "r", WithNewZeroOneProviderBaseURL(base))
+		},
 		zerooneLightModel,
 	)
 }
 
 func TestZeroOne_Timeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(200 * time.Millisecond); w.WriteHeader(http.StatusOK)
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
 	p := NewZeroOneProvider("k", "r", WithNewZeroOneProviderBaseURL(srv.URL), WithNewZeroOneProviderHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}))
@@ -131,7 +140,8 @@ func TestQwen_ProbeLightInference(t *testing.T) {
 
 func TestQwen_Timeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(200 * time.Millisecond); w.WriteHeader(http.StatusOK)
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
 	p := NewQwenProvider("k", "r", WithNewQwenProviderBaseURL(srv.URL), WithNewQwenProviderHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}))
@@ -160,7 +170,8 @@ func TestFireworks_ProbeLightInference(t *testing.T) {
 
 func TestFireworks_Timeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(200 * time.Millisecond); w.WriteHeader(http.StatusOK)
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
 	p := NewFireworksProvider("k", "r", WithNewFireworksProviderBaseURL(srv.URL), WithNewFireworksProviderHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}))

--- a/internal/probes/adapters/cohere.go
+++ b/internal/probes/adapters/cohere.go
@@ -27,7 +27,9 @@ type CohereOption func(*cohereProvider)
 func WithCohereBaseURL(u string) CohereOption { return func(p *cohereProvider) { p.baseURL = u } }
 
 // WithCohereHTTPClient overrides the HTTP client. Intended for tests.
-func WithCohereHTTPClient(c *http.Client) CohereOption { return func(p *cohereProvider) { p.client = c } }
+func WithCohereHTTPClient(c *http.Client) CohereOption {
+	return func(p *cohereProvider) { p.client = c }
+}
 
 // NewCohereProvider returns a probes.Provider backed by api.cohere.com.
 func NewCohereProvider(apiKey, region string, opts ...CohereOption) probes.Provider {

--- a/internal/probes/adapters/doubao.go
+++ b/internal/probes/adapters/doubao.go
@@ -21,7 +21,9 @@ const (
 type NewDoubaoProviderOption func(*doubaoProvider)
 
 // WithNewDoubaoProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewDoubaoProviderBaseURL(u string) NewDoubaoProviderOption { return func(p *doubaoProvider) { p.baseURL = u } }
+func WithNewDoubaoProviderBaseURL(u string) NewDoubaoProviderOption {
+	return func(p *doubaoProvider) { p.baseURL = u }
+}
 
 // WithNewDoubaoProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewDoubaoProviderHTTPClient(c *http.Client) NewDoubaoProviderOption {

--- a/internal/probes/adapters/fireworks.go
+++ b/internal/probes/adapters/fireworks.go
@@ -21,7 +21,9 @@ const (
 type NewFireworksProviderOption func(*fireworksProvider)
 
 // WithNewFireworksProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewFireworksProviderBaseURL(u string) NewFireworksProviderOption { return func(p *fireworksProvider) { p.baseURL = u } }
+func WithNewFireworksProviderBaseURL(u string) NewFireworksProviderOption {
+	return func(p *fireworksProvider) { p.baseURL = u }
+}
 
 // WithNewFireworksProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewFireworksProviderHTTPClient(c *http.Client) NewFireworksProviderOption {

--- a/internal/probes/adapters/gemini.go
+++ b/internal/probes/adapters/gemini.go
@@ -115,8 +115,8 @@ type geminiPart struct {
 }
 
 type geminiGenerateRequest struct {
-	Contents         []geminiContent  `json:"contents"`
-	GenerationConfig geminiGenConfig  `json:"generationConfig"`
+	Contents         []geminiContent `json:"contents"`
+	GenerationConfig geminiGenConfig `json:"generationConfig"`
 }
 
 type geminiGenConfig struct {

--- a/internal/probes/adapters/groq.go
+++ b/internal/probes/adapters/groq.go
@@ -67,6 +67,8 @@ func (p *groqProvider) ProbeStreaming(_ context.Context, _ string) (probes.Probe
 
 // probeOpenAICompat is the shared probe implementation for all providers that
 // expose the OpenAI Chat Completions API at /chat/completions.
+//
+//nolint:unparam
 func probeOpenAICompat(ctx context.Context, baseURL, apiKey, region, providerID, probeType string, maxDetail int, model string, client *http.Client) (probes.ProbeResult, error) {
 	started := time.Now()
 	r := probes.ProbeResult{

--- a/internal/probes/adapters/huggingface.go
+++ b/internal/probes/adapters/huggingface.go
@@ -21,7 +21,9 @@ const (
 type NewHuggingFaceProviderOption func(*huggingfaceProvider)
 
 // WithNewHuggingFaceProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewHuggingFaceProviderBaseURL(u string) NewHuggingFaceProviderOption { return func(p *huggingfaceProvider) { p.baseURL = u } }
+func WithNewHuggingFaceProviderBaseURL(u string) NewHuggingFaceProviderOption {
+	return func(p *huggingfaceProvider) { p.baseURL = u }
+}
 
 // WithNewHuggingFaceProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewHuggingFaceProviderHTTPClient(c *http.Client) NewHuggingFaceProviderOption {

--- a/internal/probes/adapters/minimax.go
+++ b/internal/probes/adapters/minimax.go
@@ -21,7 +21,9 @@ const (
 type NewMinimaxProviderOption func(*minimaxProvider)
 
 // WithNewMinimaxProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewMinimaxProviderBaseURL(u string) NewMinimaxProviderOption { return func(p *minimaxProvider) { p.baseURL = u } }
+func WithNewMinimaxProviderBaseURL(u string) NewMinimaxProviderOption {
+	return func(p *minimaxProvider) { p.baseURL = u }
+}
 
 // WithNewMinimaxProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewMinimaxProviderHTTPClient(c *http.Client) NewMinimaxProviderOption {

--- a/internal/probes/adapters/moonshot.go
+++ b/internal/probes/adapters/moonshot.go
@@ -21,7 +21,9 @@ const (
 type NewMoonshotProviderOption func(*moonshotProvider)
 
 // WithNewMoonshotProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewMoonshotProviderBaseURL(u string) NewMoonshotProviderOption { return func(p *moonshotProvider) { p.baseURL = u } }
+func WithNewMoonshotProviderBaseURL(u string) NewMoonshotProviderOption {
+	return func(p *moonshotProvider) { p.baseURL = u }
+}
 
 // WithNewMoonshotProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewMoonshotProviderHTTPClient(c *http.Client) NewMoonshotProviderOption {

--- a/internal/probes/adapters/qwen.go
+++ b/internal/probes/adapters/qwen.go
@@ -21,7 +21,9 @@ const (
 type NewQwenProviderOption func(*qwenProvider)
 
 // WithNewQwenProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewQwenProviderBaseURL(u string) NewQwenProviderOption { return func(p *qwenProvider) { p.baseURL = u } }
+func WithNewQwenProviderBaseURL(u string) NewQwenProviderOption {
+	return func(p *qwenProvider) { p.baseURL = u }
+}
 
 // WithNewQwenProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewQwenProviderHTTPClient(c *http.Client) NewQwenProviderOption {

--- a/internal/probes/adapters/zeroone.go
+++ b/internal/probes/adapters/zeroone.go
@@ -21,7 +21,9 @@ const (
 type NewZeroOneProviderOption func(*zerooneProvider)
 
 // WithNewZeroOneProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewZeroOneProviderBaseURL(u string) NewZeroOneProviderOption { return func(p *zerooneProvider) { p.baseURL = u } }
+func WithNewZeroOneProviderBaseURL(u string) NewZeroOneProviderOption {
+	return func(p *zerooneProvider) { p.baseURL = u }
+}
 
 // WithNewZeroOneProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewZeroOneProviderHTTPClient(c *http.Client) NewZeroOneProviderOption {

--- a/internal/probes/adapters/zhipu.go
+++ b/internal/probes/adapters/zhipu.go
@@ -21,7 +21,9 @@ const (
 type NewZhipuProviderOption func(*zhipuProvider)
 
 // WithNewZhipuProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewZhipuProviderBaseURL(u string) NewZhipuProviderOption { return func(p *zhipuProvider) { p.baseURL = u } }
+func WithNewZhipuProviderBaseURL(u string) NewZhipuProviderOption {
+	return func(p *zhipuProvider) { p.baseURL = u }
+}
 
 // WithNewZhipuProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewZhipuProviderHTTPClient(c *http.Client) NewZhipuProviderOption {

--- a/internal/probes/base.go
+++ b/internal/probes/base.go
@@ -45,6 +45,7 @@ type Provider interface {
 // METHODOLOGY.md §5.4. Do not add new values without a methodology PR.
 type ErrorClass string
 
+// Error classification constants.
 const (
 	ErrorClassNone            ErrorClass = ""
 	ErrorClassTimeout         ErrorClass = "timeout"

--- a/internal/probes/runner.go
+++ b/internal/probes/runner.go
@@ -8,9 +8,9 @@ import (
 )
 
 const (
-	defaultInterval    = 60 * time.Second
+	defaultInterval     = 60 * time.Second
 	defaultProbeTimeout = 30 * time.Second
-	defaultConcurrency = 8
+	defaultConcurrency  = 8
 )
 
 // ResultSink receives probe results. Implementations include LogSink (default)

--- a/internal/store/influx/writer_test.go
+++ b/internal/store/influx/writer_test.go
@@ -2,8 +2,8 @@ package influx
 
 import (
 	"context"
-	"net/http"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"

--- a/pkg/testutil/fixtures.go
+++ b/pkg/testutil/fixtures.go
@@ -18,14 +18,15 @@ func FixtureProvider(t *testing.T, pool *pgxpool.Pool) string {
 	id := "fixture_" + t.Name()
 	q := pgstore.New(pool)
 	err := q.UpsertProvider(context.Background(), pgstore.UpsertProviderParams{
-		ID:       id,
-		Name:     "Fixture Provider",
-		Category: "official",
-		BaseUrl:  "https://api.fixture.test",
-		AuthType: "bearer",
-		Region:   "global",
-		Active:   true,
-		Config:   json.RawMessage(`{}`),
+		ID:         id,
+		Name:       "Fixture Provider",
+		Category:   "official",
+		BaseUrl:    "https://api.fixture.test",
+		AuthType:   "bearer",
+		Region:     "global",
+		Active:     true,
+		Config:     json.RawMessage(`{}`),
+		ProbeScope: "global",
 	})
 	if err != nil {
 		t.Fatalf("FixtureProvider: upsert provider %q: %v", id, err)

--- a/web/__tests__/lib/websocket.test.ts
+++ b/web/__tests__/lib/websocket.test.ts
@@ -1,16 +1,25 @@
 import { WebSocketClient } from '@/lib/websocket'
 
+type EventCallback = (data?: Event | MessageEvent) => void
+
 describe('WebSocketClient', () => {
-  let mockWS: any
-  let originalWebSocket: any
+  let mockWS: {
+    send: jest.Mock
+    close: jest.Mock
+    addEventListener: jest.Mock
+    removeEventListener: jest.Mock
+    readyState: number
+    _triggerEvent: (event: string, data?: Event | MessageEvent) => void
+  }
+  let originalWebSocket: typeof global.WebSocket
 
   beforeEach(() => {
-    const eventListeners: { [key: string]: Function[] } = {}
+    const eventListeners: Record<string, EventCallback[]> = {}
 
     mockWS = {
       send: jest.fn(),
       close: jest.fn(),
-      addEventListener: jest.fn((event: string, callback: Function) => {
+      addEventListener: jest.fn((event: string, callback: EventCallback) => {
         if (!eventListeners[event]) {
           eventListeners[event] = []
         }
@@ -23,7 +32,7 @@ describe('WebSocketClient', () => {
       }),
       removeEventListener: jest.fn(),
       readyState: 1, // OPEN
-      _triggerEvent: (event: string, data?: any) => {
+      _triggerEvent: (event: string, data?: Event | MessageEvent) => {
         if (eventListeners[event]) {
           eventListeners[event].forEach(callback => callback(data))
         }
@@ -31,8 +40,9 @@ describe('WebSocketClient', () => {
     }
 
     originalWebSocket = global.WebSocket
-    // Mock WebSocket constructor and constants
-    const MockWebSocket = jest.fn(() => mockWS) as any
+    const MockWebSocket = jest.fn(() => mockWS) as unknown as typeof WebSocket & {
+      OPEN: number; CLOSED: number; CONNECTING: number; CLOSING: number
+    }
     MockWebSocket.OPEN = 1
     MockWebSocket.CLOSED = 3
     MockWebSocket.CONNECTING = 0

--- a/web/app/methodology/page.tsx
+++ b/web/app/methodology/page.tsx
@@ -104,7 +104,7 @@ export default function MethodologyPage() {
           <div className="px-4 py-3 grid grid-cols-[6rem_1fr] gap-4">
             <span className="text-xs font-semibold text-[var(--ink-400)]">Light inference</span>
             <span className="text-xs text-[var(--ink-200)]">
-              Sends a minimal prompt ("Reply with OK"), expects ≤10 token response. Runs every 60 s.
+              Sends a minimal prompt (&quot;Reply with OK&quot;), expects ≤10 token response. Runs every 60 s.
               This is the primary uptime signal.
             </span>
           </div>

--- a/web/components/ProbeTimestamp.tsx
+++ b/web/components/ProbeTimestamp.tsx
@@ -28,6 +28,9 @@ export function ProbeTimestamp({ iso, prefix }: Props) {
   const [label, setLabel] = useState(() => relativeTime(iso));
 
   useEffect(() => {
+    // Sync label to new `iso` prop on change, then poll every 10 s.
+    // The synchronous setState is intentional: it avoids a one-tick stale display.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLabel(relativeTime(iso));
     const id = setInterval(() => setLabel(relativeTime(iso)), 10_000);
     return () => clearInterval(id);

--- a/web/jest.setup.js
+++ b/web/jest.setup.js
@@ -1,1 +1,1 @@
-require('@testing-library/jest-dom')
+import '@testing-library/jest-dom'

--- a/web/lib/optimistic-updates.ts
+++ b/web/lib/optimistic-updates.ts
@@ -1,8 +1,8 @@
 export interface OptimisticItem {
   id: string
   _optimistic?: boolean
-  _originalValue?: any
-  [key: string]: any
+  _originalValue?: unknown
+  [key: string]: unknown
 }
 
 export function optimisticUpdate<T extends OptimisticItem>(

--- a/web/lib/performance.ts
+++ b/web/lib/performance.ts
@@ -1,4 +1,4 @@
-export function debounce<T extends (...args: any[]) => any>(
+export function debounce<T extends (...args: Parameters<T>) => ReturnType<T>>(
   func: T,
   wait: number
 ): (...args: Parameters<T>) => void {
@@ -10,7 +10,7 @@ export function debounce<T extends (...args: any[]) => any>(
   }
 }
 
-export function throttle<T extends (...args: any[]) => any>(
+export function throttle<T extends (...args: Parameters<T>) => ReturnType<T>>(
   func: T,
   limit: number
 ): (...args: Parameters<T>) => void {

--- a/web/lib/swr-config.tsx
+++ b/web/lib/swr-config.tsx
@@ -32,7 +32,9 @@ export function SWRProvider({ children }: SWRProviderProps) {
 }
 
 // SWR middleware to integrate with real-time updates
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function realtimeMiddleware(useSWRNext: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (key: string, fetcher: any, config: any) => {
     const swr = useSWRNext(key, fetcher, config)
 

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -12,5 +12,5 @@ export interface SubscriptionMessage {
 
 export interface WebSocketMessage {
   type: string
-  [key: string]: any
+  [key: string]: unknown
 }

--- a/web/tests/e2e/real-time-updates.spec.ts
+++ b/web/tests/e2e/real-time-updates.spec.ts
@@ -5,31 +5,28 @@ test.describe('Real-time Updates', () => {
     // Mock WebSocket for testing
     await page.addInitScript(() => {
       class MockWebSocket {
-        constructor(url: string) {
+        onopen: ((event: Event) => void) | null = null
+        onmessage: ((event: MessageEvent) => void) | null = null
+        onclose: ((event: CloseEvent) => void) | null = null
+        onerror: ((event: Event) => void) | null = null
+
+        constructor(_url: string) {
           setTimeout(() => {
-            this.onopen?.({ type: 'open' })
-            this.onmessage?.({
-              type: 'message',
+            this.onopen?.(new Event('open'))
+            this.onmessage?.(new MessageEvent('message', {
               data: JSON.stringify({ type: 'connected' })
-            })
+            }))
           }, 100)
         }
 
-        send(data: string) {
-          // Mock send
-        }
+        send(_data: string) {}
 
         close() {
-          this.onclose?.({ type: 'close' })
+          this.onclose?.(new CloseEvent('close'))
         }
-
-        onopen: ((event: any) => void) | null = null
-        onmessage: ((event: any) => void) | null = null
-        onclose: ((event: any) => void) | null = null
-        onerror: ((event: any) => void) | null = null
       }
 
-      (window as any).WebSocket = MockWebSocket
+      ;(window as unknown as Record<string, unknown>).WebSocket = MockWebSocket
     })
 
     await page.goto('/')


### PR DESCRIPTION
## Summary

Comprehensive fix for all CI failures on main. Addresses 109 Go linter errors and 25 TypeScript errors that have been preventing PR merges.

**Root causes:**
- `FixtureProvider` was missing `ProbeScope: "global"` since migration 0015 added `probe_scope NOT NULL CHECK(...)` — all integration tests were failing
- `websocket.go` and `websocket_test.go` were never committed (fixed in #151) but had their own errcheck violations
- Accumulated gofmt drift, goconst magic strings, unparam, gosec, revive comment gaps across many files
- TypeScript: `any` types, `require()` in jest.setup, unescaped entities, eslint-disable missing

**Remaining known issues (filed separately):**
- `gocyclo` complexity > 10 in: `cmd/migrate/main.go` (17), `providers.go` listProviders/getProvider (16), `badge.go` getBadge (13), `subscriptions.go` handleUpdateSubscription (15), `websocket.go` isValidChannelName (13), `live_stats.go` two functions, `auth.go` handleOAuthUpsert (11). These require refactoring — will be LLMS- issues.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (unit)
- [ ] Integration tests pass (probe_scope fixture fix)
- [ ] `npm run lint` in web/ passes with 0 errors
- [ ] CI green on all checks except gocyclo (which needs separate refactoring)