### PR TITLE
refactor LLMS-070: reduce gocyclo complexity below 10

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -78,25 +78,8 @@ func main() {
 		api.WithRateLimiter(limiter),
 	}
 
-	if jwtSecret := os.Getenv("JWT_SECRET"); jwtSecret != "" {
-		emailFrom := envOr("EMAIL_FROM", "noreply@llmstatus.io")
-		authCfg := &api.AuthConfig{
-			Store:          store,
-			Email:          email.New(requireEnv("RESEND_API_KEY"), emailFrom),
-			JWTSecret:      jwtSecret,
-			InternalSecret: requireEnv("INTERNAL_SECRET"),
-		}
-		if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {
-			opt, err := redis.ParseURL(redisURL)
-			if err != nil {
-				slog.Error("api: invalid REDIS_URL", "err", err)
-				os.Exit(1)
-			}
-			authCfg.OTPLimiter = otprl.NewRedis(redis.NewClient(opt))
-			slog.Info("api: OTP rate-limiting enabled")
-		}
+	if authCfg, ok := buildAuthConfig(store); ok {
 		opts = append(opts, api.WithAuth(authCfg))
-		slog.Info("api: auth enabled")
 	}
 
 	if hexKey := os.Getenv("SPONSOR_KEY_ENCRYPTION_KEY"); hexKey != "" {
@@ -117,13 +100,7 @@ func main() {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	go func() {
-		slog.Info("api: listening", "addr", addr)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("api: server error", "err", err)
-			os.Exit(1)
-		}
-	}()
+	go runServer(srv)
 
 	<-ctx.Done()
 	slog.Info("api: shutting down")
@@ -134,11 +111,43 @@ func main() {
 		slog.Error("api: shutdown error", "err", err)
 	}
 
-	// Gracefully shutdown WebSocket hub
 	hubShutCtx, hubCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer hubCancel()
 	if err := api.GetGlobalHub().Shutdown(hubShutCtx); err != nil {
 		slog.Error("api: hub shutdown error", "err", err)
+	}
+}
+
+func buildAuthConfig(store api.AuthStore) (*api.AuthConfig, bool) {
+	jwtSecret := os.Getenv("JWT_SECRET")
+	if jwtSecret == "" {
+		return nil, false
+	}
+	emailFrom := envOr("EMAIL_FROM", "noreply@llmstatus.io")
+	authCfg := &api.AuthConfig{
+		Store:          store,
+		Email:          email.New(requireEnv("RESEND_API_KEY"), emailFrom),
+		JWTSecret:      jwtSecret,
+		InternalSecret: requireEnv("INTERNAL_SECRET"),
+	}
+	if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {
+		opt, err := redis.ParseURL(redisURL)
+		if err != nil {
+			slog.Error("api: invalid REDIS_URL", "err", err)
+			os.Exit(1)
+		}
+		authCfg.OTPLimiter = otprl.NewRedis(redis.NewClient(opt))
+		slog.Info("api: OTP rate-limiting enabled")
+	}
+	slog.Info("api: auth enabled")
+	return authCfg, true
+}
+
+func runServer(srv *http.Server) {
+	slog.Info("api: listening", "addr", srv.Addr)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("api: server error", "err", err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -48,53 +48,68 @@ func main() {
 		cmd = flag.Arg(0)
 	}
 
-	src, err := iofs.New(migrations.FS, ".")
-	if err != nil {
-		log.Fatalf("source: %v", err)
-	}
-
-	m, err := migrate.NewWithSourceInstance("iofs", src, *dbURL)
-	if err != nil {
-		log.Fatalf("init: %v", err)
-	}
-	defer func() {
-		srcErr, dbErr := m.Close()
-		if srcErr != nil {
-			log.Printf("close source: %v", srcErr)
-		}
-		if dbErr != nil {
-			log.Printf("close db: %v", dbErr)
-		}
-	}()
+	m := newMigrator(*dbURL)
+	defer closeMigrator(m)
 
 	switch cmd {
 	case "up":
 		cmdUp(m)
 	case "down":
-		n := 1
-		if flag.NArg() > 1 {
-			n, err = strconv.Atoi(flag.Arg(1))
-			if err != nil || n < 1 {
-				log.Fatalf("down: N must be a positive integer, got %q", flag.Arg(1))
-			}
-		}
-		cmdDown(m, n)
+		runDown(m)
 	case "version":
 		cmdVersion(m)
 	case "status":
 		cmdStatus(m)
 	case "force":
-		if flag.NArg() < 2 {
-			log.Fatal("force: version number required")
-		}
-		v, verr := strconv.Atoi(flag.Arg(1))
-		if verr != nil {
-			log.Fatalf("force: invalid version %q", flag.Arg(1))
-		}
-		cmdForce(m, v)
+		runForce(m)
 	default:
 		log.Fatalf("unknown command %q — run migrate -help", cmd)
 	}
+}
+
+func newMigrator(dbURL string) *migrate.Migrate {
+	src, err := iofs.New(migrations.FS, ".")
+	if err != nil {
+		log.Fatalf("source: %v", err)
+	}
+	m, err := migrate.NewWithSourceInstance("iofs", src, dbURL)
+	if err != nil {
+		log.Fatalf("init: %v", err)
+	}
+	return m
+}
+
+func closeMigrator(m *migrate.Migrate) {
+	srcErr, dbErr := m.Close()
+	if srcErr != nil {
+		log.Printf("close source: %v", srcErr)
+	}
+	if dbErr != nil {
+		log.Printf("close db: %v", dbErr)
+	}
+}
+
+func runDown(m *migrate.Migrate) {
+	n := 1
+	if flag.NArg() > 1 {
+		var err error
+		n, err = strconv.Atoi(flag.Arg(1))
+		if err != nil || n < 1 {
+			log.Fatalf("down: N must be a positive integer, got %q", flag.Arg(1))
+		}
+	}
+	cmdDown(m, n)
+}
+
+func runForce(m *migrate.Migrate) {
+	if flag.NArg() < 2 {
+		log.Fatal("force: version number required")
+	}
+	v, err := strconv.Atoi(flag.Arg(1))
+	if err != nil {
+		log.Fatalf("force: invalid version %q", flag.Arg(1))
+	}
+	cmdForce(m, v)
 }
 
 func cmdUp(m *migrate.Migrate) {

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -143,18 +144,9 @@ func (s *Server) handleOAuthUpsert(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "forbidden")
 		return
 	}
-	var body struct {
-		Provider string `json:"provider"`
-		Sub      string `json:"sub"`
-		Email    string `json:"email"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil ||
-		body.Provider == "" || body.Sub == "" || body.Email == "" {
-		writeError(w, http.StatusBadRequest, "provider, sub and email required")
-		return
-	}
-	if body.Provider != "google" && body.Provider != "github" {
-		writeError(w, http.StatusBadRequest, "invalid provider")
+	body, err := decodeOAuthBody(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -203,6 +195,29 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---- helpers ------------------------------------------------------------
+
+type oauthBody struct {
+	Provider string
+	Sub      string
+	Email    string
+}
+
+// decodeOAuthBody parses and validates the /auth/oauth/upsert request body.
+func decodeOAuthBody(r *http.Request) (oauthBody, error) {
+	var raw struct {
+		Provider string `json:"provider"`
+		Sub      string `json:"sub"`
+		Email    string `json:"email"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil ||
+		raw.Provider == "" || raw.Sub == "" || raw.Email == "" {
+		return oauthBody{}, errors.New("provider, sub and email required")
+	}
+	if raw.Provider != "google" && raw.Provider != "github" {
+		return oauthBody{}, errors.New("invalid provider")
+	}
+	return oauthBody{Provider: raw.Provider, Sub: raw.Sub, Email: raw.Email}, nil
+}
 
 func (s *Server) writeToken(w http.ResponseWriter, user pgstore.User) {
 	token, err := auth.SignJWT(user.ID, user.Email, s.auth.JWTSecret)

--- a/internal/api/badge.go
+++ b/internal/api/badge.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"html"
 	"net/http"
@@ -28,32 +29,44 @@ func (s *Server) getBadge(w http.ResponseWriter, r *http.Request) {
 		activeIncs = nil
 	}
 
-	incMap := map[string]pgstore.Incident{}
-	for _, inc := range activeIncs {
-		if inc.Status == "ongoing" {
-			existing, seen := incMap[inc.ProviderID]
-			if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
-				incMap[inc.ProviderID] = inc
-			}
-		}
-	}
-
-	status, _ := deriveStatus(p.ID, incMap)
+	status, _ := deriveStatus(p.ID, ongoingIncidentMap(activeIncs))
 	message := status
+	if r.URL.Query().Get("style") == "detailed" {
+		message = s.badgeDetailedMessage(r.Context(), id, status)
+	}
+	writeBadge(w, p.Name, message, statusColor(status))
+}
 
-	// ?style=detailed appends live uptime when available.
-	if r.URL.Query().Get("style") == "detailed" && s.liveStats != nil {
-		if stats, err := s.liveStats.AllProviderLiveStats(r.Context()); err == nil {
-			for _, st := range stats {
-				if st.ProviderID == id && st.Uptime24h >= 0 {
-					message = fmt.Sprintf("%s · %.1f%%", status, st.Uptime24h*100)
-					break
-				}
-			}
+func (s *Server) badgeDetailedMessage(ctx context.Context, id, status string) string {
+	if s.liveStats == nil {
+		return status
+	}
+	stats, err := s.liveStats.AllProviderLiveStats(ctx)
+	if err != nil {
+		return status
+	}
+	for _, st := range stats {
+		if st.ProviderID == id && st.Uptime24h >= 0 {
+			return fmt.Sprintf("%s · %.1f%%", status, st.Uptime24h*100)
 		}
 	}
+	return status
+}
 
-	writeBadge(w, p.Name, message, statusColor(status))
+// ongoingIncidentMap builds a map of the worst ongoing incident per provider.
+// It filters to status "ongoing" so it is safe to call with a mixed-status slice.
+func ongoingIncidentMap(incs []pgstore.Incident) map[string]pgstore.Incident {
+	m := make(map[string]pgstore.Incident)
+	for _, inc := range incs {
+		if inc.Status != statusOngoing {
+			continue
+		}
+		existing, seen := m[inc.ProviderID]
+		if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
+			m[inc.ProviderID] = inc
+		}
+	}
+	return m
 }
 
 func writeBadge(w http.ResponseWriter, label, message, color string) {

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -89,14 +90,6 @@ func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	incidentByProvider := make(map[string]pgstore.Incident)
-	for _, inc := range ongoing {
-		existing, seen := incidentByProvider[inc.ProviderID]
-		if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
-			incidentByProvider[inc.ProviderID] = inc
-		}
-	}
-
 	// Fetch models for each provider (N ≈ 7; 30 s cache makes this acceptable).
 	modelsByProvider := make(map[string][]pgstore.Model)
 	for _, p := range providers {
@@ -105,38 +98,18 @@ func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Fetch all InfluxDB stats in parallel (three queries, all non-fatal).
-	var (
-		liveByProvider = make(map[string][2]float64) // provider_id → [uptime, p95]
-		modelLiveStats = make(map[string][2]float64) // "pid:model" → [uptime, p95]
-		sparklines     = make(map[string][]float64)  // "pid:model" → [60]float64
-	)
-	if s.liveStats != nil {
-		ctx := r.Context()
-		if stats, err := s.liveStats.AllProviderLiveStats(ctx); err == nil {
-			for _, st := range stats {
-				liveByProvider[st.ProviderID] = [2]float64{st.Uptime24h, st.P95Ms}
-			}
-		}
-		if mstats, err := s.liveStats.AllModelLiveStats(ctx); err == nil {
-			for _, ms := range mstats {
-				modelLiveStats[ms.ProviderID+":"+ms.Model] = [2]float64{ms.Uptime24h, ms.P95Ms}
-			}
-		}
-		if sl, err := s.liveStats.AllModelSparklines(ctx); err == nil {
-			sparklines = sl
-		}
-	}
+	live := s.loadAllLiveStats(r.Context())
+	incByProvider := ongoingIncidentMap(ongoing)
 
 	summaries := make([]providerSummary, 0, len(providers))
 	for _, p := range providers {
-		ps := toProviderSummary(p, incidentByProvider)
-		if live, ok := liveByProvider[p.ID]; ok {
-			u, p95 := live[0], live[1]
+		ps := toProviderSummary(p, incByProvider)
+		if st, ok := live.byProvider[p.ID]; ok {
+			u, p95 := st[0], st[1]
 			ps.Uptime24h = &u
 			ps.P95Ms = &p95
 		}
-		ps.ModelStats = buildModelStats(p.ID, modelsByProvider[p.ID], modelLiveStats, sparklines)
+		ps.ModelStats = buildModelStats(p.ID, modelsByProvider[p.ID], live.byModel, live.sparklines)
 		summaries = append(summaries, ps)
 	}
 
@@ -195,52 +168,9 @@ func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build incident map for status derivation.
-	incMap := map[string]pgstore.Incident{}
-	if len(activeIncs) > 0 {
-		for _, inc := range activeIncs {
-			if inc.Status == statusOngoing {
-				existing, seen := incMap[inc.ProviderID]
-				if !seen || severityRank(inc.Severity) > severityRank(existing.Severity) {
-					incMap[inc.ProviderID] = inc
-				}
-			}
-		}
-	}
-
-	// Fetch model live stats (non-fatal if InfluxDB is unavailable).
-	var (
-		modelLiveStats = make(map[string][2]float64)
-		sparklines     = make(map[string][]float64)
-	)
-	if s.liveStats != nil {
-		ctx := r.Context()
-		if mstats, err := s.liveStats.AllModelLiveStats(ctx); err == nil {
-			for _, ms := range mstats {
-				modelLiveStats[ms.ProviderID+":"+ms.Model] = [2]float64{ms.Uptime24h, ms.P95Ms}
-			}
-		}
-		if sl, err := s.liveStats.AllModelSparklines(ctx); err == nil {
-			sparklines = sl
-		}
-	}
-
-	var regionStats []regionStat
-	if s.liveStats != nil {
-		if rs, err := s.liveStats.ProviderRegionStats(r.Context(), id); err == nil {
-			regionStats = make([]regionStat, 0, len(rs))
-			for _, reg := range rs {
-				regionStats = append(regionStats, regionStat{
-					RegionID:  reg.RegionID,
-					Uptime24h: reg.Uptime24h,
-					P95Ms:     reg.P95Ms,
-				})
-			}
-		}
-	}
-
-	ps := toProviderSummary(p, incMap)
-	ps.ModelStats = buildModelStats(id, models, modelLiveStats, sparklines)
+	modelByModel, sparklines := s.loadModelLiveStats(r.Context())
+	ps := toProviderSummary(p, ongoingIncidentMap(activeIncs))
+	ps.ModelStats = buildModelStats(id, models, modelByModel, sparklines)
 
 	detail := providerDetail{
 		providerSummary:  ps,
@@ -248,7 +178,7 @@ func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) {
 		DocumentationURL: textVal(p.DocumentationUrl),
 		Models:           toModelSummaries(models),
 		ActiveIncidents:  toIncidentRefs(activeIncs),
-		RegionStats:      coalesceSlice(regionStats),
+		RegionStats:      coalesceSlice(s.loadRegionStats(r.Context(), id)),
 	}
 
 	writeEnvelope(w, detail)
@@ -328,4 +258,76 @@ func toIncidentRefs(incidents []pgstore.Incident) []incidentRef {
 		})
 	}
 	return coalesceSlice(out)
+}
+
+// allLiveStats groups the three InfluxDB stat maps used by listProviders.
+type allLiveStats struct {
+	byProvider map[string][2]float64 // provider_id → [uptime24h, p95_ms]
+	byModel    map[string][2]float64 // "provider_id:model" → [uptime24h, p95_ms]
+	sparklines map[string][]float64  // "provider_id:model" → 60 avg_ms buckets
+}
+
+// loadAllLiveStats fetches provider-level, model-level, and sparkline stats.
+// All queries are non-fatal; missing data results in zero values.
+func (s *Server) loadAllLiveStats(ctx context.Context) allLiveStats {
+	out := allLiveStats{
+		byProvider: make(map[string][2]float64),
+		byModel:    make(map[string][2]float64),
+		sparklines: make(map[string][]float64),
+	}
+	if s.liveStats == nil {
+		return out
+	}
+	if ps, err := s.liveStats.AllProviderLiveStats(ctx); err == nil {
+		for _, st := range ps {
+			out.byProvider[st.ProviderID] = [2]float64{st.Uptime24h, st.P95Ms}
+		}
+	}
+	if ms, err := s.liveStats.AllModelLiveStats(ctx); err == nil {
+		for _, m := range ms {
+			out.byModel[m.ProviderID+":"+m.Model] = [2]float64{m.Uptime24h, m.P95Ms}
+		}
+	}
+	if sl, err := s.liveStats.AllModelSparklines(ctx); err == nil {
+		out.sparklines = sl
+	}
+	return out
+}
+
+// loadModelLiveStats fetches model-level stats and sparklines for getProvider.
+func (s *Server) loadModelLiveStats(ctx context.Context) (map[string][2]float64, map[string][]float64) {
+	byModel := make(map[string][2]float64)
+	sparklines := make(map[string][]float64)
+	if s.liveStats == nil {
+		return byModel, sparklines
+	}
+	if ms, err := s.liveStats.AllModelLiveStats(ctx); err == nil {
+		for _, m := range ms {
+			byModel[m.ProviderID+":"+m.Model] = [2]float64{m.Uptime24h, m.P95Ms}
+		}
+	}
+	if sl, err := s.liveStats.AllModelSparklines(ctx); err == nil {
+		sparklines = sl
+	}
+	return byModel, sparklines
+}
+
+// loadRegionStats fetches per-region 24 h stats for a single provider.
+func (s *Server) loadRegionStats(ctx context.Context, providerID string) []regionStat {
+	if s.liveStats == nil {
+		return nil
+	}
+	rs, err := s.liveStats.ProviderRegionStats(ctx, providerID)
+	if err != nil {
+		return nil
+	}
+	out := make([]regionStat, 0, len(rs))
+	for _, reg := range rs {
+		out = append(out, regionStat{
+			RegionID:  reg.RegionID,
+			Uptime24h: reg.Uptime24h,
+			P95Ms:     reg.P95Ms,
+		})
+	}
+	return out
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/llmstatus/llmstatus/internal/keyenc"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )

--- a/internal/api/sponsors.go
+++ b/internal/api/sponsors.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/llmstatus/llmstatus/internal/keyenc"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -28,7 +28,7 @@ func (s *Server) getStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ongoing, err := s.store.ListIncidentsByStatus(r.Context(), pgstore.ListIncidentsByStatusParams{
-		Status: "ongoing",
+		Status: statusOngoing,
 		Limit:  200,
 		Offset: 0,
 	})
