### PR TITLE
feat: sponsor review workflow with admin approval

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -80,6 +80,7 @@ func main() {
 
 	if authCfg, ok := buildAuthConfig(store); ok {
 		opts = append(opts, api.WithAuth(authCfg))
+		opts = append(opts, api.WithEmailSender(authCfg.Email))
 	}
 
 	if hexKey := os.Getenv("SPONSOR_KEY_ENCRYPTION_KEY"); hexKey != "" {

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/llmstatus/llmstatus/internal/email"
+)
+
+// requireAdmin validates the Bearer token and verifies the user has is_admin=true.
+// Returns true when the caller may proceed; writes an error response and returns false otherwise.
+func (s *Server) requireAdmin(w http.ResponseWriter, r *http.Request) bool {
+	claims := s.requireAuth(w, r)
+	if claims == nil {
+		return false
+	}
+	user, err := s.auth.Store.GetUserByID(r.Context(), claims.UserID)
+	if err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return false
+	}
+	if !user.IsAdmin {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return false
+	}
+	return true
+}
+
+// GET /v1/admin/sponsors — list pending sponsors awaiting review.
+func (s *Server) adminListSponsors(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdmin(w, r) {
+		return
+	}
+	rows, err := s.store.ListPendingSponsors(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list sponsors")
+		return
+	}
+	type sponsorOut struct {
+		ID         string  `json:"id"`
+		Name       string  `json:"name"`
+		WebsiteURL *string `json:"website_url,omitempty"`
+		LogoURL    *string `json:"logo_url,omitempty"`
+		Tier       string  `json:"tier"`
+		Status     string  `json:"status"`
+		UserID     int64   `json:"user_id"`
+	}
+	out := make([]sponsorOut, len(rows))
+	for i, sp := range rows {
+		out[i] = sponsorOut{
+			ID:         sp.ID,
+			Name:       sp.Name,
+			WebsiteURL: textVal(sp.WebsiteUrl),
+			LogoURL:    textVal(sp.LogoUrl),
+			Tier:       sp.Tier,
+			Status:     sp.Status,
+			UserID:     sp.UserID,
+		}
+	}
+	writeJSON(w, http.StatusOK, coalesceSlice(out))
+}
+
+// POST /v1/admin/sponsors/{id}/approve
+func (s *Server) adminApproveSponsor(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdmin(w, r) {
+		return
+	}
+	id := r.PathValue("id")
+	sp, err := s.store.ApproveSponsor(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "sponsor not found")
+		return
+	}
+	s.sendSponsorStatusEmail(r, sp.UserID, sp.Name, "approved")
+	writeJSON(w, http.StatusOK, sp)
+}
+
+// POST /v1/admin/sponsors/{id}/reject
+func (s *Server) adminRejectSponsor(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdmin(w, r) {
+		return
+	}
+	id := r.PathValue("id")
+	sp, err := s.store.RejectSponsor(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "sponsor not found")
+		return
+	}
+	s.sendSponsorStatusEmail(r, sp.UserID, sp.Name, "rejected")
+	writeJSON(w, http.StatusOK, sp)
+}
+
+func (s *Server) sendSponsorStatusEmail(r *http.Request, userID int64, sponsorName, status string) {
+	if s.mailer == nil || s.auth == nil {
+		return
+	}
+	user, err := s.auth.Store.GetUserByID(r.Context(), userID)
+	if err != nil {
+		slog.Warn("admin: could not look up sponsor user for email", "user_id", userID, "err", err)
+		return
+	}
+	var subject, body string
+	switch status {
+	case "approved":
+		subject = fmt.Sprintf("[llmstatus] Your sponsor application for %q has been approved", sponsorName)
+		body = fmt.Sprintf(
+			"Your sponsor profile %q has been approved and is now listed on llmstatus.io/sponsors.\n\n"+
+				"You can manage your profile and API keys at https://llmstatus.io/sponsor/dashboard.",
+			sponsorName,
+		)
+	case "rejected":
+		subject = fmt.Sprintf("[llmstatus] Your sponsor application for %q was not approved", sponsorName)
+		body = fmt.Sprintf(
+			"Your sponsor application for %q was reviewed and was not approved at this time.\n\n"+
+				"If you have questions, reply to this email.",
+			sponsorName,
+		)
+	}
+	if err := s.mailer.Send(r.Context(), email.Message{
+		To:      user.Email,
+		Subject: subject,
+		Text:    body,
+	}); err != nil {
+		slog.Warn("admin: failed to send sponsor status email", "user_id", userID, "status", status, "err", err)
+	}
+}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -191,6 +191,7 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 		"email":       user.Email,
 		"digest_hour": user.DigestHour,
 		"timezone":    user.Timezone,
