### PR TITLE
feat: system sponsors, tier restructure, probe interval 300s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ NOTIFIER_POLL_INTERVAL=30s
 
 # ── Prober (cmd/prober) ──────────────────────────────────────────────────────
 REGION_ID=local-dev
-PROBE_INTERVAL=60s
+PROBE_INTERVAL=300s
 PROBE_TIMEOUT=30s
 PROBE_CONCURRENCY=4
 INGEST_URL=http://localhost:18080

--- a/cmd/prober/main.go
+++ b/cmd/prober/main.go
@@ -34,7 +34,7 @@ func main() {
 	regionID := requireEnv("REGION_ID")
 	dbURL := requireEnv("DATABASE_URL")
 
-	interval := envDuration("PROBE_INTERVAL", 60*time.Second)
+	interval := envDuration("PROBE_INTERVAL", 300*time.Second)
 	timeout := envDuration("PROBE_TIMEOUT", 30*time.Second)
 	concurrency := envInt("PROBE_CONCURRENCY", 8)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,7 @@ services:
     environment:
       DATABASE_URL: postgres://llmstatus:${POSTGRES_PASSWORD:-llmstatus}@db:5432/llmstatus?sslmode=disable
       REGION_ID: ${REGION_ID:-local-dev}
-      PROBE_INTERVAL: ${PROBE_INTERVAL:-60s}
+      PROBE_INTERVAL: ${PROBE_INTERVAL:-300s}
       PROBE_TIMEOUT: ${PROBE_TIMEOUT:-30s}
       PROBE_CONCURRENCY: ${PROBE_CONCURRENCY:-4}
       INGEST_URL: http://ingest:8080/v1/probe

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -44,10 +44,15 @@ func (s *Server) adminListSponsors(w http.ResponseWriter, r *http.Request) {
 		LogoURL    *string `json:"logo_url,omitempty"`
 		Tier       string  `json:"tier"`
 		Status     string  `json:"status"`
-		UserID     int64   `json:"user_id"`
+		UserID     *int64  `json:"user_id,omitempty"`
+		IsSystem   bool    `json:"is_system"`
 	}
 	out := make([]sponsorOut, len(rows))
 	for i, sp := range rows {
+		var uid *int64
+		if sp.UserID.Valid {
+			uid = &sp.UserID.Int64
+		}
 		out[i] = sponsorOut{
 			ID:         sp.ID,
 			Name:       sp.Name,
@@ -55,7 +60,8 @@ func (s *Server) adminListSponsors(w http.ResponseWriter, r *http.Request) {
 			LogoURL:    textVal(sp.LogoUrl),
 			Tier:       sp.Tier,
 			Status:     sp.Status,
-			UserID:     sp.UserID,
+			UserID:     uid,
+			IsSystem:   sp.IsSystem,
 		}
 	}
 	writeJSON(w, http.StatusOK, coalesceSlice(out))
@@ -72,7 +78,9 @@ func (s *Server) adminApproveSponsor(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "sponsor not found")
 		return
 	}
-	s.sendSponsorStatusEmail(r, sp.UserID, sp.Name, "approved")
+	if sp.UserID.Valid {
+		s.sendSponsorStatusEmail(r, sp.UserID.Int64, sp.Name, "approved")
+	}
 	writeJSON(w, http.StatusOK, sp)
 }
 
@@ -87,7 +95,9 @@ func (s *Server) adminRejectSponsor(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "sponsor not found")
 		return
 	}
-	s.sendSponsorStatusEmail(r, sp.UserID, sp.Name, "rejected")
+	if sp.UserID.Valid {
+		s.sendSponsorStatusEmail(r, sp.UserID.Int64, sp.Name, "rejected")
+	}
 	writeJSON(w, http.StatusOK, sp)
 }
 

--- a/internal/api/sponsors.go
+++ b/internal/api/sponsors.go
@@ -62,7 +62,7 @@ func (s *Server) listSponsors(w http.ResponseWriter, r *http.Request) {
 			IsSystem:   sp.IsSystem,
 		}
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, coalesceSlice(out))
 }
 
 // ── Auth-required ─────────────────────────────────────────────────────────

