### PR TITLE
fix: switch Google Gemini adapter to gemini-2.5-flash

### DIFF
--- a/internal/probes/adapters/gemini.go
+++ b/internal/probes/adapters/gemini.go
@@ -16,7 +16,7 @@ import (
 const (
 	geminiDefaultBaseURL = "https://generativelanguage.googleapis.com"
 	geminiProviderID     = "google_gemini"
-	geminiLightModel     = "gemini-2.0-flash"
+	geminiLightModel     = "gemini-2.5-flash"
 	geminiLightProbeType = "light_inference"
 	geminiErrorDetailMax = 200
 )

--- a/internal/probes/adapters/gemini_test.go
+++ b/internal/probes/adapters/gemini_test.go
@@ -28,7 +28,7 @@ func TestGemini_Identity(t *testing.T) {
 	if got := p.ID(); got != "google_gemini" {
 		t.Errorf("ID: got %q, want google_gemini", got)
 	}
-	if got := p.Models(); len(got) == 0 || got[0] != "gemini-2.0-flash" {
+	if got := p.Models(); len(got) == 0 || got[0] != "gemini-2.5-flash" {
 		t.Errorf("Models: got %v", got)
 	}
 }
@@ -61,7 +61,7 @@ func TestGemini_ProbeLightInference(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			p := NewGeminiProvider("fake-key", "node-1", WithGeminiBaseURL(srv.URL))
-			r, err := p.ProbeLightInference(context.Background(), "gemini-2.0-flash")
+			r, err := p.ProbeLightInference(context.Background(), "gemini-2.5-flash")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -92,7 +92,7 @@ func TestGemini_Timeout(t *testing.T) {
 		WithGeminiBaseURL(srv.URL),
 		WithGeminiHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}),
 	)
-	r, err := p.ProbeLightInference(context.Background(), "gemini-2.0-flash")
+	r, err := p.ProbeLightInference(context.Background(), "gemini-2.5-flash")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/store/migrations/0016_gemini_model_update.down.sql
+++ b/store/migrations/0016_gemini_model_update.down.sql
@@ -1,0 +1,11 @@
+-- 0016_gemini_model_update.down.sql
+
+BEGIN;
+
+DELETE FROM models WHERE provider_id = 'google_gemini' AND model_id = 'gemini-2.5-flash';
+
+UPDATE models SET active = TRUE
+WHERE provider_id = 'google_gemini'
+  AND model_id IN ('gemini-2.0-flash', 'gemini-1.5-pro');
+
+COMMIT;

--- a/store/migrations/0016_gemini_model_update.up.sql
+++ b/store/migrations/0016_gemini_model_update.up.sql
@@ -1,0 +1,15 @@
+-- 0016_gemini_model_update.sql — switch Google Gemini to gemini-2.5-flash
+
+BEGIN;
+
+-- Deactivate models no longer available on the current API key
+UPDATE models SET active = FALSE
+WHERE provider_id = 'google_gemini'
+  AND model_id IN ('gemini-2.0-flash', 'gemini-1.5-pro');
+
+-- Add gemini-2.5-flash
+INSERT INTO models (provider_id, model_id, display_name, model_type, active)
+VALUES ('google_gemini', 'gemini-2.5-flash', 'Gemini 2.5 Flash', 'chat', TRUE)
+ON CONFLICT (provider_id, model_id) DO UPDATE SET active = TRUE;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Update `geminiLightModel` constant from `gemini-2.0-flash` to `gemini-2.5-flash` (only model available on current API key)
- Migration 0016 deactivates `gemini-2.0-flash` and `gemini-1.5-pro`, adds `gemini-2.5-flash`
- Update unit tests to match new model ID

## Test plan
- [x] `go run ./scripts/test_provider.go google_gemini` → 200 OK, 1.6s (`gemini-2.5-flash`)
- [x] `go test ./internal/probes/adapters/... -run TestGemini` → all pass
- [ ] After merge+deploy: run `docker compose exec migrate migrate up` on prod, restart prober