@@ -50,13 +50,13 @@ func (s *Server) getStatus(w http.ResponseWriter, r *http.Request) {
 	for _, p := range providers {
 		st, _ := deriveStatus(p.ID, incidentByProvider)
 		switch st {
-		case "down":
+		case statusDown:
 			counts.Down++
-			worst = "down"
-		case "degraded":
+			worst = statusDown
+		case statusDegraded:
 			counts.Degraded++
-			if worst != "down" {
-				worst = "degraded"
+			if worst != statusDown {
+				worst = statusDegraded
 			}
 		default:
 			counts.Operational++

--- a/internal/api/subscriptions.go
+++ b/internal/api/subscriptions.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -9,10 +10,19 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 
 var validSeverities = map[string]bool{"minor": true, "major": true, "critical": true}
+
+// subUpdateBody is shared between create/update decoders.
+type subUpdateBody struct {
+	MinSeverity string  `json:"min_severity"`
+	EmailAlerts *bool   `json:"email_alerts"`
+	EmailDigest *bool   `json:"email_digest"`
+	WebhookURL  *string `json:"webhook_url"`
+}
 
 // handleListSubscriptions handles GET /account/subscriptions
 func (s *Server) handleListSubscriptions(w http.ResponseWriter, r *http.Request) {
@@ -35,11 +45,8 @@ func (s *Server) handleCreateSubscription(w http.ResponseWriter, r *http.Request
 		return
 	}
 	var body struct {
-		ProviderID  string  `json:"provider_id"`
-		MinSeverity string  `json:"min_severity"`
-		EmailAlerts *bool   `json:"email_alerts"`
-		EmailDigest *bool   `json:"email_digest"`
-		WebhookURL  *string `json:"webhook_url"`
+		ProviderID string `json:"provider_id"`
+		subUpdateBody
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ProviderID == "" {
 		writeError(w, http.StatusBadRequest, "provider_id required")
@@ -52,14 +59,7 @@ func (s *Server) handleCreateSubscription(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "min_severity must be minor, major or critical")
 		return
 	}
-	emailAlerts := true
-	if body.EmailAlerts != nil {
-		emailAlerts = *body.EmailAlerts
-	}
-	emailDigest := true
-	if body.EmailDigest != nil {
-		emailDigest = *body.EmailDigest
-	}
+	emailAlerts, emailDigest := resolveEmailPrefs(body.EmailAlerts, body.EmailDigest)
 
 	sub, err := s.auth.Store.CreateSubscription(r.Context(), pgstore.CreateSubscriptionParams{
 		UserID:      claims.UserID,
@@ -70,15 +70,8 @@ func (s *Server) handleCreateSubscription(w http.ResponseWriter, r *http.Request
 		WebhookUrl:  pgtype.Text{String: strOrEmpty(body.WebhookURL), Valid: body.WebhookURL != nil},
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "subscriptions_user_id_provider_id_key") {
-			writeError(w, http.StatusConflict, "already subscribed to this provider")
-			return
-		}
-		if strings.Contains(err.Error(), "subscriptions_provider_id_fkey") {
-			writeError(w, http.StatusNotFound, "provider not found")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, "could not create subscription")
+		code, msg := classifySubCreateError(err)
+		writeError(w, code, msg)
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{"data": subscriptionResponse(sub, "")})
@@ -94,12 +87,7 @@ func (s *Server) handleUpdateSubscription(w http.ResponseWriter, r *http.Request
 	if !ok {
 		return
 	}
-	var body struct {
-		MinSeverity string  `json:"min_severity"`
-		EmailAlerts *bool   `json:"email_alerts"`
-		EmailDigest *bool   `json:"email_digest"`
-		WebhookURL  *string `json:"webhook_url"`
-	}
+	var body subUpdateBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid body")
 		return
@@ -109,38 +97,12 @@ func (s *Server) handleUpdateSubscription(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Fetch existing to fill omitted fields
-	existing, err := s.auth.Store.GetSubscription(r.Context(), id)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "subscription not found")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, "could not fetch subscription")
-		return
-	}
-	if existing.UserID != claims.UserID {
-		writeError(w, http.StatusNotFound, "subscription not found")
+	existing, ok2 := s.fetchOwnedSub(r.Context(), w, id, claims.UserID)
+	if !ok2 {
 		return
 	}
 
-	severity := existing.MinSeverity
-	if body.MinSeverity != "" {
-		severity = body.MinSeverity
-	}
-	emailAlerts := existing.EmailAlerts
-	if body.EmailAlerts != nil {
-		emailAlerts = *body.EmailAlerts
-	}
-	emailDigest := existing.EmailDigest
-	if body.EmailDigest != nil {
-		emailDigest = *body.EmailDigest
-	}
-	webhookURL := existing.WebhookUrl
-	if body.WebhookURL != nil {
-		webhookURL = pgtype.Text{String: *body.WebhookURL, Valid: *body.WebhookURL != ""}
-	}
-
+	severity, emailAlerts, emailDigest, webhookURL := mergeSubFields(existing, body)
 	sub, err := s.auth.Store.UpdateSubscription(r.Context(), pgstore.UpdateSubscriptionParams{
 		ID:          id,
 		UserID:      claims.UserID,
@@ -181,6 +143,63 @@ func (s *Server) handleDeleteSubscription(w http.ResponseWriter, r *http.Request
 }
 
 // ---- helpers ---------------------------------------------------------------
+
+// fetchOwnedSub fetches a subscription and verifies the caller owns it.
+func (s *Server) fetchOwnedSub(ctx context.Context, w http.ResponseWriter, id, userID int64) (pgstore.Subscription, bool) {
+	existing, err := s.auth.Store.GetSubscription(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "subscription not found")
+			return pgstore.Subscription{}, false
+		}
+		writeError(w, http.StatusInternalServerError, "could not fetch subscription")
+		return pgstore.Subscription{}, false
+	}
+	if existing.UserID != userID {
+		writeError(w, http.StatusNotFound, "subscription not found")
+		return pgstore.Subscription{}, false
+	}
+	return existing, true
+}
+
+// mergeSubFields overlays non-zero body values onto an existing subscription.
+func mergeSubFields(existing pgstore.Subscription, body subUpdateBody) (severity string, emailAlerts bool, emailDigest bool, webhookURL pgtype.Text) {
+	severity = existing.MinSeverity
+	if body.MinSeverity != "" {
+		severity = body.MinSeverity
+	}
+	emailAlerts = existing.EmailAlerts
+	if body.EmailAlerts != nil {
+		emailAlerts = *body.EmailAlerts
+	}
+	emailDigest = existing.EmailDigest
+	if body.EmailDigest != nil {
+		emailDigest = *body.EmailDigest
+	}
+	webhookURL = existing.WebhookUrl
+	if body.WebhookURL != nil {
+		webhookURL = pgtype.Text{String: *body.WebhookURL, Valid: *body.WebhookURL != ""}
+	}
+	return
+}
+
+// resolveEmailPrefs converts optional booleans to concrete values, defaulting to true.
+func resolveEmailPrefs(ea, ed *bool) (emailAlerts, emailDigest bool) {
+	emailAlerts = ea == nil || *ea
+	emailDigest = ed == nil || *ed
+	return
+}
+
+// classifySubCreateError maps DB constraint violations to HTTP status codes.
+func classifySubCreateError(err error) (int, string) {
+	if strings.Contains(err.Error(), "subscriptions_user_id_provider_id_key") {
+		return http.StatusConflict, "already subscribed to this provider"
+	}
+	if strings.Contains(err.Error(), "subscriptions_provider_id_fkey") {
+		return http.StatusNotFound, "provider not found"
+	}
+	return http.StatusInternalServerError, "could not create subscription"
+}
 
 type subscriptionJSON struct {
 	ID           int64   `json:"id"`

--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -341,16 +341,19 @@ func isValidChannelName(channel string) bool {
 	if len(channel) == 0 || len(channel) > 256 {
 		return false
 	}
-
 	for _, r := range channel {
-		if !((r >= 'a' && r <= 'z') ||
-			(r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') ||
-			r == '_' || r == ':' || r == '-') {
+		if !isChannelRune(r) {
 			return false
 		}
 	}
 	return true
+}
+
+func isChannelRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9') ||
+		r == '_' || r == ':' || r == '-'
 }
 
 // IsSubscribed checks if the client is subscribed to a channel.

--- a/internal/notifier/digest.go
+++ b/internal/notifier/digest.go
@@ -106,16 +106,16 @@ func buildDigestEmail(ctx context.Context, ds DigestStore, subs []pgstore.ListDi
 	var sb strings.Builder
 	var hb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("llmstatus.io daily digest — %s\n\n", date))
-	hb.WriteString(fmt.Sprintf(`<!DOCTYPE html><html><body style="font-family:monospace;background:#0d0d0d;color:#e0e0e0;padding:40px;max-width:640px">
+	fmt.Fprintf(&sb, "llmstatus.io daily digest — %s\n\n", date)
+	fmt.Fprintf(&hb, `<!DOCTYPE html><html><body style="font-family:monospace;background:#0d0d0d;color:#e0e0e0;padding:40px;max-width:640px">
 <h2 style="color:#e0e0e0">[llmstatus] daily digest</h2>
-<p style="color:#888;font-size:12px;margin-bottom:24px">%s</p>`, date))
+<p style="color:#888;font-size:12px;margin-bottom:24px">%s</p>`, date)
 
 	for _, sub := range subs {
 		incidents, _ := ds.ListRecentIncidentsByProvider(ctx, sub.ProviderID)
-		sb.WriteString(fmt.Sprintf("## %s\n", sub.ProviderName))
-		hb.WriteString(fmt.Sprintf(`<div style="border:1px solid #333;border-radius:6px;padding:16px;margin-bottom:16px">
-<h3 style="margin:0 0 8px;color:#e0e0e0">%s</h3>`, sub.ProviderName))
+		fmt.Fprintf(&sb, "## %s\n", sub.ProviderName)
+		fmt.Fprintf(&hb, `<div style="border:1px solid #333;border-radius:6px;padding:16px;margin-bottom:16px">
+<h3 style="margin:0 0 8px;color:#e0e0e0">%s</h3>`, sub.ProviderName)
 
 		if len(incidents) == 0 {
 			sb.WriteString("  No incidents in the last 24h.\n\n")
@@ -124,26 +124,26 @@ func buildDigestEmail(ctx context.Context, ds DigestStore, subs []pgstore.ListDi
 			for _, inc := range incidents {
 				severity := inc.Severity
 				status := inc.Status
-				sb.WriteString(fmt.Sprintf("  [%s] %s (%s)\n", severity, inc.Title, status))
+				fmt.Fprintf(&sb, "  [%s] %s (%s)\n", severity, inc.Title, status)
 				color := "#f5a623"
 				if status == "resolved" {
 					color = "#4caf50"
 				}
-				hb.WriteString(fmt.Sprintf(
+				fmt.Fprintf(&hb,
 					`<p style="margin:4px 0;font-size:13px"><span style="color:%s">[%s]</span> %s <span style="color:#888">(%s)</span></p>`,
-					color, severity, inc.Title, status))
+					color, severity, inc.Title, status)
 			}
 			sb.WriteString("\n")
 		}
 
-		hb.WriteString(fmt.Sprintf(`<p style="margin:8px 0 0;font-size:11px"><a href="%s/providers/%s" style="color:#888">View provider →</a></p></div>`,
-			siteURL, sub.ProviderID))
+		fmt.Fprintf(&hb, `<p style="margin:8px 0 0;font-size:11px"><a href="%s/providers/%s" style="color:#888">View provider →</a></p></div>`,
+			siteURL, sub.ProviderID)
 	}
 
-	sb.WriteString(fmt.Sprintf("\nManage your subscriptions: %s\n", unsubURL))
-	hb.WriteString(fmt.Sprintf(`<p style="margin-top:32px;font-size:11px;color:#555">
+	fmt.Fprintf(&sb, "\nManage your subscriptions: %s\n", unsubURL)
+	fmt.Fprintf(&hb, `<p style="margin-top:32px;font-size:11px;color:#555">
 <a href="%s" style="color:#555">Manage subscriptions</a>
-</p></body></html>`, unsubURL))
+</p></body></html>`, unsubURL)
 
 	return sb.String(), hb.String()
 }

--- a/internal/probes/adapters/groq_test.go
+++ b/internal/probes/adapters/groq_test.go
@@ -74,16 +74,6 @@ func testOpenAICompatAdapter(t *testing.T, providerID, fixtureDir string,
 	}
 }
 
-func testOpenAICompatTimeout(t *testing.T, p probes.Provider, model string) {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(200 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
-	_ = srv // timeout via client, not server close
-}
-
 // ---- Groq -------------------------------------------------------------------
 
 func TestGroq_Identity(t *testing.T) {

--- a/internal/store/influx/live_stats.go
+++ b/internal/store/influx/live_stats.go
@@ -161,6 +161,14 @@ func (r *influxHistoryReader) AllModelLiveStats(ctx context.Context) ([]ModelLiv
 	return out, nil
 }
 
+// sparklineRow is a single result row from the sparkline query.
+type sparklineRow struct {
+	ProviderID string   `json:"provider_id"`
+	Model      string   `json:"model"`
+	Bucket     string   `json:"bucket"`
+	AvgMs      *float64 `json:"avg_ms"`
+}
+
 // AllModelSparklines returns 60 avg_ms values per provider+model for the last
 // 24 h. Each bucket covers 24 min. Zero means no successful probe data.
 // Key format: "provider_id:model".
@@ -196,21 +204,19 @@ func (r *influxHistoryReader) AllModelSparklines(ctx context.Context) (map[strin
 	}
 
 	// avg_ms can be null in JSON when the FILTER removes all rows.
-	var rows []struct {
-		ProviderID string   `json:"provider_id"`
-		Model      string   `json:"model"`
-		Bucket     string   `json:"bucket"`
-		AvgMs      *float64 `json:"avg_ms"`
-	}
+	var rows []sparklineRow
 	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
 		return nil, fmt.Errorf("influx sparklines: decode: %w", err)
 	}
 
-	// Compute the first bucket timestamp for the 24 h window.
 	nowSec := time.Now().Unix()
 	windowStartSec := nowSec - int64(windowSecs)
 	firstBucket := (windowStartSec / sparklineBucketSecs) * sparklineBucketSecs
+	return indexSparklinesFromRows(rows, firstBucket), nil
+}
 
+// indexSparklinesFromRows places each row into the correct time-bucket slot.
+func indexSparklinesFromRows(rows []sparklineRow, firstBucket int64) map[string][]float64 {
 	out := make(map[string][]float64)
 	for _, row := range rows {
 		ts, err := parseInfluxTime(row.Bucket)
@@ -229,7 +235,16 @@ func (r *influxHistoryReader) AllModelSparklines(ctx context.Context) (map[strin
 			out[key][idx] = *row.AvgMs
 		}
 	}
-	return out, nil
+	return out
+}
+
+// regionRow is a single result row from the region stats query.
+type regionRow struct {
+	RegionID string  `json:"region_id"`
+	Model    string  `json:"model"`
+	Total    float64 `json:"total"`
+	Errors   float64 `json:"errors"`
+	P95Ms    float64 `json:"p95_ms"`
 }
 
 // ProviderRegionStats returns 24 h stats per probe region for one provider.
@@ -274,23 +289,24 @@ func (r *influxHistoryReader) ProviderRegionStats(ctx context.Context, providerI
 		return nil, fmt.Errorf("influx region stats: status %d: %s", resp.StatusCode, detail)
 	}
 
-	var rows []struct {
-		RegionID string  `json:"region_id"`
-		Model    string  `json:"model"`
-		Total    float64 `json:"total"`
-		Errors   float64 `json:"errors"`
-		P95Ms    float64 `json:"p95_ms"`
-	}
+	var rows []regionRow
 	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
 		return nil, fmt.Errorf("influx region stats: decode: %w", err)
 	}
 
-	// Fold to worst uptime + max p95 per region.
-	type agg struct {
-		uptime float64
-		p95    float64
+	byRegion := foldRegionRows(rows)
+	out := make([]RegionLiveStat, 0, len(byRegion))
+	for regionID, v := range byRegion {
+		out = append(out, RegionLiveStat{RegionID: regionID, Uptime24h: v[0], P95Ms: v[1]})
 	}
-	byRegion := make(map[string]agg)
+	sort.Slice(out, func(i, j int) bool { return out[i].RegionID < out[j].RegionID })
+	return out, nil
+}
+
+// foldRegionRows folds per-model rows into worst uptime + max p95 per region.
+// Result map value: [uptime, p95_ms].
+func foldRegionRows(rows []regionRow) map[string][2]float64 {
+	byRegion := make(map[string][2]float64)
 	for _, row := range rows {
 		uptime := 1.0
 		if row.Total > 0 {
@@ -298,29 +314,18 @@ func (r *influxHistoryReader) ProviderRegionStats(ctx context.Context, providerI
 		}
 		cur, seen := byRegion[row.RegionID]
 		if !seen {
-			byRegion[row.RegionID] = agg{uptime: uptime, p95: row.P95Ms}
-		} else {
-			if uptime < cur.uptime {
-				cur.uptime = uptime
-			}
-			if row.P95Ms > cur.p95 {
-				cur.p95 = row.P95Ms
-			}
-			byRegion[row.RegionID] = cur
+			byRegion[row.RegionID] = [2]float64{uptime, row.P95Ms}
+			continue
 		}
+		if uptime < cur[0] {
+			cur[0] = uptime
+		}
+		if row.P95Ms > cur[1] {
+			cur[1] = row.P95Ms
+		}
+		byRegion[row.RegionID] = cur
 	}
-
-	out := make([]RegionLiveStat, 0, len(byRegion))
-	for regionID, a := range byRegion {
-		out = append(out, RegionLiveStat{
-			RegionID:  regionID,
-			Uptime24h: a.uptime,
-			P95Ms:     a.p95,
-		})
-	}
-	// Sort by region_id for deterministic ordering.
-	sort.Slice(out, func(i, j int) bool { return out[i].RegionID < out[j].RegionID })
-	return out, nil
+	return byRegion
 }
 
 // parseInfluxTime handles InfluxDB 3's varying timestamp formats:

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "playwright.config.ts", "tests/e2e"]
 }


### PR DESCRIPTION
## Summary
- Extracts sub-functions to bring all production-code gocyclo scores ≤ 10
- 7 functions refactored: `handleCreateSubscription`, `handleUpdateSubscription`, `handleOAuthUpsert`, `AllModelSparklines`, `ProviderRegionStats`, `cmd/migrate main`, `cmd/api main`
- Zero behaviour changes; all existing tests pass

## Changes
| File | Before | After | Helpers added |
|---|---|---|---|
| `internal/api/subscriptions.go` | create=11, update=15 | create=7, update=9 | `fetchOwnedSub`, `mergeSubFields`, `resolveEmailPrefs`, `classifySubCreateError` |
| `internal/api/auth.go` | `handleOAuthUpsert`=11 | 6 | `decodeOAuthBody` |
| `internal/store/influx/live_stats.go` | sparklines=12, regions=13 | sparklines=6, regions=7 | `indexSparklinesFromRows`, `foldRegionRows` |
| `cmd/migrate/main.go` | main=17 | 8 | `newMigrator`, `closeMigrator`, `runDown`, `runForce` |
| `cmd/api/main.go` | main=11 | 7 | `buildAuthConfig`, `runServer` |

Also includes previously committed linter fixes (badge, providers, websocket, status, sponsors, digest, tsconfig, groq_test).

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -short` — all pass
- [x] `gocyclo -over 10 cmd/ internal/` — only `_test.go` files remain (excluded by `.golangci.yml`)

Closes #LLMS-070

🤖 Generated with [Claude Code](https://claude.com/claude-code)