### PR TITLE
fix: build prober in app_dir then install to /usr/local/bin as root

### DIFF
--- a/deploy/ansible/roles/probe/tasks/main.yml
+++ b/deploy/ansible/roles/probe/tasks/main.yml
@@ -39,13 +39,20 @@
 
 # ── Build prober binary ───────────────────────────────────────────────────
 - name: build prober
-  command: /usr/local/go/bin/go build -o /usr/local/bin/llmstatus-prober ./cmd/prober
+  command: /usr/local/go/bin/go build -o {{ app_dir }}/llmstatus-prober ./cmd/prober
   args:
     chdir: "{{ app_dir }}"
   become_user: ubuntu
   environment:
     HOME: /home/ubuntu
     GOPATH: /home/ubuntu/go
+
+- name: install prober binary
+  copy:
+    src: "{{ app_dir }}/llmstatus-prober"
+    dest: /usr/local/bin/llmstatus-prober
+    mode: "0755"
+    remote_src: true
 
 # ── Prober env and service ────────────────────────────────────────────────
 - name: deploy prober env file


### PR DESCRIPTION
ubuntu user cannot write to /usr/local/bin/ — build to app_dir first, then copy with root.