### PR TITLE
improve UI: animated logo, larger text, sparkline area fill

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -114,3 +114,26 @@ html, body {
 .input-field:focus {
   border-color: var(--ink-400);
 }
+
+/* ── Heartbeat logo animation ─────────────────────────────────────────── */
+@keyframes heartbeat {
+  0%, 50%, 100% { transform: scale(1); opacity: 0.85; }
+  38%           { transform: scale(1.55); opacity: 1; }
+  44%           { transform: scale(0.9); opacity: 0.9; }
+}
+
+@keyframes beat-ring {
+  0%, 38%, 100% { transform: scale(1); opacity: 0; }
+  40%           { transform: scale(1); opacity: 0.45; }
+  65%           { transform: scale(2.6); opacity: 0; }
+}
+
+.beat {
+  animation: heartbeat 2.4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  will-change: transform;
+}
+
+.beat-ring {
+  animation: beat-ring 2.4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  will-change: transform, opacity;
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -134,6 +134,10 @@ html, body {
 }
 
 .beat-ring {
-  animation: beat-ring 2.4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation: beat-ring 2.4s ease-out infinite;
   will-change: transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .beat, .beat-ring { animation: none; }
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -69,15 +69,15 @@ export default async function HomePage() {
           backgroundSize: "8px 8px",
         }}
       >
-        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--signal-amber)] mb-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--signal-amber)] mb-4">
           llmstatus.io
         </p>
-        <h1 className="text-3xl font-semibold text-[var(--ink-100)] leading-tight mb-3">
+        <h1 className="text-4xl font-semibold text-[var(--ink-100)] leading-tight mb-4">
           Independent real-time monitoring
           <br />
           for the AI infrastructure.
         </h1>
-        <p className="text-sm text-[var(--ink-400)] leading-relaxed">
+        <p className="text-base text-[var(--ink-400)] leading-relaxed">
           Measured from 7 global locations.
           <br />
           Not scraped from official status pages.
