### PR TITLE
fix: include provider-level uptime/p95 in getProvider response

### DIFF
--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -173,6 +173,18 @@ func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) {
 	modelByModel, sparklines := s.loadModelLiveStats(r.Context())
 	ps := toProviderSummary(p, ongoingIncidentMap(activeIncs))
 	ps.ModelStats = buildModelStats(id, models, modelByModel, sparklines)
+	if s.liveStats != nil {
+		if stats, err := s.liveStats.AllProviderLiveStats(r.Context()); err == nil {
+			for _, st := range stats {
+				if st.ProviderID == id {
+					u, p95 := st.Uptime24h, st.P95Ms
+					ps.Uptime24h = &u
+					ps.P95Ms = &p95
+					break
+				}
+			}
+		}
+	}
 
 	detail := providerDetail{
 		providerSummary:  ps,


### PR DESCRIPTION
## Summary
- `GET /v1/providers/{id}` was not populating `uptime_24h` / `p95_ms` at the provider level
- Compare page showed "—" for both metrics on every provider
- Fix: load `AllProviderLiveStats` in `getProvider` and attach the matching entry

## Test plan
- [x] `go build ./internal/api/...` passes
- [ ] After deploy: `GET /v1/providers/openai` returns non-null `uptime_24h` and `p95_ms`
- [ ] Compare page shows real uptime values