+		"is_admin":    user.IsAdmin,
 	})
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/llmstatus/llmstatus/internal/email"
 	"github.com/llmstatus/llmstatus/internal/keyenc"
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
@@ -35,6 +36,7 @@ type Server struct {
 	limiter   *RateLimiter      // optional; nil → no rate limiting
 	auth      *AuthConfig       // optional; nil → auth routes return 501
 	keyEnc    *keyenc.Encrypter // optional; nil → sponsor key endpoints return 503
+	mailer    email.Sender      // optional; nil → admin approval emails skipped
 	hub       *Hub              // WebSocket hub for real-time updates
 	mux       *http.ServeMux
 	handler   http.Handler // mux optionally wrapped with limiter middleware
@@ -53,6 +55,11 @@ func WithAuth(cfg *AuthConfig) func(*Server) {
 // WithKeyEncrypter enables sponsor API key storage.
 func WithKeyEncrypter(enc *keyenc.Encrypter) func(*Server) {
 	return func(s *Server) { s.keyEnc = enc }
+}
+
+// WithEmailSender enables transactional emails (sponsor approval notifications).
+func WithEmailSender(m email.Sender) func(*Server) {
+	return func(s *Server) { s.mailer = m }
 }
 
 // New creates a Server and registers all routes. Pass functional options
@@ -122,6 +129,11 @@ func (s *Server) registerRoutes() {
 		s.mux.HandleFunc("PATCH /v1/sponsor/me", s.updateSponsorMe)
 		s.mux.HandleFunc("PUT /v1/sponsor/me/keys/{provider_id}", s.upsertSponsorKey)
 		s.mux.HandleFunc("DELETE /v1/sponsor/me/keys/{provider_id}", s.deleteSponsorKey)
+
+		// Admin
+		s.mux.HandleFunc("GET /v1/admin/sponsors", s.adminListSponsors)
+		s.mux.HandleFunc("POST /v1/admin/sponsors/{id}/approve", s.adminApproveSponsor)
+		s.mux.HandleFunc("POST /v1/admin/sponsors/{id}/reject", s.adminRejectSponsor)
 	}
 }
 

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -25,9 +25,13 @@ type Store interface {
 
 	// Sponsors
 	ListActiveSponsors(ctx context.Context) ([]pgstore.Sponsor, error)
+	ListPendingSponsors(ctx context.Context) ([]pgstore.Sponsor, error)
 	CreateSponsor(ctx context.Context, arg pgstore.CreateSponsorParams) (pgstore.Sponsor, error)
+	GetSponsorByID(ctx context.Context, id string) (pgstore.Sponsor, error)
 	GetSponsorByUserID(ctx context.Context, userID int64) (pgstore.Sponsor, error)
 	UpdateSponsor(ctx context.Context, arg pgstore.UpdateSponsorParams) (pgstore.Sponsor, error)
+	ApproveSponsor(ctx context.Context, id string) (pgstore.Sponsor, error)
+	RejectSponsor(ctx context.Context, id string) (pgstore.Sponsor, error)
 	ListSponsorKeys(ctx context.Context, sponsorID string) ([]pgstore.SponsorKey, error)
 	UpsertSponsorKey(ctx context.Context, arg pgstore.UpsertSponsorKeyParams) (pgstore.SponsorKey, error)
 	DeleteSponsorKey(ctx context.Context, arg pgstore.DeleteSponsorKeyParams) error

--- a/internal/api/testhelpers_test.go
+++ b/internal/api/testhelpers_test.go
@@ -126,8 +126,16 @@ func (f *fakeStore) ListActiveSponsors(_ context.Context) ([]pgstore.Sponsor, er
 	return nil, f.err
 }
 
+func (f *fakeStore) ListPendingSponsors(_ context.Context) ([]pgstore.Sponsor, error) {
+	return nil, f.err
+}
+
 func (f *fakeStore) CreateSponsor(_ context.Context, arg pgstore.CreateSponsorParams) (pgstore.Sponsor, error) {
 	return pgstore.Sponsor{}, f.err
+}
+
+func (f *fakeStore) GetSponsorByID(_ context.Context, _ string) (pgstore.Sponsor, error) {
+	return pgstore.Sponsor{}, pgx.ErrNoRows
 }
 
 func (f *fakeStore) GetSponsorByUserID(_ context.Context, userID int64) (pgstore.Sponsor, error) {
@@ -135,6 +143,14 @@ func (f *fakeStore) GetSponsorByUserID(_ context.Context, userID int64) (pgstore
 }
 
 func (f *fakeStore) UpdateSponsor(_ context.Context, arg pgstore.UpdateSponsorParams) (pgstore.Sponsor, error) {
+	return pgstore.Sponsor{}, f.err
+}
+
+func (f *fakeStore) ApproveSponsor(_ context.Context, _ string) (pgstore.Sponsor, error) {
+	return pgstore.Sponsor{}, f.err
+}
+
+func (f *fakeStore) RejectSponsor(_ context.Context, _ string) (pgstore.Sponsor, error) {
 	return pgstore.Sponsor{}, f.err
 }
 

--- a/internal/store/postgres/gen/models.go
+++ b/internal/store/postgres/gen/models.go
@@ -98,6 +98,7 @@ type Sponsor struct {
 	Tier       string             `json:"tier"`
 	Active     bool               `json:"active"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	Status     string             `json:"status"`
 }
 
 type SponsorKey struct {
@@ -131,6 +132,7 @@ type User struct {
 	Timezone   string             `json:"timezone"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	VerifiedAt pgtype.Timestamptz `json:"verified_at"`
+	IsAdmin    bool               `json:"is_admin"`
 }
 
 type UserReport struct {

--- a/internal/store/postgres/gen/querier.go
+++ b/internal/store/postgres/gen/querier.go
@@ -12,6 +12,7 @@ import (
 )
 
 type Querier interface {
+	ApproveSponsor(ctx context.Context, id string) (Sponsor, error)
 	// Finds a valid (unused, unexpired) token for the user and marks it used.
 	ConsumeOTPToken(ctx context.Context, arg ConsumeOTPTokenParams) (OtpToken, error)
 	// ============================================================
@@ -42,14 +43,14 @@ type Querier interface {
 	GetUserByEmail(ctx context.Context, email string) (User, error)
 	GetUserByID(ctx context.Context, id int64) (User, error)
 	GetUserByOAuth(ctx context.Context, arg GetUserByOAuthParams) (User, error)
-	IsAlertSent(ctx context.Context, arg IsAlertSentParams) (bool, error)
-	IsDigestSent(ctx context.Context, arg IsDigestSentParams) (bool, error)
 	// ============================================================
 	// user_reports (LLMS-048)
 	// ============================================================
 	// Inserts a report only when no report from the same ip_hash exists for the
 	// same provider within the last 5 minutes (server-side dedup).
 	InsertUserReport(ctx context.Context, arg InsertUserReportParams) error
+	IsAlertSent(ctx context.Context, arg IsAlertSentParams) (bool, error)
+	IsDigestSent(ctx context.Context, arg IsDigestSentParams) (bool, error)
 	ListActiveProviders(ctx context.Context) ([]Provider, error)
 	ListActiveSponsorKeys(ctx context.Context) ([]SponsorKey, error)
 	ListActiveSponsors(ctx context.Context) ([]Sponsor, error)
@@ -60,6 +61,7 @@ type Querier interface {
 	ListIncidentsByStatus(ctx context.Context, arg ListIncidentsByStatusParams) ([]Incident, error)
 	ListIncidentsUpdatedSince(ctx context.Context, updatedAt pgtype.Timestamptz) ([]Incident, error)
 	ListModelsByProvider(ctx context.Context, providerID string) ([]Model, error)
+	ListPendingSponsors(ctx context.Context) ([]Sponsor, error)
 	ListProviders(ctx context.Context) ([]Provider, error)
 	// Returns active providers visible to a probe node with the given scope.
 	// 'global' providers are probed by every node; 'intl'/'cn' are scope-specific.
@@ -80,6 +82,7 @@ type Querier interface {
 	LogAlert(ctx context.Context, arg LogAlertParams) error
 	LogDigest(ctx context.Context, arg LogDigestParams) error
 	MarkUserVerified(ctx context.Context, id int64) error
+	RejectSponsor(ctx context.Context, id string) (Sponsor, error)
 	ResolveIncident(ctx context.Context, arg ResolveIncidentParams) error
 	SetIncidentDescription(ctx context.Context, arg SetIncidentDescriptionParams) error
 	SetProviderActive(ctx context.Context, arg SetProviderActiveParams) error

--- a/internal/store/postgres/gen/queries.sql.go
+++ b/internal/store/postgres/gen/queries.sql.go
@@ -13,6 +13,27 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const approveSponsor = `-- name: ApproveSponsor :one
+UPDATE sponsors SET status = 'approved', active = TRUE WHERE id = $1 RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status
+`
+
+func (q *Queries) ApproveSponsor(ctx context.Context, id string) (Sponsor, error) {
+	row := q.db.QueryRow(ctx, approveSponsor, id)
+	var i Sponsor
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Name,
+		&i.WebsiteUrl,
+		&i.LogoUrl,
+		&i.Tier,
+		&i.Active,
+		&i.CreatedAt,
+		&i.Status,
+	)
+	return i, err
+}
+
 const consumeOTPToken = `-- name: ConsumeOTPToken :one
 UPDATE otp_tokens
 SET used_at = NOW()
@@ -148,7 +169,7 @@ const createSponsor = `-- name: CreateSponsor :one
 
 INSERT INTO sponsors (id, user_id, name, website_url, logo_url, tier)
 VALUES ($1, $2, $3, $4, $5, 'standard')
-RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at
+RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status
 `
 
 type CreateSponsorParams struct {
@@ -178,6 +199,7 @@ func (q *Queries) CreateSponsor(ctx context.Context, arg CreateSponsorParams) (S
 		&i.Tier,
 		&i.Active,
 		&i.CreatedAt,
+		&i.Status,
 	)
 	return i, err
 }
@@ -404,7 +426,7 @@ func (q *Queries) GetProvider(ctx context.Context, id string) (Provider, error) 
 }
 
 const getSponsorByID = `-- name: GetSponsorByID :one
-SELECT id, user_id, name, website_url, logo_url, tier, active, created_at FROM sponsors WHERE id = $1
+SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status FROM sponsors WHERE id = $1
 `
 
 func (q *Queries) GetSponsorByID(ctx context.Context, id string) (Sponsor, error) {
@@ -419,12 +441,13 @@ func (q *Queries) GetSponsorByID(ctx context.Context, id string) (Sponsor, error
 		&i.Tier,
 		&i.Active,
 		&i.CreatedAt,
+		&i.Status,
 	)
 	return i, err
 }
 
 const getSponsorByUserID = `-- name: GetSponsorByUserID :one
-SELECT id, user_id, name, website_url, logo_url, tier, active, created_at FROM sponsors WHERE user_id = $1
+SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status FROM sponsors WHERE user_id = $1
 `
 
 func (q *Queries) GetSponsorByUserID(ctx context.Context, userID int64) (Sponsor, error) {
@@ -439,6 +462,7 @@ func (q *Queries) GetSponsorByUserID(ctx context.Context, userID int64) (Sponsor
 		&i.Tier,
 		&i.Active,
 		&i.CreatedAt,
+		&i.Status,
 	)
 	return i, err
 }
@@ -464,7 +488,7 @@ func (q *Queries) GetSubscription(ctx context.Context, id int64) (Subscription, 
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, digest_hour, timezone, created_at, verified_at FROM users WHERE email = $1
+SELECT id, email, digest_hour, timezone, created_at, verified_at, is_admin FROM users WHERE email = $1
 `
 
 func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error) {
@@ -477,12 +501,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.Timezone,
 		&i.CreatedAt,
 		&i.VerifiedAt,
+		&i.IsAdmin,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, digest_hour, timezone, created_at, verified_at FROM users WHERE id = $1
+SELECT id, email, digest_hour, timezone, created_at, verified_at, is_admin FROM users WHERE id = $1
 `
 
 func (q *Queries) GetUserByID(ctx context.Context, id int64) (User, error) {
@@ -495,12 +520,13 @@ func (q *Queries) GetUserByID(ctx context.Context, id int64) (User, error) {
 		&i.Timezone,
 		&i.CreatedAt,
 		&i.VerifiedAt,
+		&i.IsAdmin,
 	)
 	return i, err
 }
 
 const getUserByOAuth = `-- name: GetUserByOAuth :one
-SELECT u.id, u.email, u.digest_hour, u.timezone, u.created_at, u.verified_at FROM users u
+SELECT u.id, u.email, u.digest_hour, u.timezone, u.created_at, u.verified_at, u.is_admin FROM users u
 JOIN oauth_accounts o ON o.user_id = u.id
 WHERE o.provider = $1 AND o.sub = $2
 `
@@ -520,8 +546,36 @@ func (q *Queries) GetUserByOAuth(ctx context.Context, arg GetUserByOAuthParams) 
 		&i.Timezone,
 		&i.CreatedAt,
 		&i.VerifiedAt,
+		&i.IsAdmin,
 	)
 	return i, err
+}
+
+const insertUserReport = `-- name: InsertUserReport :exec
+
+INSERT INTO user_reports (provider_id, ip_hash)
+SELECT $1, $2
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_reports
+    WHERE provider_id = $1
+      AND ip_hash     = $2
+      AND created_at  > NOW() - INTERVAL '5 minutes'
+)
+`
+
+type InsertUserReportParams struct {
+	ProviderID string `json:"provider_id"`
+	IpHash     string `json:"ip_hash"`
+}
+
+// ============================================================
+// user_reports (LLMS-048)
+// ============================================================
+// Inserts a report only when no report from the same ip_hash exists for the
+// same provider within the last 5 minutes (server-side dedup).
+func (q *Queries) InsertUserReport(ctx context.Context, arg InsertUserReportParams) error {
+	_, err := q.db.Exec(ctx, insertUserReport, arg.ProviderID, arg.IpHash)
+	return err
 }
 
 const isAlertSent = `-- name: IsAlertSent :one
@@ -571,33 +625,6 @@ func (q *Queries) IsDigestSent(ctx context.Context, arg IsDigestSentParams) (boo
 	var sent bool
 	err := row.Scan(&sent)
 	return sent, err
-}
-
-const insertUserReport = `-- name: InsertUserReport :exec
-
-INSERT INTO user_reports (provider_id, ip_hash)
-SELECT $1, $2
-WHERE NOT EXISTS (
-    SELECT 1 FROM user_reports
-    WHERE provider_id = $1
-      AND ip_hash     = $2
-      AND created_at  > NOW() - INTERVAL '5 minutes'
-)
-`
-
-type InsertUserReportParams struct {
-	ProviderID string `json:"provider_id"`
-	IpHash     string `json:"ip_hash"`
-}
-
-// ============================================================
-// user_reports (LLMS-048)
-// ============================================================
-// Inserts a report only when no report from the same ip_hash exists for the
-// same provider within the last 5 minutes (server-side dedup).
-func (q *Queries) InsertUserReport(ctx context.Context, arg InsertUserReportParams) error {
-	_, err := q.db.Exec(ctx, insertUserReport, arg.ProviderID, arg.IpHash)
-	return err
 }
 
 const listActiveProviders = `-- name: ListActiveProviders :many
@@ -675,7 +702,7 @@ func (q *Queries) ListActiveSponsorKeys(ctx context.Context) ([]SponsorKey, erro
 }
 
 const listActiveSponsors = `-- name: ListActiveSponsors :many
-SELECT id, user_id, name, website_url, logo_url, tier, active, created_at FROM sponsors WHERE active = TRUE ORDER BY tier DESC, created_at ASC
+SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status FROM sponsors WHERE status = 'approved' ORDER BY tier DESC, created_at ASC
 `
 
 func (q *Queries) ListActiveSponsors(ctx context.Context) ([]Sponsor, error) {
@@ -696,6 +723,7 @@ func (q *Queries) ListActiveSponsors(ctx context.Context) ([]Sponsor, error) {
 			&i.Tier,
 			&i.Active,
 			&i.CreatedAt,
+			&i.Status,
 		); err != nil {
 			return nil, err
 		}
@@ -986,6 +1014,40 @@ func (q *Queries) ListModelsByProvider(ctx context.Context, providerID string) (
 	return items, nil
 }
 
+const listPendingSponsors = `-- name: ListPendingSponsors :many
+SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status FROM sponsors WHERE status = 'pending' ORDER BY created_at ASC
+`
+
+func (q *Queries) ListPendingSponsors(ctx context.Context) ([]Sponsor, error) {
+	rows, err := q.db.Query(ctx, listPendingSponsors)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Sponsor{}
+	for rows.Next() {
+		var i Sponsor
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.Name,
+			&i.WebsiteUrl,
+			&i.LogoUrl,
+			&i.Tier,
+			&i.Active,
+			&i.CreatedAt,
+			&i.Status,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listProviders = `-- name: ListProviders :many
 SELECT id, name, category, base_url, auth_type, status_page_url, documentation_url, region, added_at, active, config, probe_scope FROM providers
 ORDER BY name
@@ -1256,7 +1318,7 @@ func (q *Queries) ListSubscriptionsForProvider(ctx context.Context, providerID s
 
 const listUsersForDigest = `-- name: ListUsersForDigest :many
 
-SELECT DISTINCT u.id, u.email, u.digest_hour, u.timezone, u.created_at, u.verified_at
+SELECT DISTINCT u.id, u.email, u.digest_hour, u.timezone, u.created_at, u.verified_at, u.is_admin
 FROM users u
 JOIN subscriptions s ON s.user_id = u.id
 WHERE s.email_digest = TRUE
@@ -1282,6 +1344,7 @@ func (q *Queries) ListUsersForDigest(ctx context.Context) ([]User, error) {
 			&i.Timezone,
 			&i.CreatedAt,
 			&i.VerifiedAt,
+			&i.IsAdmin,
 		); err != nil {
 			return nil, err
 		}
@@ -1338,6 +1401,27 @@ UPDATE users SET verified_at = NOW() WHERE id = $1 AND verified_at IS NULL
 func (q *Queries) MarkUserVerified(ctx context.Context, id int64) error {
 	_, err := q.db.Exec(ctx, markUserVerified, id)
 	return err
+}
+
+const rejectSponsor = `-- name: RejectSponsor :one
+UPDATE sponsors SET status = 'rejected', active = FALSE WHERE id = $1 RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status
+`
+
+func (q *Queries) RejectSponsor(ctx context.Context, id string) (Sponsor, error) {
+	row := q.db.QueryRow(ctx, rejectSponsor, id)
+	var i Sponsor
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Name,
+		&i.WebsiteUrl,
+		&i.LogoUrl,
+		&i.Tier,
+		&i.Active,
+		&i.CreatedAt,
+		&i.Status,
+	)
+	return i, err
 }
 
 const resolveIncident = `-- name: ResolveIncident :exec
@@ -1426,7 +1510,7 @@ const updateSponsor = `-- name: UpdateSponsor :one
 UPDATE sponsors
 SET name = $2, website_url = $3, logo_url = $4
 WHERE id = $1
-RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at
+RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status
 `
 
 type UpdateSponsorParams struct {
@@ -1453,6 +1537,7 @@ func (q *Queries) UpdateSponsor(ctx context.Context, arg UpdateSponsorParams) (S
 		&i.Tier,
 		&i.Active,
 		&i.CreatedAt,
+		&i.Status,
 	)
 	return i, err
 }
@@ -1711,7 +1796,7 @@ const upsertUser = `-- name: UpsertUser :one
 INSERT INTO users (email)
 VALUES ($1)
 ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email
-RETURNING id, email, digest_hour, timezone, created_at, verified_at
+RETURNING id, email, digest_hour, timezone, created_at, verified_at, is_admin
 `
 
 // ============================================================
@@ -1727,6 +1812,7 @@ func (q *Queries) UpsertUser(ctx context.Context, email string) (User, error) {
 		&i.Timezone,
 		&i.CreatedAt,
 		&i.VerifiedAt,
+		&i.IsAdmin,
 	)
 	return i, err
 }

--- a/internal/store/postgres/queries.sql
+++ b/internal/store/postgres/queries.sql
@@ -345,7 +345,16 @@ WHERE id = $1
 RETURNING *;
 
 -- name: ListActiveSponsors :many
-SELECT * FROM sponsors WHERE active = TRUE ORDER BY tier DESC, created_at ASC;
+SELECT * FROM sponsors WHERE status = 'approved' ORDER BY tier DESC, created_at ASC;
+
+-- name: ListPendingSponsors :many
+SELECT * FROM sponsors WHERE status = 'pending' ORDER BY created_at ASC;
+
+-- name: ApproveSponsor :one
+UPDATE sponsors SET status = 'approved', active = TRUE WHERE id = $1 RETURNING *;
+
+-- name: RejectSponsor :one
+UPDATE sponsors SET status = 'rejected', active = FALSE WHERE id = $1 RETURNING *;
 
 -- ── Sponsor keys ──────────────────────────────────────────────────────────
 

--- a/store/migrations/0017_sponsor_status.down.sql
+++ b/store/migrations/0017_sponsor_status.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users DROP COLUMN is_admin;
+ALTER TABLE sponsors DROP COLUMN status;
+ALTER TABLE sponsors ALTER COLUMN active SET DEFAULT TRUE;

--- a/store/migrations/0017_sponsor_status.up.sql
+++ b/store/migrations/0017_sponsor_status.up.sql
@@ -1,0 +1,13 @@
+-- Add sponsor review workflow: status column and is_admin flag.
+
+ALTER TABLE sponsors ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'approved', 'rejected'));
+
+-- Existing active sponsors are already approved.
+UPDATE sponsors SET status = 'approved' WHERE active = TRUE;
+UPDATE sponsors SET status = 'rejected' WHERE active = FALSE;
+
+-- New sponsors start inactive until an admin approves.
+ALTER TABLE sponsors ALTER COLUMN active SET DEFAULT FALSE;
+
+ALTER TABLE users ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT FALSE;

--- a/web/app/admin/sponsors/SponsorReviewList.tsx
+++ b/web/app/admin/sponsors/SponsorReviewList.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+
+interface PendingSponsor {
+  id: string;
+  name: string;
+  website_url: string | null;
+  logo_url: string | null;
+  tier: string;
+  user_id: number;
+}
+
+async function doAction(id: string, action: "approve" | "reject", token: string) {
+  const res = await fetch(`/api/admin/sponsors/${id}?action=${action}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await res.text());
+}
+
+export default function SponsorReviewList({
+  sponsors,
+  apiToken,
+}: {
+  sponsors: PendingSponsor[];
+  apiToken: string;
+}) {
+  const [list, setList] = useState(sponsors);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handle(id: string, action: "approve" | "reject") {
+    setBusy(id + action);
+    setError(null);
+    try {
+      await doAction(id, action, apiToken);
+      setList((prev) => prev.filter((s) => s.id !== id));
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (list.length === 0) {
+    return (
+      <p className="text-sm text-[var(--ink-500)]">No pending applications.</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {error && (
+        <p className="text-sm text-[var(--signal-down)]">{error}</p>
+      )}
+      {list.map((sp) => (
+        <div
+          key={sp.id}
+          className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] p-4"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-sm font-semibold text-[var(--ink-100)]">{sp.name}</p>
+              <p className="text-xs text-[var(--ink-500)] mt-0.5">id: {sp.id}</p>
+              {sp.website_url && (
+                <p className="text-xs text-[var(--ink-400)] mt-0.5">{sp.website_url}</p>
+              )}
+              {sp.logo_url && (
+                <p className="text-xs text-[var(--ink-500)] mt-0.5">logo: {sp.logo_url}</p>
+              )}
+            </div>
+            <div className="flex gap-2 shrink-0">
+              <button
+                disabled={busy !== null}
+                onClick={() => handle(sp.id, "approve")}
+                className="px-3 py-1 rounded text-xs font-medium bg-[var(--signal-up)] text-black hover:opacity-80 disabled:opacity-40 transition-opacity"
+              >
+                {busy === sp.id + "approve" ? "…" : "Approve"}
+              </button>
+              <button
+                disabled={busy !== null}
+                onClick={() => handle(sp.id, "reject")}
+                className="px-3 py-1 rounded text-xs font-medium bg-[var(--signal-down)] text-white hover:opacity-80 disabled:opacity-40 transition-opacity"
+              >
+                {busy === sp.id + "reject" ? "…" : "Reject"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/app/admin/sponsors/page.tsx
+++ b/web/app/admin/sponsors/page.tsx
@@ -1,0 +1,64 @@
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { getSession } from "@/lib/session";
+import SponsorReviewList from "./SponsorReviewList";
+
+export const metadata: Metadata = { title: "Admin — Sponsor Review" };
+
+const API = process.env.API_URL ?? "http://localhost:8081";
+
+interface PendingSponsor {
+  id: string;
+  name: string;
+  website_url: string | null;
+  logo_url: string | null;
+  tier: string;
+  user_id: number;
+}
+
+async function fetchIsAdmin(token: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${API}/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    });
+    if (!res.ok) return false;
+    const { data } = await res.json();
+    return data?.is_admin === true;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchPendingSponsors(token: string): Promise<PendingSponsor[]> {
+  try {
+    const res = await fetch(`${API}/v1/admin/sponsors`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    });
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
+export default async function AdminSponsorsPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+
+  const isAdmin = await fetchIsAdmin(session.token);
+  if (!isAdmin) redirect("/");
+
+  const sponsors = await fetchPendingSponsors(session.token);
+
+  return (
+    <main className="flex-1 mx-auto w-full max-w-2xl px-6 py-10">
+      <h1 className="mb-2 text-xl font-semibold text-[var(--ink-100)]">Sponsor Review</h1>
+      <p className="mb-6 text-sm text-[var(--ink-500)]">
+        {sponsors.length} pending application{sponsors.length !== 1 ? "s" : ""}
+      </p>
+      <SponsorReviewList sponsors={sponsors} apiToken={session.token} />
+    </main>
+  );
+}

--- a/web/app/api/admin/sponsors/[id]/route.ts
+++ b/web/app/api/admin/sponsors/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API = process.env.API_URL ?? "http://localhost:8081";
+
+function auth(req: NextRequest) {
+  return req.headers.get("Authorization") ?? "";
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const action = req.nextUrl.searchParams.get("action");
+  if (action !== "approve" && action !== "reject") {
+    return NextResponse.json({ error: "invalid action" }, { status: 400 });
+  }
+  const res = await fetch(`${API}/v1/admin/sponsors/${id}/${action}`, {
+    method: "POST",
+    headers: { Authorization: auth(req) },
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/web/app/api/admin/sponsors/route.ts
+++ b/web/app/api/admin/sponsors/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API = process.env.API_URL ?? "http://localhost:8081";
+
+function auth(req: NextRequest) {
+  return req.headers.get("Authorization") ?? "";
+}
+
+export async function GET(req: NextRequest) {
+  const res = await fetch(`${API}/v1/admin/sponsors`, {
+    headers: { Authorization: auth(req) },
+    cache: "no-store",
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/web/app/sponsor/dashboard/page.tsx
+++ b/web/app/sponsor/dashboard/page.tsx
@@ -17,6 +17,7 @@ interface Sponsor {
   logo_url: string | null;
   tier: string;
   active: boolean;
+  status: string;
 }
 
 interface SponsorKey {
@@ -81,6 +82,14 @@ export default async function SponsorDashboardPage() {
             can add API keys for providers you want to support.
           </p>
           <RegisterForm apiToken={session.token} />
+        </div>
+      ) : me.sponsor.status === "pending" ? (
+        <div className="rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] p-6">
+          <h2 className="mb-1 text-base font-semibold text-[var(--ink-100)]">Application under review</h2>
+          <p className="text-sm text-[var(--ink-400)]">
+            Your sponsor application for <strong>{me.sponsor.name}</strong> is pending admin approval.
+            You&#39;ll receive an email once a decision has been made.
+          </p>
         </div>
       ) : (
         <div className="flex flex-col gap-8">


### PR DESCRIPTION
## Summary

- **DB migration 0017**: Adds `status` column to `sponsors` (pending/approved/rejected) and `is_admin` boolean to `users`. Existing active sponsors migrate automatically to `approved`.
- **Go API**: New admin endpoints `GET/POST /v1/admin/sponsors` protected by `requireAdmin` middleware. `GET /auth/me` now returns `is_admin`. Email notifications on approve/reject via Resend.
- **Frontend**: `/admin/sponsors` server-rendered page with approve/reject UI. Sponsor dashboard shows "pending review" state.

## Test plan

- [ ] Run migration 0017 on prod DB
- [ ] Verify existing sponsors retain `status='approved'` and remain visible
- [ ] Set `is_admin=true` for operator user in DB
- [ ] Sign in as admin, visit `/admin/sponsors` — should redirect to home if not admin
- [ ] Register a new sponsor — should appear in admin queue, not on public `/sponsors` page
- [ ] Approve sponsor — should send email, sponsor appears on public page
- [ ] Reject sponsor — should send email, sponsor stays hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)