### PR TITLE
fix: skip non-embedding probes for OpenAI embedding models

### DIFF
--- a/internal/probes/adapters/openai.go
+++ b/internal/probes/adapters/openai.go
@@ -76,7 +76,14 @@ func (p *openaiProvider) Models() []string { return []string{openaiLightModel} }
 // malformed body): those are carried in the result's ErrorClass.
 // It only returns a non-nil error for programmer / environment bugs
 // (context cancelled, marshalling failure).
+func isOpenAIEmbeddingModel(model string) bool {
+	return strings.Contains(model, "embedding")
+}
+
 func (p *openaiProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
+	if isOpenAIEmbeddingModel(model) {
+		return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: openaiProviderID, ProbeType: "light_inference"}
+	}
 	started := time.Now()
 	r := probes.ProbeResult{
 		ProviderID: openaiProviderID,

--- a/internal/probes/adapters/openai_quality.go
+++ b/internal/probes/adapters/openai_quality.go
@@ -23,6 +23,9 @@ const (
 // expected token. A 200 response whose content does not contain the expected
 // word is classified as ErrorClassQualityMismatch.
 func (p *openaiProvider) ProbeQuality(ctx context.Context, model string) (probes.ProbeResult, error) {
+	if isOpenAIEmbeddingModel(model) {
+		return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: openaiProviderID, ProbeType: "quality"}
+	}
 	started := time.Now()
 	r := probes.ProbeResult{
 		ProviderID: openaiProviderID,

--- a/internal/probes/adapters/openai_streaming.go
+++ b/internal/probes/adapters/openai_streaming.go
@@ -30,6 +30,9 @@ type openaiStreamChunk struct {
 // time. A stream that ends with [DONE] before producing any content token is
 // classified as ErrorClassMalformedBody.
 func (p *openaiProvider) ProbeStreaming(ctx context.Context, model string) (probes.ProbeResult, error) {
+	if isOpenAIEmbeddingModel(model) {
+		return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: openaiProviderID, ProbeType: "streaming"}
+	}
 	started := time.Now()
 	r := probes.ProbeResult{
 		ProviderID: openaiProviderID,


### PR DESCRIPTION
## Summary
- `text-embedding-3-small` was receiving `light_inference`, `quality`, and `streaming` probes, all returning 403
- Add `isOpenAIEmbeddingModel` helper (checks if model name contains "embedding")
- Return `ErrNotSupported` from those three probe methods for embedding models
- Embedding models continue to receive only the `ProbeEmbedding` probe

## Test plan
- [x] `go test ./internal/probes/adapters/... -run TestOpenAI` — all pass
- [ ] After deploy: verify `text-embedding-3-small` only shows embedding probes in InfluxDB