### PR TITLE
deploy: build images in CI, pull from GHCR on server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: Build and push Docker images
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  ORG: llmstatus
+
+jobs:
+  build:
+    name: Build ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - service: api
+            dockerfile: deploy/docker/Dockerfile.golang
+            build_arg: CMD=api
+          - service: ingest
+            dockerfile: deploy/docker/Dockerfile.golang
+            build_arg: CMD=ingest
+          - service: detector
+            dockerfile: deploy/docker/Dockerfile.golang
+            build_arg: CMD=detector
+          - service: prober
+            dockerfile: deploy/docker/Dockerfile.golang
+            build_arg: CMD=prober
+          - service: notifier
+            dockerfile: deploy/docker/Dockerfile.golang
+            build_arg: CMD=notifier
+          - service: migrate
+            dockerfile: deploy/docker/Dockerfile.golang
+            build_arg: CMD=migrate
+          - service: web
+            dockerfile: deploy/docker/Dockerfile.web
+            build_arg: ""
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ${{ matrix.service }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          build-args: ${{ matrix.build_arg }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.ORG }}/llmstatus-${{ matrix.service }}:latest
+            ${{ env.REGISTRY }}/${{ env.ORG }}/llmstatus-${{ matrix.service }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/deploy/ansible/roles/main-server/tasks/main.yml
+++ b/deploy/ansible/roles/main-server/tasks/main.yml
@@ -167,16 +167,19 @@
     state: started
 
 # ── Docker Compose services ───────────────────────────────────────────────
-- name: pull Docker images
+- name: log in to GHCR
+  command: docker login ghcr.io -u {{ ghcr_username }} -p {{ ghcr_token }}
+  become_user: ubuntu
+  no_log: true
+
+- name: pull Docker images from GHCR
   command: docker compose pull
   args:
     chdir: "{{ app_dir }}"
   become_user: ubuntu
-  register: compose_pull
-  changed_when: "'Downloaded newer image' in compose_pull.stdout"
 
 - name: start services
-  command: docker compose up -d
+  command: docker compose up -d --no-build
   args:
     chdir: "{{ app_dir }}"
   become_user: ubuntu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
   # ── one-shot migration runner ───────────────────────────────────────────────
 
   migrate:
+    image: ghcr.io/llmstatus/llmstatus-migrate:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile.golang
@@ -83,6 +84,7 @@ services:
   # ── Go services ────────────────────────────────────────────────────────────
 
   ingest:
+    image: ghcr.io/llmstatus/llmstatus-ingest:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile.golang
@@ -102,6 +104,7 @@ services:
       - "18080:8080"
 
   detector:
+    image: ghcr.io/llmstatus/llmstatus-detector:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile.golang
@@ -122,6 +125,7 @@ services:
         condition: service_healthy
 
   api:
+    image: ghcr.io/llmstatus/llmstatus-api:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile.golang
@@ -150,6 +154,7 @@ services:
       retries: 5
 
   notifier:
+    image: ghcr.io/llmstatus/llmstatus-notifier:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile.golang
@@ -170,6 +175,7 @@ services:
   # ── frontend ───────────────────────────────────────────────────────────────
 
   web:
+    image: ghcr.io/llmstatus/llmstatus-web:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile.web
@@ -187,6 +193,7 @@ services:
   # ── probe runner ──────────────────────────────────────────────────────────
 
   prober:
+    image: ghcr.io/llmstatus/llmstatus-prober:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile.golang


### PR DESCRIPTION
## Summary
- Add .github/workflows/build.yml: builds all 7 Docker images on push to main, pushes to ghcr.io/llmstatus/* with layer caching
- docker-compose.yml: add image: ghcr.io/llmstatus/* to every service so docker compose pull fetches pre-built images
- Ansible main-server: log in to GHCR before pull; --no-build flag prevents on-server compilation

## Problem solved
Building Docker images on the server (t3.small, 2 GB RAM) caused OOM during the first deployment attempt. Next.js build alone needs ~1.5 GB. Pre-built images in GHCR fix this.

## Test plan
- [ ] Merge triggers build.yml
- [ ] All 7 images appear in ghcr.io/llmstatus
- [ ] Re-run Ansible playbook: docker compose pull succeeds

🤖 Generated with Claude Code