@@ -85,7 +85,7 @@ export default async function HomePage() {
       </div>
 
       <div className="mb-6">
-        <p className={`text-sm font-medium ${summaryColor}`}>{summaryText}</p>
+        <p className={`text-base font-medium ${summaryColor}`}>{summaryText}</p>
       </div>
 
       {/* Recent incidents — shown only when data exists */}

--- a/web/components/LatencySparkline.tsx
+++ b/web/components/LatencySparkline.tsx
@@ -1,29 +1,24 @@
 interface Props {
-  data: number[];   // 60 avg_ms values; 0 means no data
+  data: number[];
   width?: number;
   height?: number;
-  className?: string; // applied to the <svg> element; use "w-full" to fill container
+  className?: string;
+  area?: boolean;
+  color?: string;
 }
 
-// buildPath converts 60 avg_ms values into an SVG path string.
-// Zero values are treated as gaps (M move instead of L line).
-function buildPath(data: number[], w: number, h: number): string {
+function buildLinePath(data: number[], w: number, h: number): string {
   const valid = data.filter((v) => v > 0);
   if (valid.length === 0) return "";
 
   const max = Math.max(...valid);
-  const pad = 2; // vertical padding in px
-
+  const pad = 2;
   let d = "";
   let prevHadData = false;
 
   for (let i = 0; i < data.length; i++) {
     const x = ((i / (data.length - 1)) * w).toFixed(1);
-    if (data[i] <= 0) {
-      prevHadData = false;
-      continue;
-    }
-    // Invert Y: higher latency = lower on the chart (nearer the bottom).
+    if (data[i] <= 0) { prevHadData = false; continue; }
     const y = (h - pad - ((data[i] / max) * (h - pad * 2))).toFixed(1);
     d += prevHadData ? `L${x} ${y}` : `M${x} ${y}`;
     prevHadData = true;
@@ -31,11 +26,56 @@ function buildPath(data: number[], w: number, h: number): string {
   return d;
 }
 
-export function LatencySparkline({ data, width = 88, height = 28, className }: Props) {
-  const d = buildPath(data, width, height);
-  if (!d) {
-    return <span className="text-[10px] text-[var(--ink-500)]">no data</span>;
+function buildAreaPaths(data: number[], w: number, h: number): string {
+  const valid = data.filter((v) => v > 0);
+  if (valid.length === 0) return "";
+
+  const max = Math.max(...valid);
+  const pad = 2;
+
+  const segments: { x: number; y: number }[][] = [];
+  let cur: { x: number; y: number }[] = [];
+
+  for (let i = 0; i < data.length; i++) {
+    const x = (i / (data.length - 1)) * w;
+    if (data[i] <= 0) {
+      if (cur.length > 0) { segments.push(cur); cur = []; }
+      continue;
+    }
+    const y = h - pad - ((data[i] / max) * (h - pad * 2));
+    cur.push({ x, y });
   }
+  if (cur.length > 0) segments.push(cur);
+
+  return segments
+    .filter((s) => s.length >= 2)
+    .map((seg) => {
+      const first = seg[0];
+      const last = seg[seg.length - 1];
+      let p = `M${first.x.toFixed(1)} ${h}L${first.x.toFixed(1)} ${first.y.toFixed(1)}`;
+      for (let i = 1; i < seg.length; i++) {
+        p += `L${seg[i].x.toFixed(1)} ${seg[i].y.toFixed(1)}`;
+      }
+      p += `L${last.x.toFixed(1)} ${h}Z`;
+      return p;
+    })
+    .join(" ");
+}
+
+export function LatencySparkline({
+  data,
+  width = 88,
+  height = 28,
+  className,
+  area = false,
+  color = "var(--viz-1)",
+}: Props) {
+  const lineD = buildLinePath(data, width, height);
+  if (!lineD) {
+    return <span className="text-[11px] text-[var(--ink-500)]">no data</span>;
+  }
+
+  const areaD = area ? buildAreaPaths(data, width, height) : "";
 
   return (
     <svg
@@ -46,14 +86,25 @@ export function LatencySparkline({ data, width = 88, height = 28, className }: P
       className={className}
       aria-hidden="true"
     >
+      {area && (
+        <defs>
+          <linearGradient id="sp-area-grad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.28" />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+      )}
+      {area && areaD && (
+        <path d={areaD} fill="url(#sp-area-grad)" />
+      )}
       <path
-        d={d}
+        d={lineD}
         fill="none"
-        stroke="var(--viz-1)"
+        stroke={color}
         strokeWidth="1.5"
         strokeLinejoin="round"
         strokeLinecap="round"
-        opacity="0.85"
+        opacity="0.9"
       />
     </svg>
   );

--- a/web/components/LatencySparkline.tsx
+++ b/web/components/LatencySparkline.tsx
@@ -5,6 +5,7 @@ interface Props {
   className?: string;
   area?: boolean;
   color?: string;
+  gradientId?: string;
 }
 
 function buildLinePath(data: number[], w: number, h: number): string {
@@ -13,11 +14,12 @@ function buildLinePath(data: number[], w: number, h: number): string {
 
   const max = Math.max(...valid);
   const pad = 2;
+  const divisor = data.length > 1 ? data.length - 1 : 1;
   let d = "";
   let prevHadData = false;
 
   for (let i = 0; i < data.length; i++) {
-    const x = ((i / (data.length - 1)) * w).toFixed(1);
+    const x = ((i / divisor) * w).toFixed(1);
     if (data[i] <= 0) { prevHadData = false; continue; }
     const y = (h - pad - ((data[i] / max) * (h - pad * 2))).toFixed(1);
     d += prevHadData ? `L${x} ${y}` : `M${x} ${y}`;
@@ -32,12 +34,13 @@ function buildAreaPaths(data: number[], w: number, h: number): string {
 
   const max = Math.max(...valid);
   const pad = 2;
+  const divisor = data.length > 1 ? data.length - 1 : 1;
 
   const segments: { x: number; y: number }[][] = [];
   let cur: { x: number; y: number }[] = [];
 
   for (let i = 0; i < data.length; i++) {
-    const x = (i / (data.length - 1)) * w;
+    const x = (i / divisor) * w;
     if (data[i] <= 0) {
       if (cur.length > 0) { segments.push(cur); cur = []; }
       continue;
@@ -48,7 +51,7 @@ function buildAreaPaths(data: number[], w: number, h: number): string {
   if (cur.length > 0) segments.push(cur);
 
   return segments
-    .filter((s) => s.length >= 2)
+    .filter((s) => s.length >= 2)  // single-point segments produce no visible line or area
     .map((seg) => {
       const first = seg[0];
       const last = seg[seg.length - 1];
@@ -69,6 +72,7 @@ export function LatencySparkline({
   className,
   area = false,
   color = "var(--viz-1)",
+  gradientId,
 }: Props) {
   const lineD = buildLinePath(data, width, height);
   if (!lineD) {
@@ -76,6 +80,9 @@ export function LatencySparkline({
   }
 
   const areaD = area ? buildAreaPaths(data, width, height) : "";
+  // Derive a stable, unique gradient ID from the color string so multiple SVGs
+  // on the same page don't collide (url(#id) is document-scoped, not SVG-scoped).
+  const gid = gradientId ?? `sp-grad-${color.replace(/[^a-z0-9]/gi, "")}`;
 
   return (
     <svg
@@ -88,14 +95,14 @@ export function LatencySparkline({
     >
       {area && (
         <defs>
-          <linearGradient id="sp-area-grad" x1="0" y1="0" x2="0" y2="1">
+          <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
             <stop offset="0%" stopColor={color} stopOpacity="0.28" />
             <stop offset="100%" stopColor={color} stopOpacity="0" />
           </linearGradient>
         </defs>
       )}
       {area && areaD && (
-        <path d={areaD} fill="url(#sp-area-grad)" />
+        <path d={areaD} fill={`url(#${gid})`} />
       )}
       <path
         d={lineD}

--- a/web/components/NavLink.tsx
+++ b/web/components/NavLink.tsx
@@ -6,21 +6,44 @@ import { usePathname } from "next/navigation";
 interface Props {
   href: string;
   children: React.ReactNode;
+  variant?: "default" | "pill";
 }
 
-export function NavLink({ href, children }: Props) {
+export function NavLink({ href, children, variant = "default" }: Props) {
   const pathname = usePathname();
   const active = pathname === href || (href !== "/" && pathname.startsWith(href));
+
+  if (variant === "pill") {
+    return (
+      <Link
+        href={href}
+        className={`px-3 py-1 rounded border text-xs font-semibold tracking-wide transition-colors ${
+          active
+            ? "border-[var(--signal-ok)] text-[var(--signal-ok)] bg-[var(--signal-ok-bg)]"
+            : "border-[var(--ink-500)] text-[var(--ink-300)] hover:border-[var(--signal-ok)] hover:text-[var(--signal-ok)]"
+        }`}
+      >
+        {children}
+      </Link>
+    );
+  }
+
   return (
     <Link
       href={href}
-      className={`text-xs transition-colors ${
+      className={`relative px-2.5 py-1.5 rounded text-sm transition-colors ${
         active
-          ? "text-[var(--ink-100)] font-medium"
-          : "text-[var(--ink-400)] hover:text-[var(--ink-200)]"
+          ? "text-[var(--ink-100)] font-semibold"
+          : "text-[var(--ink-400)] hover:text-[var(--ink-200)] hover:bg-[var(--canvas-overlay)]"
       }`}
     >
       {children}
+      {active && (
+        <span
+          className="absolute bottom-0 left-2.5 right-2.5 h-[2px] rounded-full bg-[var(--signal-ok)]"
+          aria-hidden="true"
+        />
+      )}
     </Link>
   );
 }

--- a/web/components/ProviderCard.tsx
+++ b/web/components/ProviderCard.tsx
@@ -2,25 +2,33 @@ import Link from "next/link";
 import type { ProviderSummary, ModelStat } from "@/lib/api";
 import { LatencySparkline } from "./LatencySparkline";
 
-// ── Status pill ────────────────────────────────────────────────────────────
+// ── Status ─────────────────────────────────────────────────────────────────
 
-const STATUS_STYLES = {
+const STATUS_PILL: Record<string, string> = {
   operational: "bg-[var(--signal-ok-bg)] text-[var(--signal-ok)]",
   degraded:    "bg-[var(--signal-warn-bg)] text-[var(--signal-warn)]",
   down:        "bg-[var(--signal-down-bg)] text-[var(--signal-down)]",
-} as const;
+};
 
-function StatusPill({ status }: { status: string }) {
-  const cls = STATUS_STYLES[status as keyof typeof STATUS_STYLES]
-    ?? "bg-[var(--canvas-overlay)] text-[var(--ink-400)]";
-  return (
-    <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${cls}`}>
-      {status}
-    </span>
-  );
-}
+const STATUS_DOT: Record<string, string> = {
+  operational: "bg-[var(--signal-ok)]",
+  degraded:    "bg-[var(--signal-warn)]",
+  down:        "bg-[var(--signal-down)]",
+};
 
-// ── Stat cell ──────────────────────────────────────────────────────────────
+const STATUS_ACCENT: Record<string, string> = {
+  operational: "shadow-[inset_3px_0_0_var(--signal-ok)]",
+  degraded:    "shadow-[inset_3px_0_0_var(--signal-warn)]",
+  down:        "shadow-[inset_3px_0_0_var(--signal-down)]",
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  operational: "var(--signal-ok)",
+  degraded:    "var(--signal-warn)",
+  down:        "var(--signal-down)",
+};
+
+// ── Uptime color ────────────────────────────────────────────────────────────
 
 function uptimeColor(u: number): string {
   if (u >= 0.995) return "text-[var(--signal-ok)]";
@@ -28,21 +36,7 @@ function uptimeColor(u: number): string {
   return "text-[var(--signal-down)]";
 }
 
-function StatCell({ label, value, colorClass }: { label: string; value: string; colorClass?: string }) {
-  return (
-    <div className="flex flex-col gap-0.5">
-      <span className="text-[9px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
-        {label}
-      </span>
-      <span className={`text-sm font-mono tabular-nums ${colorClass ?? "text-[var(--ink-300)]"}`}>
-        {value}
-      </span>
-    </div>
-  );
-}
-
-// ── Provider-level sparkline ───────────────────────────────────────────────
-// Average non-zero avg_ms values across all models per time bucket.
+// ── Aggregate sparklines across all models ──────────────────────────────────
 
 function aggregateSparklines(modelStats: ModelStat[]): number[] {
   const BUCKETS = 60;
@@ -59,13 +53,9 @@ function aggregateSparklines(modelStats: ModelStat[]): number[] {
   return sums.map((s, i) => (counts[i] > 0 ? s / counts[i] : 0));
 }
 
-// ── Provider card ──────────────────────────────────────────────────────────
+// ── Provider card ───────────────────────────────────────────────────────────
 
-interface Props {
-  provider: ProviderSummary;
-}
-
-export function ProviderCard({ provider: p }: Props) {
+export function ProviderCard({ provider: p }: { provider: ProviderSummary }) {
   const uptime = p.uptime_24h !== undefined
     ? (p.uptime_24h * 100).toFixed(1) + "%"
     : "—";
@@ -79,46 +69,77 @@ export function ProviderCard({ provider: p }: Props) {
   const modelNames = (p.model_stats ?? []).map((m) => m.display_name);
   const sparkline = aggregateSparklines(p.model_stats ?? []);
 
+  const pillCls = STATUS_PILL[p.current_status] ?? "bg-[var(--canvas-overlay)] text-[var(--ink-400)]";
+  const dotCls  = STATUS_DOT[p.current_status]  ?? "bg-[var(--ink-500)]";
+  const accentCls = STATUS_ACCENT[p.current_status] ?? "";
+  const sparkColor = STATUS_COLOR[p.current_status] ?? "var(--viz-1)";
+
   return (
     <Link
       href={`/providers/${p.id}`}
-      className="flex flex-col rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)]
-                 hover:border-[var(--ink-500)] hover:bg-[var(--canvas-overlay)]
-                 transition-colors"
+      className={`flex flex-col rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)]
+                  hover:border-[var(--ink-500)] hover:bg-[var(--canvas-overlay)]
+                  transition-colors ${accentCls}`}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3">
-        <span className="text-sm font-semibold text-[var(--ink-100)]">{p.name}</span>
-        <StatusPill status={p.current_status} />
+      <div className="flex items-center justify-between px-4 py-3.5">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <span className={`w-2 h-2 rounded-full shrink-0 ${dotCls}`} />
+          <span className="text-base font-semibold text-[var(--ink-100)] truncate">{p.name}</span>
+        </div>
+        <span className={`shrink-0 rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${pillCls}`}>
+          {p.current_status}
+        </span>
       </div>
 
-      {/* Stats + sparkline */}
-      <div className="flex items-end gap-4 border-t border-[var(--ink-600)] px-4 py-3">
-        <StatCell
-          label="Uptime 24h"
-          value={uptime}
-          colorClass={p.uptime_24h !== undefined ? uptimeColor(p.uptime_24h) : "text-[var(--ink-500)]"}
+      {/* Sparkline — full width, taller, area fill */}
+      <div className="px-4 pb-2">
+        <LatencySparkline
+          data={sparkline}
+          width={300}
+          height={48}
+          className="w-full"
+          area
+          color={sparkColor}
         />
-        <StatCell label="p95" value={p95} />
-        <div className="flex-1">
-          <LatencySparkline data={sparkline} width={200} height={28} className="w-full" />
+      </div>
+
+      {/* Stats row */}
+      <div className="flex items-center gap-6 border-t border-[var(--ink-600)] px-4 py-3">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+            Uptime 24h
+          </span>
+          <span className={`text-base font-mono tabular-nums font-semibold ${
+            p.uptime_24h !== undefined ? uptimeColor(p.uptime_24h) : "text-[var(--ink-500)]"
+          }`}>
+            {uptime}
+          </span>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--ink-500)]">
+            p95 Latency
+          </span>
+          <span className="text-base font-mono tabular-nums font-semibold text-[var(--ink-200)]">
+            {p95}
+          </span>
         </div>
       </div>
 
       {/* Model tags */}
       {modelNames.length > 0 && (
-        <div className="flex flex-wrap gap-1 border-t border-[var(--ink-600)] px-4 pb-3 pt-2">
+        <div className="flex flex-wrap gap-1 border-t border-[var(--ink-600)] px-4 pb-3 pt-2.5">
           {modelNames.slice(0, 4).map((name) => (
             <span
               key={name}
-              className="rounded bg-[var(--canvas-overlay)] px-1.5 py-0.5 text-[10px] text-[var(--ink-500)]"
+              className="rounded bg-[var(--canvas-overlay)] px-2 py-0.5 text-[11px] text-[var(--ink-400)]"
             >
               {name}
             </span>
           ))}
           {modelNames.length > 4 && (
-            <span className="px-1 py-0.5 text-[10px] text-[var(--ink-600)]">
-              +{modelNames.length - 4} more
+            <span className="px-1 py-0.5 text-[11px] text-[var(--ink-600)]">
+              +{modelNames.length - 4}
             </span>
           )}
         </div>

--- a/web/components/ProviderCard.tsx
+++ b/web/components/ProviderCard.tsx
@@ -1,28 +1,29 @@
 import Link from "next/link";
-import type { ProviderSummary, ModelStat } from "@/lib/api";
+import type { ProviderSummary, ProviderStatus } from "@/lib/api";
 import { LatencySparkline } from "./LatencySparkline";
+import { aggregateSparklines } from "@/lib/sparkline";
 
 // ── Status ─────────────────────────────────────────────────────────────────
 
-const STATUS_PILL: Record<string, string> = {
+const STATUS_PILL: Record<ProviderStatus, string> = {
   operational: "bg-[var(--signal-ok-bg)] text-[var(--signal-ok)]",
   degraded:    "bg-[var(--signal-warn-bg)] text-[var(--signal-warn)]",
   down:        "bg-[var(--signal-down-bg)] text-[var(--signal-down)]",
 };
 
-const STATUS_DOT: Record<string, string> = {
+const STATUS_DOT: Record<ProviderStatus, string> = {
   operational: "bg-[var(--signal-ok)]",
   degraded:    "bg-[var(--signal-warn)]",
   down:        "bg-[var(--signal-down)]",
 };
 
-const STATUS_ACCENT: Record<string, string> = {
+const STATUS_ACCENT: Record<ProviderStatus, string> = {
   operational: "shadow-[inset_3px_0_0_var(--signal-ok)]",
   degraded:    "shadow-[inset_3px_0_0_var(--signal-warn)]",
   down:        "shadow-[inset_3px_0_0_var(--signal-down)]",
 };
 
-const STATUS_COLOR: Record<string, string> = {
+const STATUS_COLOR: Record<ProviderStatus, string> = {
   operational: "var(--signal-ok)",
   degraded:    "var(--signal-warn)",
   down:        "var(--signal-down)",
@@ -34,23 +35,6 @@ function uptimeColor(u: number): string {
   if (u >= 0.995) return "text-[var(--signal-ok)]";
   if (u >= 0.95)  return "text-[var(--signal-warn)]";
   return "text-[var(--signal-down)]";
-}
-
-// ── Aggregate sparklines across all models ──────────────────────────────────
-
-function aggregateSparklines(modelStats: ModelStat[]): number[] {
-  const BUCKETS = 60;
-  const sums = new Array<number>(BUCKETS).fill(0);
-  const counts = new Array<number>(BUCKETS).fill(0);
-  for (const m of modelStats) {
-    for (let i = 0; i < BUCKETS; i++) {
-      if (m.sparkline[i] > 0) {
-        sums[i] += m.sparkline[i];
-        counts[i]++;
-      }
-    }
-  }
-  return sums.map((s, i) => (counts[i] > 0 ? s / counts[i] : 0));
 }
 
 // ── Provider card ───────────────────────────────────────────────────────────

--- a/web/components/ProviderTable.tsx
+++ b/web/components/ProviderTable.tsx
@@ -1,8 +1,24 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
-import type { ProviderSummary } from "@/lib/api";
+import type { ProviderSummary, ModelStat } from "@/lib/api";
 import { StatusPill } from "./StatusPill";
+import { LatencySparkline } from "./LatencySparkline";
+
+function aggregateSparklines(modelStats: ModelStat[]): number[] {
+  const BUCKETS = 60;
+  const sums = new Array<number>(BUCKETS).fill(0);
+  const counts = new Array<number>(BUCKETS).fill(0);
+  for (const m of modelStats) {
+    for (let i = 0; i < BUCKETS; i++) {
+      if (m.sparkline[i] > 0) {
+        sums[i] += m.sparkline[i];
+        counts[i]++;
+      }
+    }
+  }
+  return sums.map((s, i) => (counts[i] > 0 ? s / counts[i] : 0));
+}
 
 const CATEGORY_LABEL: Record<string, string> = {
   official: "Official",
@@ -120,6 +136,9 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
             <th className={`${thCls} text-right`} onClick={() => handleSort("p95")}>
               <SortIcon col="p95" active={sortKey} dir={sortDir} /> p95
             </th>
+            <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">
+              Trend
+            </th>
             <th className={`${thCls} text-right`} onClick={() => handleSort("status")}>
               <SortIcon col="status" active={sortKey} dir={sortDir} /> Status
             </th>
@@ -152,6 +171,14 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
               </td>
               <td className="px-4 py-3 text-right font-mono text-[var(--ink-200)]">
                 {formatP95(p.p95_ms)}
+              </td>
+              <td className="px-4 py-3 text-right">
+                <LatencySparkline
+                  data={aggregateSparklines(p.model_stats ?? [])}
+                  width={80}
+                  height={22}
+                  area
+                />
               </td>
               <td className="px-4 py-3 text-right">
                 <StatusPill status={p.current_status} />

--- a/web/components/ProviderTable.tsx
+++ b/web/components/ProviderTable.tsx
@@ -1,24 +1,16 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
-import type { ProviderSummary, ModelStat } from "@/lib/api";
+import type { ProviderSummary } from "@/lib/api";
 import { StatusPill } from "./StatusPill";
 import { LatencySparkline } from "./LatencySparkline";
+import { aggregateSparklines } from "@/lib/sparkline";
 
-function aggregateSparklines(modelStats: ModelStat[]): number[] {
-  const BUCKETS = 60;
-  const sums = new Array<number>(BUCKETS).fill(0);
-  const counts = new Array<number>(BUCKETS).fill(0);
-  for (const m of modelStats) {
-    for (let i = 0; i < BUCKETS; i++) {
-      if (m.sparkline[i] > 0) {
-        sums[i] += m.sparkline[i];
-        counts[i]++;
-      }
-    }
-  }
-  return sums.map((s, i) => (counts[i] > 0 ? s / counts[i] : 0));
-}
+const STATUS_SPARKLINE_COLOR: Record<string, string> = {
+  operational: "var(--signal-ok)",
+  degraded:    "var(--signal-warn)",
+  down:        "var(--signal-down)",
+};
 
 const CATEGORY_LABEL: Record<string, string> = {
   official: "Official",
@@ -178,6 +170,7 @@ export function ProviderTable({ providers }: { providers: ProviderSummary[] }) {
                   width={80}
                   height={22}
                   area
+                  color={STATUS_SPARKLINE_COLOR[p.current_status] ?? "var(--viz-1)"}
                 />
               </td>
               <td className="px-4 py-3 text-right">

--- a/web/components/SiteHeader.tsx
+++ b/web/components/SiteHeader.tsx
@@ -6,29 +6,49 @@ export async function SiteHeader() {
   const session = await getSession().catch(() => null);
 
   return (
-    <header className="border-b border-[var(--ink-600)] px-6 py-4">
-      <div className="mx-auto max-w-4xl flex items-center justify-between">
+    <header className="sticky top-0 z-50 border-b border-[var(--ink-600)] bg-[var(--canvas-raised)] px-6">
+      <div className="mx-auto max-w-4xl flex items-center justify-between h-14">
+
+        {/* Logo — pulsing heartbeat dot + wordmark */}
         <Link
           href="/"
-          className="font-mono text-sm font-medium hover:opacity-80 transition-opacity"
+          className="flex items-center gap-2.5 group shrink-0"
           aria-label="llmstatus home"
         >
-          <span className="text-[var(--signal-amber)]">[</span>
-          <span className="text-[var(--ink-100)] mx-1.5">llmstatus</span>
-          <span className="text-[var(--signal-amber)]">]</span>
+          <span className="relative flex h-2.5 w-2.5 shrink-0">
+            <span className="beat-ring absolute inset-0 rounded-full bg-[var(--signal-ok)]" />
+            <span className="beat relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--signal-ok)]" />
+          </span>
+          <span className="font-mono font-bold text-base text-[var(--ink-100)] tracking-tight leading-none">
+            llmstatus
+            <span className="text-[var(--ink-500)] font-normal text-sm">.io</span>
+          </span>
         </Link>
-        <nav className="flex items-center gap-6" aria-label="Site navigation">
+
+        {/* Navigation — grouped */}
+        <nav className="flex items-center gap-1" aria-label="Site navigation">
+          {/* Primary */}
           <NavLink href="/providers">Providers</NavLink>
           <NavLink href="/incidents">Incidents</NavLink>
           <NavLink href="/china">China</NavLink>
           <NavLink href="/compare">Compare</NavLink>
-          <NavLink href="/sponsors">Sponsors</NavLink>
-          <NavLink href="/badges">Badges</NavLink>
+
+          {/* Separator */}
+          <span className="mx-1 h-4 w-px bg-[var(--ink-600)]" aria-hidden="true" />
+
+          {/* Secondary */}
           <NavLink href="/api">API</NavLink>
+          <NavLink href="/badges">Badges</NavLink>
+          <NavLink href="/sponsors">Sponsors</NavLink>
+
+          {/* Separator */}
+          <span className="mx-1 h-4 w-px bg-[var(--ink-600)]" aria-hidden="true" />
+
+          {/* Auth */}
           {session ? (
-            <NavLink href="/account">Account</NavLink>
+            <NavLink href="/account" variant="pill">Account</NavLink>
           ) : (
-            <NavLink href="/login">Sign in</NavLink>
+            <NavLink href="/login" variant="pill">Sign in</NavLink>
           )}
         </nav>
       </div>

--- a/web/lib/sparkline.ts
+++ b/web/lib/sparkline.ts
@@ -1,0 +1,16 @@
+import type { ModelStat } from "./api";
+
+export function aggregateSparklines(modelStats: ModelStat[]): number[] {
+  const BUCKETS = 60;
+  const sums = new Array<number>(BUCKETS).fill(0);
+  const counts = new Array<number>(BUCKETS).fill(0);
+  for (const m of modelStats) {
+    for (let i = 0; i < BUCKETS; i++) {
+      if (m.sparkline[i] > 0) {
+        sums[i] += m.sparkline[i];
+        counts[i]++;
+      }
+    }
+  }
+  return sums.map((s, i) => (counts[i] > 0 ? s / counts[i] : 0));
+}


### PR DESCRIPTION
## Summary

- **Animated logo**: replaced `[llmstatus]` bracket wordmark with a pulsing teal heartbeat dot + mono wordmark using CSS `heartbeat` / `beat-ring` keyframes (2.4s, no JS)
- **Navigation redesign**: links bumped to `text-sm`, grouped into Primary / Secondary / Auth with hairline separators; active link shows 2px teal capsule underline; Sign in/Account rendered as a pill CTA via new `variant="pill"` prop on `NavLink`
- **ProviderCard enhancements**: status-colored left inset shadow accent (`inset 3px 0 0`), sparkline height 28→48px with gradient area fill, stat values bumped to `text-base font-semibold`
- **LatencySparkline**: new `area` and `color` props; `buildAreaPaths` segments continuous runs into closed `M…L…Z` polygons with a top-to-transparent `linearGradient`
- **ProviderTable**: new "Trend" column with 80×22 area sparkline aggregated from `model_stats`
- **Homepage hero**: `text-3xl` → `text-4xl`, body copy `text-sm` → `text-base`

## Test plan

- [ ] Dev server boots without errors (`npm run dev`)
- [ ] Homepage: hero text larger, provider cards show area sparklines with status-colored lines and left accent
- [ ] Providers page: table has new "Trend" sparkline column
- [ ] Logo pulses smoothly; no jank at 2.4s repeat
- [ ] Active nav link shows teal underline capsule
- [ ] Sign in pill renders with border; turns teal on active/hover
- [ ] Providers without `model_stats` show "no data" text gracefully
- [ ] TypeScript: `tsc --noEmit` passes for all modified files (pre-existing test type errors unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)