--- a/internal/api/sponsors.go
+++ b/internal/api/sponsors.go
@@ -16,6 +16,10 @@ func nullText(s string) pgtype.Text {
 	return pgtype.Text{String: s, Valid: s != ""}
 }
 
+func userIDParam(id int64) pgtype.Int8 {
+	return pgtype.Int8{Int64: id, Valid: true}
+}
+
 var slugRe = regexp.MustCompile(`^[a-z0-9-]{2,40}$`)
 
 // ── Public ────────────────────────────────────────────────────────────────
@@ -32,23 +36,30 @@ func (s *Server) listSponsors(w http.ResponseWriter, r *http.Request) {
 		Name       string  `json:"name"`
 		WebsiteURL *string `json:"website_url,omitempty"`
 		LogoURL    *string `json:"logo_url,omitempty"`
+		Tagline    *string `json:"tagline,omitempty"`
 		Tier       string  `json:"tier"`
+		IsSystem   bool    `json:"is_system"`
 	}
 	out := make([]sponsorOut, len(rows))
 	for i, sp := range rows {
-		var website, logo *string
+		var website, logo, tagline *string
 		if sp.WebsiteUrl.Valid {
 			website = &sp.WebsiteUrl.String
 		}
 		if sp.LogoUrl.Valid {
 			logo = &sp.LogoUrl.String
 		}
+		if sp.Tagline.Valid {
+			tagline = &sp.Tagline.String
+		}
 		out[i] = sponsorOut{
 			ID:         sp.ID,
 			Name:       sp.Name,
 			WebsiteURL: website,
 			LogoURL:    logo,
+			Tagline:    tagline,
 			Tier:       sp.Tier,
+			IsSystem:   sp.IsSystem,
 		}
 	}
 	writeJSON(w, http.StatusOK, out)
