### PR TITLE
fix: prober must only probe active models

### DIFF
--- a/cmd/prober/main.go
+++ b/cmd/prober/main.go
@@ -119,7 +119,9 @@ func loadProviderConfigs(ctx context.Context, pool *pgxpool.Pool, regionID strin
 
 		modelIDs := make([]string, 0, len(models))
 		for _, m := range models {
-			modelIDs = append(modelIDs, m.ModelID)
+			if m.Active {
+				modelIDs = append(modelIDs, m.ModelID)
+			}
 		}
 
 		if len(modelIDs) == 0 {


### PR DESCRIPTION
## Summary
- `ListModelsByProvider` returns all models including inactive ones
- Prober was probing inactive models (e.g. `gemini-2.0-flash`, `gemini-1.5-pro` after migration 0016 set them inactive)
- Add `m.Active` filter in `loadProviderConfigs`

## Test plan
- [x] Observed in prod: gemini-2.0-flash still getting probed after 0016 migration
- [x] Fix adds the same active filter that `buildModelStats` already applies in the API