### PR TITLE
fix: wire auth env vars into api and web containers

### DIFF
--- a/deploy/ansible/roles/main-server/templates/env.j2
+++ b/deploy/ansible/roles/main-server/templates/env.j2
@@ -22,11 +22,25 @@ REDIS_URL=redis://redis:6379
 API_URL=http://api:8081
 INGEST_SECRET={{ ingest_secret }}
 
+# Auth
+JWT_SECRET={{ jwt_secret }}
+INTERNAL_SECRET={{ internal_secret }}
+
 # Notifier (email via Resend)
 {% if resend_api_key is defined and resend_api_key %}
 RESEND_API_KEY={{ resend_api_key }}
 {% endif %}
 EMAIL_FROM=noreply@llmstatus.io
+
+# OAuth (optional — omitted when vault value is false)
+{% if google_client_id is defined and google_client_id and google_client_id != false %}
+GOOGLE_CLIENT_ID={{ google_client_id }}
+GOOGLE_CLIENT_SECRET={{ google_client_secret }}
+{% endif %}
+{% if github_client_id is defined and github_client_id and github_client_id != false %}
+GITHUB_CLIENT_ID={{ github_client_id }}
+GITHUB_CLIENT_SECRET={{ github_client_secret }}
+{% endif %}
 
 # Site
 NEXT_PUBLIC_SITE_URL=https://llmstatus.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,10 @@ services:
       INFLUX_DATABASE: ${INFLUX_DATABASE:-probes}
       API_ADDR: ":8081"
       API_RATE_LIMIT: ${API_RATE_LIMIT:-60}
+      JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret-change-in-prod}
+      INTERNAL_SECRET: ${INTERNAL_SECRET:-dev-internal-secret}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      EMAIL_FROM: ${EMAIL_FROM:-noreply@llmstatus.io}
     depends_on:
       db:
         condition: service_healthy
@@ -184,6 +188,12 @@ services:
     environment:
       API_URL: http://api:8081
       NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:13000}
+      JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret-change-in-prod}
+      INTERNAL_SECRET: ${INTERNAL_SECRET:-dev-internal-secret}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
     depends_on:
       api:
         condition: service_healthy

--- a/web/env.local.example
+++ b/web/env.local.example
@@ -17,3 +17,18 @@ NEXT_PUBLIC_SITE_URL=http://localhost:13000
 #   PORT=13000 npm run dev
 # Or add to this file if your tooling supports it:
 PORT=13000
+
+# ── Auth ─────────────────────────────────────────────────────────────────────
+# Must match JWT_SECRET and INTERNAL_SECRET in the api container (llmstatus/.env).
+JWT_SECRET=REPLACE_ME
+INTERNAL_SECRET=REPLACE_ME
+
+# ── Google OAuth (optional) ──────────────────────────────────────────────────
+# Leave empty to hide the Google login button.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# ── GitHub OAuth (optional, use the dev App) ─────────────────────────────────
+# Leave empty to hide the GitHub login button.
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=


### PR DESCRIPTION
## Summary
- `docker-compose.yml`: add `JWT_SECRET`, `INTERNAL_SECRET`, `RESEND_API_KEY`, `EMAIL_FROM` to `api` service; add `JWT_SECRET`, `INTERNAL_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` to `web` service
- `deploy/ansible/roles/main-server/templates/env.j2`: inject `JWT_SECRET`, `INTERNAL_SECRET`, and OAuth credentials from vault
- `web/env.local.example`: document auth vars for `npm run dev` setup

## Root cause
Containers had stale dummy values (`re_dummy_key_emails_will_not_send`, `dev-jwt-secret-change-in-prod`) because docker-compose.yml never declared these variables — they were never read from `.env`. OTP email was failing with 500. Google/GitHub login buttons were hidden because the env vars were empty strings.

## Test plan
- [ ] `docker compose up -d --force-recreate api web` → OTP email sends successfully
- [ ] Google login button appears and completes OAuth flow
- [ ] GitHub login button appears and completes OAuth flow
- [ ] Same email via OTP and OAuth resolves to same user account