### PR TITLE
fix: prober.env.j2 emit REGION_ID not NODE_NAME

### DIFF
--- a/deploy/ansible/roles/probe/templates/prober.env.j2
+++ b/deploy/ansible/roles/probe/templates/prober.env.j2
@@ -1,4 +1,4 @@
-NODE_NAME={{ probe_node_name }}
+REGION_ID={{ probe_node_name }}
 INGEST_URL={{ ingest_url }}
 INGEST_SECRET={{ ingest_secret }}
 


### PR DESCRIPTION
## Summary
- `prober.env.j2`: 修正环境变量名从 `NODE_NAME` 改为 `REGION_ID`，与 prober 二进制实际读取的变量名一致
- `hosts.yml` 变更为本地文件，不入 git（已在 .gitignore）

## Root cause
Probe 节点一直没被 Ansible 部署（inventory 空），同时模板里变量名写错，导致即使部署了也无法正确标记 region。

## Test plan
- [ ] Ansible 部署到 4 个 probe 节点成功
- [ ] 各节点 prober 服务启动，InfluxDB 收到对应 region_id 的数据
- [ ] Provider 页 Regional Status 出现 us-east-1 / ap-northeast-1 / ap-southeast-1 / eu-central-1