### PR TITLE
fix: TypeScript type error in rollbackUpdate and Ansible roles_path

### DIFF
--- a/deploy/ansible/ansible.cfg
+++ b/deploy/ansible/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 inventory          = inventories/prod/hosts.yml
+roles_path         = roles
 remote_user        = ubuntu
 private_key_file   = ~/.ssh/id_rsa
 host_key_checking  = False

--- a/web/lib/optimistic-updates.ts
+++ b/web/lib/optimistic-updates.ts
@@ -35,7 +35,7 @@ export function rollbackUpdate<T extends OptimisticItem>(
       }
       // Fallback to original value if server data not available
       if (item._originalValue) {
-        return item._originalValue
+        return item._originalValue as T
       }
     }
     return item


### PR DESCRIPTION
## Summary
- `rollbackUpdate<T>` returned `unknown` instead of `T` when falling back to `_originalValue`; added `as T` cast — regression from #152 causing Next.js build to fail
- `deploy/ansible/ansible.cfg`: added `roles_path = roles` so `ansible-playbook playbooks/site.yml` resolves roles correctly

## Test plan
- [ ] `cd web && npm run build` passes without TypeScript errors
- [ ] `ansible-playbook deploy/ansible/playbooks/site.yml --syntax-check` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)