@@ -87,7 +98,7 @@ func (s *Server) registerSponsor(w http.ResponseWriter, r *http.Request) {
 
 	sp, err := s.store.CreateSponsor(r.Context(), pgstore.CreateSponsorParams{
 		ID:         body.ID,
-		UserID:     claims.UserID,
+		UserID:     userIDParam(claims.UserID),
 		Name:       body.Name,
 		WebsiteUrl: nullText(body.WebsiteURL),
 		LogoUrl:    nullText(body.LogoURL),
@@ -110,7 +121,7 @@ func (s *Server) getSponsorMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sp, err := s.store.GetSponsorByUserID(r.Context(), claims.UserID)
+	sp, err := s.store.GetSponsorByUserID(r.Context(), userIDParam(claims.UserID))
 	if err != nil {
 		writeError(w, http.StatusNotFound, "no sponsor profile found")
 		return
@@ -160,7 +171,7 @@ func (s *Server) updateSponsorMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sp, err := s.store.GetSponsorByUserID(r.Context(), claims.UserID)
+	sp, err := s.store.GetSponsorByUserID(r.Context(), userIDParam(claims.UserID))
 	if err != nil {
 		writeError(w, http.StatusNotFound, "no sponsor profile found")
 		return
@@ -204,7 +215,7 @@ func (s *Server) upsertSponsorKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sp, err := s.store.GetSponsorByUserID(r.Context(), claims.UserID)
+	sp, err := s.store.GetSponsorByUserID(r.Context(), userIDParam(claims.UserID))
 	if err != nil {
 		writeError(w, http.StatusNotFound, "no sponsor profile found")
 		return
@@ -259,7 +270,7 @@ func (s *Server) deleteSponsorKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sp, err := s.store.GetSponsorByUserID(r.Context(), claims.UserID)
+	sp, err := s.store.GetSponsorByUserID(r.Context(), userIDParam(claims.UserID))
 	if err != nil {
 		writeError(w, http.StatusNotFound, "no sponsor profile found")
 		return

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
@@ -28,7 +29,7 @@ type Store interface {
 	ListPendingSponsors(ctx context.Context) ([]pgstore.Sponsor, error)
 	CreateSponsor(ctx context.Context, arg pgstore.CreateSponsorParams) (pgstore.Sponsor, error)
 	GetSponsorByID(ctx context.Context, id string) (pgstore.Sponsor, error)
-	GetSponsorByUserID(ctx context.Context, userID int64) (pgstore.Sponsor, error)
+	GetSponsorByUserID(ctx context.Context, userID pgtype.Int8) (pgstore.Sponsor, error)
 	UpdateSponsor(ctx context.Context, arg pgstore.UpdateSponsorParams) (pgstore.Sponsor, error)
 	ApproveSponsor(ctx context.Context, id string) (pgstore.Sponsor, error)
 	RejectSponsor(ctx context.Context, id string) (pgstore.Sponsor, error)

--- a/internal/api/testhelpers_test.go
+++ b/internal/api/testhelpers_test.go
@@ -138,7 +138,7 @@ func (f *fakeStore) GetSponsorByID(_ context.Context, _ string) (pgstore.Sponsor
 	return pgstore.Sponsor{}, pgx.ErrNoRows
 }
 
-func (f *fakeStore) GetSponsorByUserID(_ context.Context, userID int64) (pgstore.Sponsor, error) {
+func (f *fakeStore) GetSponsorByUserID(_ context.Context, userID pgtype.Int8) (pgstore.Sponsor, error) {
 	return pgstore.Sponsor{}, pgx.ErrNoRows
 }
 

--- a/internal/probes/runner.go
+++ b/internal/probes/runner.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultInterval     = 60 * time.Second
+	defaultInterval     = 300 * time.Second
 	defaultProbeTimeout = 30 * time.Second
 	defaultConcurrency  = 8
 )

--- a/internal/store/postgres/gen/models.go
+++ b/internal/store/postgres/gen/models.go
@@ -91,7 +91,7 @@ type Provider struct {
 
 type Sponsor struct {
 	ID         string             `json:"id"`
-	UserID     int64              `json:"user_id"`
+	UserID     pgtype.Int8        `json:"user_id"`
 	Name       string             `json:"name"`
 	WebsiteUrl pgtype.Text        `json:"website_url"`
 	LogoUrl    pgtype.Text        `json:"logo_url"`
@@ -99,6 +99,8 @@ type Sponsor struct {
 	Active     bool               `json:"active"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	Status     string             `json:"status"`
+	IsSystem   bool               `json:"is_system"`
+	Tagline    pgtype.Text        `json:"tagline"`
 }
 
 type SponsorKey struct {

--- a/internal/store/postgres/gen/querier.go
+++ b/internal/store/postgres/gen/querier.go
@@ -38,7 +38,7 @@ type Querier interface {
 	// ============================================================
 	GetProvider(ctx context.Context, id string) (Provider, error)
 	GetSponsorByID(ctx context.Context, id string) (Sponsor, error)
-	GetSponsorByUserID(ctx context.Context, userID int64) (Sponsor, error)
+	GetSponsorByUserID(ctx context.Context, userID pgtype.Int8) (Sponsor, error)
 	GetSubscription(ctx context.Context, id int64) (Subscription, error)
 	GetUserByEmail(ctx context.Context, email string) (User, error)
 	GetUserByID(ctx context.Context, id int64) (User, error)

--- a/internal/store/postgres/gen/queries.sql.go
+++ b/internal/store/postgres/gen/queries.sql.go
@@ -14,7 +14,7 @@ import (
 )
 
 const approveSponsor = `-- name: ApproveSponsor :one
-UPDATE sponsors SET status = 'approved', active = TRUE WHERE id = $1 RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status
+UPDATE sponsors SET status = 'approved', active = TRUE WHERE id = $1 RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status, is_system, tagline
 `
 
 func (q *Queries) ApproveSponsor(ctx context.Context, id string) (Sponsor, error) {
@@ -30,6 +30,8 @@ func (q *Queries) ApproveSponsor(ctx context.Context, id string) (Sponsor, error
 		&i.Active,
 		&i.CreatedAt,
 		&i.Status,
+		&i.IsSystem,
+		&i.Tagline,
 	)
 	return i, err
 }
@@ -169,12 +171,12 @@ const createSponsor = `-- name: CreateSponsor :one
 
 INSERT INTO sponsors (id, user_id, name, website_url, logo_url, tier)
 VALUES ($1, $2, $3, $4, $5, 'standard')
-RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status
+RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status, is_system, tagline
 `
 
 type CreateSponsorParams struct {
 	ID         string      `json:"id"`
-	UserID     int64       `json:"user_id"`
+	UserID     pgtype.Int8 `json:"user_id"`
 	Name       string      `json:"name"`
 	WebsiteUrl pgtype.Text `json:"website_url"`
 	LogoUrl    pgtype.Text `json:"logo_url"`
@@ -200,6 +202,8 @@ func (q *Queries) CreateSponsor(ctx context.Context, arg CreateSponsorParams) (S
 		&i.Active,
 		&i.CreatedAt,
 		&i.Status,
+		&i.IsSystem,
+		&i.Tagline,
 	)
 	return i, err
 }
@@ -426,7 +430,7 @@ func (q *Queries) GetProvider(ctx context.Context, id string) (Provider, error) 
 }
 
 const getSponsorByID = `-- name: GetSponsorByID :one
-SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status FROM sponsors WHERE id = $1
+SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status, is_system, tagline FROM sponsors WHERE id = $1
 `
 
 func (q *Queries) GetSponsorByID(ctx context.Context, id string) (Sponsor, error) {
@@ -442,15 +446,17 @@ func (q *Queries) GetSponsorByID(ctx context.Context, id string) (Sponsor, error
 		&i.Active,
 		&i.CreatedAt,
 		&i.Status,
+		&i.IsSystem,
+		&i.Tagline,
 	)
 	return i, err
 }
 
 const getSponsorByUserID = `-- name: GetSponsorByUserID :one
-SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status FROM sponsors WHERE user_id = $1
+SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status, is_system, tagline FROM sponsors WHERE user_id = $1
 `
 
-func (q *Queries) GetSponsorByUserID(ctx context.Context, userID int64) (Sponsor, error) {
+func (q *Queries) GetSponsorByUserID(ctx context.Context, userID pgtype.Int8) (Sponsor, error) {
 	row := q.db.QueryRow(ctx, getSponsorByUserID, userID)
 	var i Sponsor
 	err := row.Scan(
@@ -463,6 +469,8 @@ func (q *Queries) GetSponsorByUserID(ctx context.Context, userID int64) (Sponsor
 		&i.Active,
 		&i.CreatedAt,
 		&i.Status,
+		&i.IsSystem,
+		&i.Tagline,
 	)
 	return i, err
 }
@@ -702,7 +710,7 @@ func (q *Queries) ListActiveSponsorKeys(ctx context.Context) ([]SponsorKey, erro
 }
 
 const listActiveSponsors = `-- name: ListActiveSponsors :many
-SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status FROM sponsors WHERE status = 'approved' ORDER BY tier DESC, created_at ASC
+SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status, is_system, tagline FROM sponsors WHERE status = 'approved' ORDER BY tier DESC, created_at ASC
 `
 
 func (q *Queries) ListActiveSponsors(ctx context.Context) ([]Sponsor, error) {
@@ -724,6 +732,8 @@ func (q *Queries) ListActiveSponsors(ctx context.Context) ([]Sponsor, error) {
 			&i.Active,
 			&i.CreatedAt,
 			&i.Status,
+			&i.IsSystem,
+			&i.Tagline,
 		); err != nil {
 			return nil, err
 		}
@@ -1015,7 +1025,7 @@ func (q *Queries) ListModelsByProvider(ctx context.Context, providerID string) (
 }
 
 const listPendingSponsors = `-- name: ListPendingSponsors :many
-SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status FROM sponsors WHERE status = 'pending' ORDER BY created_at ASC
+SELECT id, user_id, name, website_url, logo_url, tier, active, created_at, status, is_system, tagline FROM sponsors WHERE status = 'pending' ORDER BY created_at ASC
 `
 
 func (q *Queries) ListPendingSponsors(ctx context.Context) ([]Sponsor, error) {
@@ -1037,6 +1047,8 @@ func (q *Queries) ListPendingSponsors(ctx context.Context) ([]Sponsor, error) {
 			&i.Active,
 			&i.CreatedAt,
 			&i.Status,
+			&i.IsSystem,
+			&i.Tagline,
 		); err != nil {
 			return nil, err
 		}
@@ -1404,7 +1416,7 @@ func (q *Queries) MarkUserVerified(ctx context.Context, id int64) error {
 }
 
 const rejectSponsor = `-- name: RejectSponsor :one
-UPDATE sponsors SET status = 'rejected', active = FALSE WHERE id = $1 RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status
+UPDATE sponsors SET status = 'rejected', active = FALSE WHERE id = $1 RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status, is_system, tagline
 `
 
 func (q *Queries) RejectSponsor(ctx context.Context, id string) (Sponsor, error) {
@@ -1420,6 +1432,8 @@ func (q *Queries) RejectSponsor(ctx context.Context, id string) (Sponsor, error)
 		&i.Active,
 		&i.CreatedAt,
 		&i.Status,
+		&i.IsSystem,
+		&i.Tagline,
 	)
 	return i, err
 }
@@ -1510,7 +1524,7 @@ const updateSponsor = `-- name: UpdateSponsor :one
 UPDATE sponsors
 SET name = $2, website_url = $3, logo_url = $4
 WHERE id = $1
-RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status
+RETURNING id, user_id, name, website_url, logo_url, tier, active, created_at, status, is_system, tagline
 `
 
 type UpdateSponsorParams struct {
@@ -1538,6 +1552,8 @@ func (q *Queries) UpdateSponsor(ctx context.Context, arg UpdateSponsorParams) (S
 		&i.Active,
 		&i.CreatedAt,
 		&i.Status,
+		&i.IsSystem,
+		&i.Tagline,
 	)
 	return i, err
 }

--- a/store/migrations/0018_system_sponsors.down.sql
+++ b/store/migrations/0018_system_sponsors.down.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+DELETE FROM sponsors WHERE created_at < '2026-04-26 00:00:00+00';
+
+ALTER TABLE sponsors DROP CONSTRAINT IF EXISTS sponsors_user_or_system;
+ALTER TABLE sponsors ALTER COLUMN user_id SET NOT NULL;
+
+ALTER TABLE sponsors DROP COLUMN IF EXISTS is_system;
+ALTER TABLE sponsors DROP COLUMN IF EXISTS tagline;
+
+ALTER TABLE sponsors DROP CONSTRAINT IF EXISTS sponsors_tier_check;
+ALTER TABLE sponsors ADD CONSTRAINT sponsors_tier_check
+    CHECK (tier IN ('founding', 'standard'));
+
+COMMIT;

--- a/store/migrations/0018_system_sponsors.up.sql
+++ b/store/migrations/0018_system_sponsors.up.sql
@@ -1,4 +1,4 @@
--- 0018_system_sponsors.sql — system-level sponsors and tier restructure (LLMS-XXX)
+-- 0018_system_sponsors.sql — system-level sponsors and tier restructure
 --
 -- Changes:
 --   1. user_id becomes nullable so system sponsors need no user account.

--- a/store/migrations/0018_system_sponsors.up.sql
+++ b/store/migrations/0018_system_sponsors.up.sql
@@ -1,0 +1,66 @@
+-- 0018_system_sponsors.sql — system-level sponsors and tier restructure (LLMS-XXX)
+--
+-- Changes:
+--   1. user_id becomes nullable so system sponsors need no user account.
+--   2. is_system flag prevents accidental deletion through normal flows.
+--   3. tagline TEXT for sponsor description shown on the sponsors page.
+--   4. tier constraint expanded to platinum / gold / silver (legacy values kept).
+--   5. Seeds three Platinum system sponsors (Gold/Silver shown as frontend placeholders when empty).
+
+BEGIN;
+
+-- Allow system sponsors to have no backing user account.
+ALTER TABLE sponsors ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE sponsors ADD COLUMN is_system BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE sponsors ADD COLUMN tagline    TEXT;
+ALTER TABLE sponsors ADD CONSTRAINT sponsors_user_or_system
+    CHECK (is_system = TRUE OR user_id IS NOT NULL);
+
+-- Expand tier vocabulary; keep 'founding'/'standard' for existing rows.
+ALTER TABLE sponsors DROP CONSTRAINT IF EXISTS sponsors_tier_check;
+ALTER TABLE sponsors ADD CONSTRAINT sponsors_tier_check
+    CHECK (tier IN ('platinum', 'gold', 'silver', 'founding', 'standard'));
+
+-- ── Platinum system sponsors ──────────────────────────────────────────────────
+
+INSERT INTO sponsors (id, user_id, name, website_url, logo_url, tagline, tier, active, status, is_system)
+VALUES
+    (
+        'soxai',
+        NULL,
+        'SoxAI',
+        'https://soxai.io',
+        'https://s3.llmstatus.io/sponsors/logo-1024-dark.png',
+        'Unified access to 40+ AI providers through a single OpenAI-compatible API. Built for teams that demand reliability, flexibility, and control.',
+        'platinum',
+        TRUE,
+        'approved',
+        TRUE
+    ),
+    (
+        'onedotnet',
+        NULL,
+        'OneDotNet',
+        'https://onedotnet.com',
+        'https://s3.llmstatus.io/sponsors/onedotnet-appicon-dark.png',
+        'AI-Powered Global Network Solutions',
+        'platinum',
+        TRUE,
+        'approved',
+        TRUE
+    ),
+    (
+        'fastsox',
+        NULL,
+        'FastSox',
+        'https://fastsox.com',
+        'https://s3.llmstatus.io/sponsors/app-icon-512.png',
+        'Secure VPN with Zero Trust architecture for individuals and enterprises. Military-grade encryption, global network, no-logs policy.',
+        'platinum',
+        TRUE,
+        'approved',
+        TRUE
+    )
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/web/app/sponsors/page.tsx
+++ b/web/app/sponsors/page.tsx
@@ -25,6 +25,14 @@ async function fetchSponsors(): Promise<Sponsor[]> {
   }
 }
 
+function safeHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
 const TIER_ORDER = ["platinum", "gold", "silver"] as const;
 type Tier = (typeof TIER_ORDER)[number];
 
@@ -36,15 +44,18 @@ const TIER_LABEL: Record<Tier, string> = {
 
 const TIER_ACCENT: Record<Tier, string> = {
   platinum: "var(--ink-100)",
-  gold: "#b8922e",
-  silver: "#7a8899",
+  gold: "var(--signal-amber)",
+  silver: "var(--ink-300)",
 };
+
+const KNOWN_TIERS = new Set<string>(TIER_ORDER);
 
 export default async function SponsorsPage() {
   const all = await fetchSponsors();
   const byTier = Object.fromEntries(
     TIER_ORDER.map((t) => [t, all.filter((s) => s.tier === t)])
   ) as Record<Tier, Sponsor[]>;
+  const legacy = all.filter((s) => !KNOWN_TIERS.has(s.tier));
 
   return (
     <main className="flex-1 mx-auto w-full max-w-3xl px-6 py-10">
@@ -61,6 +72,19 @@ export default async function SponsorsPage() {
           sponsors={byTier[tier]}
         />
       ))}
+
+      {legacy.length > 0 && (
+        <section className="mb-10">
+          <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-[var(--ink-400)]">
+            Partners
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {legacy.map((sp) => (
+              <SponsorCard key={sp.id} sponsor={sp} />
+            ))}
+          </div>
+        </section>
+      )}
 
       <div className="rounded-lg border border-[var(--signal-amber)] bg-[var(--canvas-raised)] p-6 mt-4">
         <h2 className="mb-2 text-base font-semibold text-[var(--ink-100)]">Become a Sponsor</h2>
@@ -81,16 +105,13 @@ export default async function SponsorsPage() {
 }
 
 function TierSection({ tier, sponsors }: { tier: Tier; sponsors: Sponsor[] }) {
-  const accent = TIER_ACCENT[tier];
-  const label = TIER_LABEL[tier];
-
   return (
     <section className="mb-10">
       <h2
         className="mb-4 text-xs font-semibold uppercase tracking-widest"
-        style={{ color: accent }}
+        style={{ color: TIER_ACCENT[tier] }}
       >
-        {label}
+        {TIER_LABEL[tier]}
       </h2>
 
       {sponsors.length > 0 ? (
@@ -120,6 +141,8 @@ function PlaceholderSlot({ tier }: { tier: Tier }) {
 }
 
 function SponsorCard({ sponsor }: { sponsor: Sponsor }) {
+  const hostname = sponsor.website_url ? safeHostname(sponsor.website_url) : null;
+
   const inner = (
     <div className="flex gap-4 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] p-4 hover:border-[var(--ink-400)] transition-colors h-full">
       {sponsor.logo_url ? (
@@ -136,9 +159,9 @@ function SponsorCard({ sponsor }: { sponsor: Sponsor }) {
       )}
       <div className="min-w-0">
         <p className="text-sm font-semibold text-[var(--ink-100)]">{sponsor.name}</p>
-        {sponsor.website_url && (
+        {hostname && (
           <p className="text-xs text-[var(--ink-500)] mt-0.5 truncate">
-            {new URL(sponsor.website_url).hostname}
+            {hostname}
           </p>
         )}
         {sponsor.tagline && (

--- a/web/app/sponsors/page.tsx
+++ b/web/app/sponsors/page.tsx
@@ -10,7 +10,9 @@ interface Sponsor {
   name: string;
   website_url?: string;
   logo_url?: string;
+  tagline?: string;
   tier: string;
+  is_system?: boolean;
 }
 
 async function fetchSponsors(): Promise<Sponsor[]> {
@@ -23,30 +25,44 @@ async function fetchSponsors(): Promise<Sponsor[]> {
   }
 }
 
+const TIER_ORDER = ["platinum", "gold", "silver"] as const;
+type Tier = (typeof TIER_ORDER)[number];
+
+const TIER_LABEL: Record<Tier, string> = {
+  platinum: "Platinum",
+  gold: "Gold",
+  silver: "Silver",
+};
+
+const TIER_ACCENT: Record<Tier, string> = {
+  platinum: "var(--ink-100)",
+  gold: "#b8922e",
+  silver: "#7a8899",
+};
+
 export default async function SponsorsPage() {
-  const sponsors = await fetchSponsors();
+  const all = await fetchSponsors();
+  const byTier = Object.fromEntries(
+    TIER_ORDER.map((t) => [t, all.filter((s) => s.tier === t)])
+  ) as Record<Tier, Sponsor[]>;
 
   return (
     <main className="flex-1 mx-auto w-full max-w-3xl px-6 py-10">
       <h1 className="mb-2 text-2xl font-semibold text-[var(--ink-100)]">Sponsors</h1>
-      <p className="mb-8 text-sm text-[var(--ink-400)]">
+      <p className="mb-10 text-sm text-[var(--ink-400)]">
         These organizations sponsor llmstatus.io, helping us run probes and keep the
         data freely accessible.
       </p>
 
-      {sponsors.length > 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
-          {sponsors.map((sp) => (
-            <SponsorCard key={sp.id} sponsor={sp} />
-          ))}
-        </div>
-      ) : (
-        <div className="mb-12 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] p-6 text-center">
-          <p className="text-sm text-[var(--ink-500)]">No sponsors yet — be the first!</p>
-        </div>
-      )}
+      {TIER_ORDER.map((tier) => (
+        <TierSection
+          key={tier}
+          tier={tier}
+          sponsors={byTier[tier]}
+        />
+      ))}
 
-      <div className="rounded-lg border border-[var(--signal-amber)] bg-[var(--canvas-raised)] p-6">
+      <div className="rounded-lg border border-[var(--signal-amber)] bg-[var(--canvas-raised)] p-6 mt-4">
         <h2 className="mb-2 text-base font-semibold text-[var(--ink-100)]">Become a Sponsor</h2>
         <p className="mb-4 text-sm text-[var(--ink-400)] leading-relaxed">
           Sponsoring gives your organization a listing here and lets you supply your own
@@ -64,26 +80,70 @@ export default async function SponsorsPage() {
   );
 }
 
+function TierSection({ tier, sponsors }: { tier: Tier; sponsors: Sponsor[] }) {
+  const accent = TIER_ACCENT[tier];
+  const label = TIER_LABEL[tier];
+
+  return (
+    <section className="mb-10">
+      <h2
+        className="mb-4 text-xs font-semibold uppercase tracking-widest"
+        style={{ color: accent }}
+      >
+        {label}
+      </h2>
+
+      {sponsors.length > 0 ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {sponsors.map((sp) => (
+            <SponsorCard key={sp.id} sponsor={sp} />
+          ))}
+        </div>
+      ) : (
+        <PlaceholderSlot tier={tier} />
+      )}
+    </section>
+  );
+}
+
+function PlaceholderSlot({ tier }: { tier: Tier }) {
+  return (
+    <div className="rounded-lg border border-dashed border-[var(--ink-600)] bg-[var(--canvas-raised)] p-5 text-center">
+      <p className="text-sm text-[var(--ink-500)]">
+        {TIER_LABEL[tier]} sponsor slot available —{" "}
+        <Link href="/sponsor/dashboard" className="underline underline-offset-2 hover:text-[var(--ink-300)] transition-colors">
+          get in touch
+        </Link>
+      </p>
+    </div>
+  );
+}
+
 function SponsorCard({ sponsor }: { sponsor: Sponsor }) {
   const inner = (
-    <div className="flex items-center gap-4 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] p-4 hover:border-[var(--ink-400)] transition-colors">
+    <div className="flex gap-4 rounded-lg border border-[var(--ink-600)] bg-[var(--canvas-raised)] p-4 hover:border-[var(--ink-400)] transition-colors h-full">
       {sponsor.logo_url ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={sponsor.logo_url}
           alt={`${sponsor.name} logo`}
-          className="h-10 w-10 rounded object-contain bg-[var(--canvas)]"
+          className="h-12 w-12 shrink-0 rounded object-contain bg-[var(--canvas)]"
         />
       ) : (
-        <div className="h-10 w-10 rounded bg-[var(--ink-600)] flex items-center justify-center text-xs font-bold text-[var(--ink-300)]">
+        <div className="h-12 w-12 shrink-0 rounded bg-[var(--ink-600)] flex items-center justify-center text-xs font-bold text-[var(--ink-300)]">
           {sponsor.name.slice(0, 2).toUpperCase()}
         </div>
       )}
-      <div>
-        <p className="text-sm font-medium text-[var(--ink-100)]">{sponsor.name}</p>
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-[var(--ink-100)]">{sponsor.name}</p>
         {sponsor.website_url && (
-          <p className="text-xs text-[var(--ink-500)] mt-0.5 truncate max-w-48">
+          <p className="text-xs text-[var(--ink-500)] mt-0.5 truncate">
             {new URL(sponsor.website_url).hostname}
+          </p>
+        )}
+        {sponsor.tagline && (
+          <p className="text-xs text-[var(--ink-400)] mt-1.5 leading-relaxed line-clamp-3">
+            {sponsor.tagline}
           </p>
         )}
       </div>
@@ -92,7 +152,7 @@ function SponsorCard({ sponsor }: { sponsor: Sponsor }) {
 
   if (sponsor.website_url) {
     return (
-      <a href={sponsor.website_url} target="_blank" rel="noopener noreferrer">
+      <a href={sponsor.website_url} target="_blank" rel="noopener noreferrer" className="flex">
         {inner}
       </a>
     );


### PR DESCRIPTION
## Summary

- **Migration 0018**: adds `is_system` + `tagline` columns to `sponsors`; expands tier constraint to `platinum/gold/silver`; makes `user_id` nullable for system rows; seeds SoxAI, OneDotNet, FastSox as Platinum system sponsors
- **Sponsors page**: grouped by tier (Platinum → Gold → Silver) with per-tier placeholder slots and tagline display
- **API**: `GET /v1/sponsors` now returns `tagline` and `is_system`; admin approve/reject skips email for system sponsors (no `user_id`)
- **Probe interval**: default changed from 60s → 300s across `runner.go`, `cmd/prober/main.go`, `docker-compose.yml`, `.env.example` (~5× token cost reduction)

## Migration notes

- Down migration deletes sponsors with `created_at < '2026-04-26 00:00:00+00'` (today's system seeds only; future user sponsors preserved)
- Production: clear existing test sponsor data before deploying, then run `migrate up`

## Test plan

- [ ] `go build ./...` passes
- [ ] `sqlc generate` output matches committed gen files
- [ ] `docker compose run --rm migrate` applies 0018 cleanly on a fresh DB
- [ ] `GET /v1/sponsors` returns 3 platinum sponsors with tagline and is_system=true
- [ ] Sponsors page renders Platinum section with 3 cards; Gold/Silver show placeholder slots
- [ ] Prober starts with 300s interval in logs