### PR TITLE
fix: resolve remaining CI failures on main

### DIFF
--- a/deploy/ansible/ansible.cfg
+++ b/deploy/ansible/ansible.cfg
@@ -5,7 +5,8 @@ remote_user        = ubuntu
 private_key_file   = ~/.ssh/id_rsa
 host_key_checking  = False
 retry_files_enabled = False
-stdout_callback    = yaml
+stdout_callback    = default
+result_format      = yaml
 
 [ssh_connection]
 pipelining         = True

--- a/deploy/ansible/playbooks/group_vars
+++ b/deploy/ansible/playbooks/group_vars
@@ -1,0 +1,1 @@
+../group_vars

--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -215,7 +215,6 @@ func (c *Client) readPump() {
 	_ = c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
 	c.conn.SetPongHandler(func(string) error {
 		return c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
-		return nil
 	})
 
 	for {

--- a/tests/integration/store/store_test.go
+++ b/tests/integration/store/store_test.go
@@ -27,14 +27,15 @@ func TestIntegration_Provider(t *testing.T) {
 
 	t.Run("upsert and get", func(t *testing.T) {
 		err := q.UpsertProvider(ctx, pgstore.UpsertProviderParams{
-			ID:       "test_openai",
-			Name:     "OpenAI",
-			Category: "official",
-			BaseUrl:  "https://api.openai.com",
-			AuthType: "bearer",
-			Region:   "global",
-			Active:   true,
-			Config:   json.RawMessage(`{"models":["gpt-4o-mini"]}`),
+			ID:         "test_openai",
+			Name:       "OpenAI",
+			Category:   "official",
+			BaseUrl:    "https://api.openai.com",
+			AuthType:   "bearer",
+			Region:     "global",
+			Active:     true,
+			Config:     json.RawMessage(`{"models":["gpt-4o-mini"]}`),
+			ProbeScope: "global",
 		})
 		if err != nil {
 			t.Fatalf("UpsertProvider: %v", err)
@@ -57,14 +58,15 @@ func TestIntegration_Provider(t *testing.T) {
 
 	t.Run("upsert is idempotent", func(t *testing.T) {
 		params := pgstore.UpsertProviderParams{
-			ID:       "test_openai",
-			Name:     "OpenAI (updated)",
-			Category: "official",
-			BaseUrl:  "https://api.openai.com",
-			AuthType: "bearer",
-			Region:   "us",
-			Active:   true,
-			Config:   json.RawMessage(`{}`),
+			ID:         "test_openai",
+			Name:       "OpenAI (updated)",
+			Category:   "official",
+			BaseUrl:    "https://api.openai.com",
+			AuthType:   "bearer",
+			Region:     "us",
+			Active:     true,
+			Config:     json.RawMessage(`{}`),
+			ProbeScope: "global",
 		}
 		if err := q.UpsertProvider(ctx, params); err != nil {
 			t.Fatalf("UpsertProvider (2nd): %v", err)
@@ -85,7 +87,7 @@ func TestIntegration_Provider(t *testing.T) {
 		_ = q.UpsertProvider(ctx, pgstore.UpsertProviderParams{
 			ID: "test_inactive", Name: "Inactive", Category: "official",
 			BaseUrl: "https://x.test", AuthType: "bearer", Region: "global",
-			Active: false, Config: json.RawMessage(`{}`),
+			Active: false, Config: json.RawMessage(`{}`), ProbeScope: "global",
 		})
 
 		active, err := q.ListActiveProviders(ctx)

--- a/web/lib/realtime-context.tsx
+++ b/web/lib/realtime-context.tsx
@@ -28,9 +28,9 @@ export function RealtimeProvider({ children }: { children: React.ReactNode }) {
         dispatch({
           type: 'PROVIDER_UPDATE',
           provider: {
-            id: message.provider_id,
-            status: message.status,
-            lastUpdated: message.timestamp || Date.now(),
+            id: message.provider_id as string,
+            status: message.status as 'operational' | 'degraded' | 'down',
+            lastUpdated: (message.timestamp as number | undefined) || Date.now(),
           },
         })
       }

--- a/web/lib/swr-config.tsx
+++ b/web/lib/swr-config.tsx
@@ -35,7 +35,7 @@ export function SWRProvider({ children }: SWRProviderProps) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function realtimeMiddleware(useSWRNext: any) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (key: string, fetcher: any, config: any) => {
+  return (key: unknown, fetcher: any, config: any) => {
     const swr = useSWRNext(key, fetcher, config)
 
     // This would be enhanced to listen to real-time updates


### PR DESCRIPTION
## Summary
- `internal/api/websocket.go`: remove unreachable `return nil` after pong handler return (go vet unreachable code)
- `tests/integration/store/store_test.go`: add `ProbeScope: "global"` to all three direct `UpsertProviderParams` calls — migration 0015 added a NOT NULL check constraint; `FixtureProvider` was fixed in #152 but direct test calls were missed
- `web/lib/realtime-context.tsx`: cast `message.status` to `'operational' | 'degraded' | 'down'` union type (not `string`) to satisfy `ProviderStatus.status`
- `web/lib/swr-config.tsx`: widen `key` parameter type from `string` to `unknown` for SWR `Middleware` compatibility (`Key` is not just `string`)
- `deploy/ansible/ansible.cfg`: replace removed `community.general.yaml` callback with built-in `default` + `result_format = yaml` (removed in community.general v12); add `playbooks/group_vars` symlink to `../group_vars` so Ansible resolves group vars relative to playbook dir

## Test plan
- [ ] Go vet passes (no unreachable code)
- [ ] Integration tests pass (UpsertProvider with probe_scope)
- [ ] `npm run build` type-checks cleanly
- [ ] Ansible syntax-check passes from `deploy/ansible/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)