### PR TITLE
fix: notifier restart: on-failure to prevent clean-exit loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
       args:
         CMD: notifier
     container_name: llmstatus-notifier
-    restart: unless-stopped
+    restart: on-failure
     environment:
       DATABASE_URL: postgres://llmstatus:${POSTGRES_PASSWORD:-llmstatus}@db:5432/llmstatus?sslmode=disable
       RESEND_API_KEY: ${RESEND_API_KEY:-}


### PR DESCRIPTION
When RESEND_API_KEY is absent the notifier exits 0. `unless-stopped` restarts on any exit including 0. Changed to `on-failure` so Docker only restarts on crashes.