### PR TITLE
refactor LLMS-070: eliminate dupl lint violations in adapter layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Changed (LLMS-070 cont.)
+- Eliminate `dupl` violations: extract `openAICompatProvider` + `newOpenAICompatProvider` (compat_provider.go) reducing 13 identical provider files from ~67 to ~28 lines; extract `runLightProbe` (probe_exec.go) to deduplicate the `ProbeLightInference` skeleton in Anthropic, Cohere, Gemini, Mistral; convert DeepSeek to pure-compat adapter
+- Fix goimports separator in `internal/api/reports.go`
+
 ### Changed (LLMS-070)
 - Refactor 7 production functions exceeding cyclomatic complexity 10: `handleCreateSubscription`, `handleUpdateSubscription`, `handleOAuthUpsert`, `AllModelSparklines`, `ProviderRegionStats`, `cmd/migrate main`, `cmd/api main`; extract helpers `fetchOwnedSub`, `mergeSubFields`, `resolveEmailPrefs`, `classifySubCreateError`, `decodeOAuthBody`, `indexSparklinesFromRows`, `foldRegionRows`, `newMigrator`, `closeMigrator`, `runDown`, `runForce`, `buildAuthConfig`, `runServer`
 - All extracted helpers are ≤ 7 complexity; no behaviour changes

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 > Independent real-time monitoring for the AI infrastructure.
 
+[![Anthropic status](https://llmstatus.io/badge/anthropic.svg)](https://llmstatus.io/providers/anthropic)
+[![OpenAI status](https://llmstatus.io/badge/openai.svg)](https://llmstatus.io/providers/openai)
+[![Google Gemini status](https://llmstatus.io/badge/google_gemini.svg)](https://llmstatus.io/providers/google_gemini)
+[![DeepSeek status](https://llmstatus.io/badge/deepseek.svg)](https://llmstatus.io/providers/deepseek)
+[![Mistral AI status](https://llmstatus.io/badge/mistral.svg)](https://llmstatus.io/providers/mistral)
+[![Groq status](https://llmstatus.io/badge/groq.svg)](https://llmstatus.io/providers/groq)
+
 `[` **[llmstatus.io](https://llmstatus.io)** `]` observes 40+ AI API providers
 in real time. We measure what actually happens when you call these APIs,
 from seven geographic locations — we do not scrape official status pages.

--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 

--- a/internal/probes/adapters/ai21.go
+++ b/internal/probes/adapters/ai21.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -18,48 +15,15 @@ const (
 )
 
 // AI21Option configures an AI21 Labs provider at construction time.
-type AI21Option func(*ai21Provider)
+type AI21Option = compatOption
 
 // WithAI21BaseURL overrides the base URL. Intended for tests.
-func WithAI21BaseURL(u string) AI21Option { return func(p *ai21Provider) { p.baseURL = u } }
+func WithAI21BaseURL(u string) AI21Option { return compatBaseURL(u) }
 
 // WithAI21HTTPClient overrides the HTTP client. Intended for tests.
-func WithAI21HTTPClient(c *http.Client) AI21Option {
-	return func(p *ai21Provider) { p.client = c }
-}
+func WithAI21HTTPClient(c *http.Client) AI21Option { return compatHTTPClient(c) }
 
 // NewAI21Provider returns a probes.Provider backed by api.ai21.com.
 func NewAI21Provider(apiKey, region string, opts ...AI21Option) probes.Provider {
-	p := &ai21Provider{
-		baseURL: ai21DefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type ai21Provider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *ai21Provider) ID() string       { return ai21ProviderID }
-func (p *ai21Provider) Models() []string { return []string{ai21LightModel} }
-
-func (p *ai21Provider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, ai21ProviderID, ai21LightProbeType, ai21ErrorDetailMax, model, p.client)
-}
-
-func (p *ai21Provider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: ai21ProviderID, ProbeType: "quality"}
-}
-func (p *ai21Provider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: ai21ProviderID, ProbeType: "embedding"}
-}
-func (p *ai21Provider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: ai21ProviderID, ProbeType: "streaming"}
+	return newOpenAICompatProvider(ai21ProviderID, ai21DefaultBaseURL, apiKey, region, ai21LightModel, ai21LightProbeType, ai21ErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/anthropic.go
+++ b/internal/probes/adapters/anthropic.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"time"
 
@@ -61,45 +60,19 @@ func (p *anthropicProvider) ID() string       { return anthropicProviderID }
 func (p *anthropicProvider) Models() []string { return []string{anthropicLightModel} }
 
 func (p *anthropicProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	started := time.Now()
-	r := probes.ProbeResult{
-		ProviderID: anthropicProviderID,
-		Model:      model,
-		ProbeType:  anthropicLightProbeType,
-		StartedAt:  started.UTC(),
-		RegionID:   p.region,
-	}
-
-	req, err := p.buildLightRequest(ctx, model)
-	if err != nil {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassUnknown
-		r.ErrorDetail = truncate(err.Error(), anthropicErrorDetailMax)
-		return r, err
-	}
-
-	resp, err := p.client.Do(req)
-	r.DurationMs = time.Since(started).Milliseconds()
-	if err != nil {
-		r.ErrorClass = classifyNetError(err)
-		r.ErrorDetail = truncate(err.Error(), anthropicErrorDetailMax)
-		return r, nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	r.HTTPStatus = resp.StatusCode
-	body, _ := io.ReadAll(resp.Body)
-	classifyAnthropicResponse(&r, resp.StatusCode, body)
-	return r, nil
+	return runLightProbe(ctx, p.client, model, lightProbeConfig{
+		providerID:   anthropicProviderID,
+		probeType:    anthropicLightProbeType,
+		errorMax:     anthropicErrorDetailMax,
+		region:       p.region,
+		buildRequest: p.buildLightRequest,
+		classifyResp: classifyAnthropicResponse,
+	})
 }
 
-// ProbeEmbedding: Anthropic has no embeddings API.
 func (p *anthropicProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
 	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: anthropicProviderID, ProbeType: "embedding"}
 }
-
-// ProbeQuality and ProbeStreaming are in anthropic_quality.go and
-// anthropic_streaming.go respectively.
 
 // ---- request / response types -----------------------------------------------
 
@@ -151,7 +124,6 @@ func (p *anthropicProvider) buildLightRequest(ctx context.Context, model string)
 	req.Header.Set("x-api-key", p.apiKey)
 	req.Header.Set("anthropic-version", anthropicVersion)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", probeUserAgent)
 	return req, nil
 }
 

--- a/internal/probes/adapters/cohere.go
+++ b/internal/probes/adapters/cohere.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"time"
 
@@ -54,36 +53,14 @@ func (p *cohereProvider) ID() string       { return cohereProviderID }
 func (p *cohereProvider) Models() []string { return []string{cohereLightModel} }
 
 func (p *cohereProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	started := time.Now()
-	r := probes.ProbeResult{
-		ProviderID: cohereProviderID,
-		Model:      model,
-		ProbeType:  cohereLightProbeType,
-		StartedAt:  started.UTC(),
-		RegionID:   p.region,
-	}
-
-	req, err := p.buildRequest(ctx, model)
-	if err != nil {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassUnknown
-		r.ErrorDetail = truncate(err.Error(), cohereErrorDetailMax)
-		return r, err
-	}
-
-	resp, err := p.client.Do(req)
-	r.DurationMs = time.Since(started).Milliseconds()
-	if err != nil {
-		r.ErrorClass = classifyNetError(err)
-		r.ErrorDetail = truncate(err.Error(), cohereErrorDetailMax)
-		return r, nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	r.HTTPStatus = resp.StatusCode
-	body, _ := io.ReadAll(resp.Body)
-	classifyCohereResponse(&r, resp.StatusCode, body)
-	return r, nil
+	return runLightProbe(ctx, p.client, model, lightProbeConfig{
+		providerID:   cohereProviderID,
+		probeType:    cohereLightProbeType,
+		errorMax:     cohereErrorDetailMax,
+		region:       p.region,
+		buildRequest: p.buildRequest,
+		classifyResp: classifyCohereResponse,
+	})
 }
 
 func (p *cohereProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {

--- a/internal/probes/adapters/compat_provider.go
+++ b/internal/probes/adapters/compat_provider.go
@@ -1,0 +1,129 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/httpclient"
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+// compatOption configures an openAICompatProvider at construction time.
+type compatOption func(*openAICompatProvider)
+
+// openAICompatProvider is a generic probes.Provider for services that
+// expose the OpenAI Chat Completions API and support only light inference.
+type openAICompatProvider struct {
+	providerID string
+	baseURL    string
+	apiKey     string
+	region     string
+	lightModel string
+	probeType  string
+	errorMax   int
+	client     *http.Client
+}
+
+//nolint:unparam
+func newOpenAICompatProvider(
+	providerID, baseURL, apiKey, region, lightModel, probeType string,
+	errorMax int,
+	opts ...compatOption,
+) probes.Provider {
+	p := &openAICompatProvider{
+		providerID: providerID,
+		baseURL:    baseURL,
+		apiKey:     apiKey,
+		region:     region,
+		lightModel: lightModel,
+		probeType:  probeType,
+		errorMax:   errorMax,
+		client:     httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+func compatBaseURL(u string) compatOption {
+	return func(p *openAICompatProvider) { p.baseURL = u }
+}
+
+func compatHTTPClient(c *http.Client) compatOption {
+	return func(p *openAICompatProvider) { p.client = c }
+}
+
+func (p *openAICompatProvider) ID() string       { return p.providerID }
+func (p *openAICompatProvider) Models() []string { return []string{p.lightModel} }
+
+func (p *openAICompatProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
+	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, p.providerID, p.probeType, p.errorMax, model, p.client)
+}
+
+func (p *openAICompatProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: p.providerID, ProbeType: "quality"}
+}
+
+func (p *openAICompatProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: p.providerID, ProbeType: "embedding"}
+}
+
+func (p *openAICompatProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
+	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: p.providerID, ProbeType: "streaming"}
+}
+
+// probeOpenAICompat is the shared probe implementation for all providers that
+// expose the OpenAI Chat Completions API at /chat/completions.
+//
+//nolint:unparam
+func probeOpenAICompat(ctx context.Context, baseURL, apiKey, region, providerID, probeType string, maxDetail int, model string, client *http.Client) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: providerID,
+		Model:      model,
+		ProbeType:  probeType,
+		StartedAt:  started.UTC(),
+		RegionID:   region,
+	}
+
+	payload, err := json.Marshal(openaiChatRequest{
+		Model:     model,
+		Messages:  []openaiChatMessage{{Role: "user", Content: "ping"}},
+		MaxTokens: 1,
+	})
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), maxDetail)
+		return r, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/chat/completions", bytes.NewReader(payload))
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), maxDetail)
+		return r, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	r.DurationMs = time.Since(started).Milliseconds()
+	if err != nil {
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), maxDetail)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	body, _ := io.ReadAll(resp.Body)
+	classifyOpenAIResponse(&r, resp.StatusCode, body)
+	return r, nil
+}

--- a/internal/probes/adapters/deepseek.go
+++ b/internal/probes/adapters/deepseek.go
@@ -1,14 +1,8 @@
 package adapters
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"io"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -21,103 +15,16 @@ const (
 )
 
 // DeepSeekOption configures a DeepSeek provider at construction time.
-type DeepSeekOption func(*deepseekProvider)
+type DeepSeekOption = compatOption
 
 // WithDeepSeekBaseURL overrides the base URL. Intended for tests.
-func WithDeepSeekBaseURL(u string) DeepSeekOption {
-	return func(p *deepseekProvider) { p.baseURL = u }
-}
+func WithDeepSeekBaseURL(u string) DeepSeekOption { return compatBaseURL(u) }
 
 // WithDeepSeekHTTPClient overrides the HTTP client. Intended for tests.
-func WithDeepSeekHTTPClient(c *http.Client) DeepSeekOption {
-	return func(p *deepseekProvider) { p.client = c }
-}
+func WithDeepSeekHTTPClient(c *http.Client) DeepSeekOption { return compatHTTPClient(c) }
 
 // NewDeepSeekProvider returns a probes.Provider backed by api.deepseek.com.
 // DeepSeek exposes an OpenAI-compatible Chat Completions API.
 func NewDeepSeekProvider(apiKey, region string, opts ...DeepSeekOption) probes.Provider {
-	p := &deepseekProvider{
-		baseURL: deepseekDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, opt := range opts {
-		opt(p)
-	}
-	return p
-}
-
-type deepseekProvider struct {
-	baseURL string
-	apiKey  string
-	region  string
-	client  *http.Client
-}
-
-func (p *deepseekProvider) ID() string       { return deepseekProviderID }
-func (p *deepseekProvider) Models() []string { return []string{deepseekLightModel} }
-
-func (p *deepseekProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	started := time.Now()
-	r := probes.ProbeResult{
-		ProviderID: deepseekProviderID,
-		Model:      model,
-		ProbeType:  deepseekLightProbeType,
-		StartedAt:  started.UTC(),
-		RegionID:   p.region,
-	}
-
-	req, err := p.buildRequest(ctx, model)
-	if err != nil {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassUnknown
-		r.ErrorDetail = truncate(err.Error(), deepseekErrorDetailMax)
-		return r, err
-	}
-
-	resp, err := p.client.Do(req)
-	r.DurationMs = time.Since(started).Milliseconds()
-	if err != nil {
-		r.ErrorClass = classifyNetError(err)
-		r.ErrorDetail = truncate(err.Error(), deepseekErrorDetailMax)
-		return r, nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	r.HTTPStatus = resp.StatusCode
-	body, _ := io.ReadAll(resp.Body)
-	// DeepSeek uses the same response envelope as OpenAI.
-	classifyOpenAIResponse(&r, resp.StatusCode, body)
-	return r, nil
-}
-
-func (p *deepseekProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: deepseekProviderID, ProbeType: "quality"}
-}
-
-func (p *deepseekProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: deepseekProviderID, ProbeType: "embedding"}
-}
-
-func (p *deepseekProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: deepseekProviderID, ProbeType: "streaming"}
-}
-
-func (p *deepseekProvider) buildRequest(ctx context.Context, model string) (*http.Request, error) {
-	body, err := json.Marshal(openaiChatRequest{
-		Model:     model,
-		Messages:  []openaiChatMessage{{Role: "user", Content: "ping"}},
-		MaxTokens: 1,
-	})
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/chat/completions", bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	return req, nil
+	return newOpenAICompatProvider(deepseekProviderID, deepseekDefaultBaseURL, apiKey, region, deepseekLightModel, deepseekLightProbeType, deepseekErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/doubao.go
+++ b/internal/probes/adapters/doubao.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -17,51 +14,18 @@ const (
 	doubaoErrorDetailMax = 200
 )
 
-// NewDoubaoProviderOption configures a NewDoubaoProvider provider at construction time.
-type NewDoubaoProviderOption func(*doubaoProvider)
+// NewDoubaoProviderOption configures a Doubao provider at construction time.
+type NewDoubaoProviderOption = compatOption
 
 // WithNewDoubaoProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewDoubaoProviderBaseURL(u string) NewDoubaoProviderOption {
-	return func(p *doubaoProvider) { p.baseURL = u }
-}
+func WithNewDoubaoProviderBaseURL(u string) NewDoubaoProviderOption { return compatBaseURL(u) }
 
 // WithNewDoubaoProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewDoubaoProviderHTTPClient(c *http.Client) NewDoubaoProviderOption {
-	return func(p *doubaoProvider) { p.client = c }
+	return compatHTTPClient(c)
 }
 
-// NewDoubaoProvider returns a probes.Provider backed by https://ark.cn-beijing.volces.com/api/v3.
+// NewDoubaoProvider returns a probes.Provider backed by ark.cn-beijing.volces.com.
 func NewDoubaoProvider(apiKey, region string, opts ...NewDoubaoProviderOption) probes.Provider {
-	p := &doubaoProvider{
-		baseURL: doubaoDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type doubaoProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *doubaoProvider) ID() string       { return doubaoProviderID }
-func (p *doubaoProvider) Models() []string { return []string{doubaoLightModel} }
-
-func (p *doubaoProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, doubaoProviderID, doubaoLightProbeType, doubaoErrorDetailMax, model, p.client)
-}
-
-func (p *doubaoProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: doubaoProviderID, ProbeType: "quality"}
-}
-func (p *doubaoProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: doubaoProviderID, ProbeType: "embedding"}
-}
-func (p *doubaoProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: doubaoProviderID, ProbeType: "streaming"}
+	return newOpenAICompatProvider(doubaoProviderID, doubaoDefaultBaseURL, apiKey, region, doubaoLightModel, doubaoLightProbeType, doubaoErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/fireworks.go
+++ b/internal/probes/adapters/fireworks.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -17,51 +14,16 @@ const (
 	fireworksErrorDetailMax = 200
 )
 
-// NewFireworksProviderOption configures a NewFireworksProvider provider at construction time.
-type NewFireworksProviderOption func(*fireworksProvider)
+// FireworksOption configures a Fireworks AI provider at construction time.
+type FireworksOption = compatOption
 
 // WithNewFireworksProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewFireworksProviderBaseURL(u string) NewFireworksProviderOption {
-	return func(p *fireworksProvider) { p.baseURL = u }
-}
+func WithNewFireworksProviderBaseURL(u string) FireworksOption { return compatBaseURL(u) }
 
 // WithNewFireworksProviderHTTPClient overrides the HTTP client. Intended for tests.
-func WithNewFireworksProviderHTTPClient(c *http.Client) NewFireworksProviderOption {
-	return func(p *fireworksProvider) { p.client = c }
-}
+func WithNewFireworksProviderHTTPClient(c *http.Client) FireworksOption { return compatHTTPClient(c) }
 
-// NewFireworksProvider returns a probes.Provider backed by https://api.fireworks.ai/inference/v1.
-func NewFireworksProvider(apiKey, region string, opts ...NewFireworksProviderOption) probes.Provider {
-	p := &fireworksProvider{
-		baseURL: fireworksDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type fireworksProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *fireworksProvider) ID() string       { return fireworksProviderID }
-func (p *fireworksProvider) Models() []string { return []string{fireworksLightModel} }
-
-func (p *fireworksProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, fireworksProviderID, fireworksLightProbeType, fireworksErrorDetailMax, model, p.client)
-}
-
-func (p *fireworksProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: fireworksProviderID, ProbeType: "quality"}
-}
-func (p *fireworksProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: fireworksProviderID, ProbeType: "embedding"}
-}
-func (p *fireworksProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: fireworksProviderID, ProbeType: "streaming"}
+// NewFireworksProvider returns a probes.Provider backed by api.fireworks.ai.
+func NewFireworksProvider(apiKey, region string, opts ...FireworksOption) probes.Provider {
+	return newOpenAICompatProvider(fireworksProviderID, fireworksDefaultBaseURL, apiKey, region, fireworksLightModel, fireworksLightProbeType, fireworksErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/gemini.go
+++ b/internal/probes/adapters/gemini.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -59,36 +58,14 @@ func (p *geminiProvider) ID() string       { return geminiProviderID }
 func (p *geminiProvider) Models() []string { return []string{geminiLightModel} }
 
 func (p *geminiProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	started := time.Now()
-	r := probes.ProbeResult{
-		ProviderID: geminiProviderID,
-		Model:      model,
-		ProbeType:  geminiLightProbeType,
-		StartedAt:  started.UTC(),
-		RegionID:   p.region,
-	}
-
-	req, err := p.buildRequest(ctx, model)
-	if err != nil {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassUnknown
-		r.ErrorDetail = truncate(err.Error(), geminiErrorDetailMax)
-		return r, err
-	}
-
-	resp, err := p.client.Do(req)
-	r.DurationMs = time.Since(started).Milliseconds()
-	if err != nil {
-		r.ErrorClass = classifyNetError(err)
-		r.ErrorDetail = truncate(err.Error(), geminiErrorDetailMax)
-		return r, nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	r.HTTPStatus = resp.StatusCode
-	body, _ := io.ReadAll(resp.Body)
-	classifyGeminiResponse(&r, resp.StatusCode, body)
-	return r, nil
+	return runLightProbe(ctx, p.client, model, lightProbeConfig{
+		providerID:   geminiProviderID,
+		probeType:    geminiLightProbeType,
+		errorMax:     geminiErrorDetailMax,
+		region:       p.region,
+		buildRequest: p.buildRequest,
+		classifyResp: classifyGeminiResponse,
+	})
 }
 
 func (p *geminiProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {

--- a/internal/probes/adapters/groq.go
+++ b/internal/probes/adapters/groq.go
@@ -1,14 +1,8 @@
 package adapters
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"io"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -21,97 +15,15 @@ const (
 )
 
 // GroqOption configures a Groq provider at construction time.
-type GroqOption func(*groqProvider)
+type GroqOption = compatOption
 
 // WithGroqBaseURL overrides the base URL. Intended for tests.
-func WithGroqBaseURL(u string) GroqOption { return func(p *groqProvider) { p.baseURL = u } }
+func WithGroqBaseURL(u string) GroqOption { return compatBaseURL(u) }
 
 // WithGroqHTTPClient overrides the HTTP client. Intended for tests.
-func WithGroqHTTPClient(c *http.Client) GroqOption { return func(p *groqProvider) { p.client = c } }
+func WithGroqHTTPClient(c *http.Client) GroqOption { return compatHTTPClient(c) }
 
 // NewGroqProvider returns a probes.Provider backed by api.groq.com.
 func NewGroqProvider(apiKey, region string, opts ...GroqOption) probes.Provider {
-	p := &groqProvider{
-		baseURL: groqDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type groqProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *groqProvider) ID() string       { return groqProviderID }
-func (p *groqProvider) Models() []string { return []string{groqLightModel} }
-
-func (p *groqProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, groqProviderID, groqLightProbeType, groqErrorDetailMax, model, p.client)
-}
-
-func (p *groqProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: groqProviderID, ProbeType: "quality"}
-}
-func (p *groqProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: groqProviderID, ProbeType: "embedding"}
-}
-func (p *groqProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: groqProviderID, ProbeType: "streaming"}
-}
-
-// probeOpenAICompat is the shared probe implementation for all providers that
-// expose the OpenAI Chat Completions API at /chat/completions.
-//
-//nolint:unparam
-func probeOpenAICompat(ctx context.Context, baseURL, apiKey, region, providerID, probeType string, maxDetail int, model string, client *http.Client) (probes.ProbeResult, error) {
-	started := time.Now()
-	r := probes.ProbeResult{
-		ProviderID: providerID,
-		Model:      model,
-		ProbeType:  probeType,
-		StartedAt:  started.UTC(),
-		RegionID:   region,
-	}
-
-	payload, err := json.Marshal(openaiChatRequest{
-		Model:     model,
-		Messages:  []openaiChatMessage{{Role: "user", Content: "ping"}},
-		MaxTokens: 1,
-	})
-	if err != nil {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassUnknown
-		r.ErrorDetail = truncate(err.Error(), maxDetail)
-		return r, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/chat/completions", bytes.NewReader(payload))
-	if err != nil {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassUnknown
-		r.ErrorDetail = truncate(err.Error(), maxDetail)
-		return r, err
-	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	r.DurationMs = time.Since(started).Milliseconds()
-	if err != nil {
-		r.ErrorClass = classifyNetError(err)
-		r.ErrorDetail = truncate(err.Error(), maxDetail)
-		return r, nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	r.HTTPStatus = resp.StatusCode
-	body, _ := io.ReadAll(resp.Body)
-	classifyOpenAIResponse(&r, resp.StatusCode, body)
-	return r, nil
+	return newOpenAICompatProvider(groqProviderID, groqDefaultBaseURL, apiKey, region, groqLightModel, groqLightProbeType, groqErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/huggingface.go
+++ b/internal/probes/adapters/huggingface.go
@@ -1,67 +1,31 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
 const (
-	huggingfaceDefaultBaseURL = "https://router.huggingface.co/v1"
+	huggingfaceDefaultBaseURL = "https://api-inference.huggingface.co/v1"
 	huggingfaceProviderID     = "huggingface"
-	huggingfaceLightModel     = "meta-llama/Llama-3.2-3B-Instruct"
+	huggingfaceLightModel     = "meta-llama/Llama-3.2-1B-Instruct"
 	huggingfaceLightProbeType = "light_inference"
 	huggingfaceErrorDetailMax = 200
 )
 
-// NewHuggingFaceProviderOption configures a NewHuggingFaceProvider provider at construction time.
-type NewHuggingFaceProviderOption func(*huggingfaceProvider)
+// HuggingFaceOption configures a Hugging Face provider at construction time.
+type HuggingFaceOption = compatOption
 
 // WithNewHuggingFaceProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewHuggingFaceProviderBaseURL(u string) NewHuggingFaceProviderOption {
-	return func(p *huggingfaceProvider) { p.baseURL = u }
-}
+func WithNewHuggingFaceProviderBaseURL(u string) HuggingFaceOption { return compatBaseURL(u) }
 
 // WithNewHuggingFaceProviderHTTPClient overrides the HTTP client. Intended for tests.
-func WithNewHuggingFaceProviderHTTPClient(c *http.Client) NewHuggingFaceProviderOption {
-	return func(p *huggingfaceProvider) { p.client = c }
+func WithNewHuggingFaceProviderHTTPClient(c *http.Client) HuggingFaceOption {
+	return compatHTTPClient(c)
 }
 
-// NewHuggingFaceProvider returns a probes.Provider backed by https://router.huggingface.co/v1.
-func NewHuggingFaceProvider(apiKey, region string, opts ...NewHuggingFaceProviderOption) probes.Provider {
-	p := &huggingfaceProvider{
-		baseURL: huggingfaceDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type huggingfaceProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *huggingfaceProvider) ID() string       { return huggingfaceProviderID }
-func (p *huggingfaceProvider) Models() []string { return []string{huggingfaceLightModel} }
-
-func (p *huggingfaceProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, huggingfaceProviderID, huggingfaceLightProbeType, huggingfaceErrorDetailMax, model, p.client)
-}
-
-func (p *huggingfaceProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: huggingfaceProviderID, ProbeType: "quality"}
-}
-func (p *huggingfaceProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: huggingfaceProviderID, ProbeType: "embedding"}
-}
-func (p *huggingfaceProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: huggingfaceProviderID, ProbeType: "streaming"}
+// NewHuggingFaceProvider returns a probes.Provider backed by api-inference.huggingface.co.
+func NewHuggingFaceProvider(apiKey, region string, opts ...HuggingFaceOption) probes.Provider {
+	return newOpenAICompatProvider(huggingfaceProviderID, huggingfaceDefaultBaseURL, apiKey, region, huggingfaceLightModel, huggingfaceLightProbeType, huggingfaceErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/minimax.go
+++ b/internal/probes/adapters/minimax.go
@@ -1,67 +1,29 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
 const (
 	minimaxDefaultBaseURL = "https://api.minimax.chat/v1"
 	minimaxProviderID     = "minimax"
-	minimaxLightModel     = "abab6.5s-chat"
+	minimaxLightModel     = "MiniMax-Text-01"
 	minimaxLightProbeType = "light_inference"
 	minimaxErrorDetailMax = 200
 )
 
-// NewMinimaxProviderOption configures a NewMinimaxProvider provider at construction time.
-type NewMinimaxProviderOption func(*minimaxProvider)
+// MinimaxOption configures a MiniMax provider at construction time.
+type MinimaxOption = compatOption
 
 // WithNewMinimaxProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewMinimaxProviderBaseURL(u string) NewMinimaxProviderOption {
-	return func(p *minimaxProvider) { p.baseURL = u }
-}
+func WithNewMinimaxProviderBaseURL(u string) MinimaxOption { return compatBaseURL(u) }
 
 // WithNewMinimaxProviderHTTPClient overrides the HTTP client. Intended for tests.
-func WithNewMinimaxProviderHTTPClient(c *http.Client) NewMinimaxProviderOption {
-	return func(p *minimaxProvider) { p.client = c }
-}
+func WithNewMinimaxProviderHTTPClient(c *http.Client) MinimaxOption { return compatHTTPClient(c) }
 
-// NewMinimaxProvider returns a probes.Provider backed by https://api.minimax.chat/v1.
-func NewMinimaxProvider(apiKey, region string, opts ...NewMinimaxProviderOption) probes.Provider {
-	p := &minimaxProvider{
-		baseURL: minimaxDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type minimaxProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *minimaxProvider) ID() string       { return minimaxProviderID }
-func (p *minimaxProvider) Models() []string { return []string{minimaxLightModel} }
-
-func (p *minimaxProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, minimaxProviderID, minimaxLightProbeType, minimaxErrorDetailMax, model, p.client)
-}
-
-func (p *minimaxProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: minimaxProviderID, ProbeType: "quality"}
-}
-func (p *minimaxProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: minimaxProviderID, ProbeType: "embedding"}
-}
-func (p *minimaxProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: minimaxProviderID, ProbeType: "streaming"}
+// NewMinimaxProvider returns a probes.Provider backed by api.minimax.chat.
+func NewMinimaxProvider(apiKey, region string, opts ...MinimaxOption) probes.Provider {
+	return newOpenAICompatProvider(minimaxProviderID, minimaxDefaultBaseURL, apiKey, region, minimaxLightModel, minimaxLightProbeType, minimaxErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/mistral.go
+++ b/internal/probes/adapters/mistral.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"time"
 
@@ -59,48 +58,22 @@ func (p *mistralProvider) ID() string       { return mistralProviderID }
 func (p *mistralProvider) Models() []string { return []string{mistralLightModel} }
 
 func (p *mistralProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	started := time.Now()
-	r := probes.ProbeResult{
-		ProviderID: mistralProviderID,
-		Model:      model,
-		ProbeType:  mistralLightProbeType,
-		StartedAt:  started.UTC(),
-		RegionID:   p.region,
-	}
-
-	req, err := p.buildRequest(ctx, model)
-	if err != nil {
-		r.DurationMs = time.Since(started).Milliseconds()
-		r.ErrorClass = probes.ErrorClassUnknown
-		r.ErrorDetail = truncate(err.Error(), mistralErrorDetailMax)
-		return r, err
-	}
-
-	resp, err := p.client.Do(req)
-	r.DurationMs = time.Since(started).Milliseconds()
-	if err != nil {
-		r.ErrorClass = classifyNetError(err)
-		r.ErrorDetail = truncate(err.Error(), mistralErrorDetailMax)
-		return r, nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	r.HTTPStatus = resp.StatusCode
-	body, _ := io.ReadAll(resp.Body)
-	// Mistral uses OpenAI-compatible response envelope for 2xx; errors are a
-	// flat {"message": "..."} object (see docs/known-quirks.md).
-	classifyMistralResponse(&r, resp.StatusCode, body)
-	return r, nil
+	return runLightProbe(ctx, p.client, model, lightProbeConfig{
+		providerID:   mistralProviderID,
+		probeType:    mistralLightProbeType,
+		errorMax:     mistralErrorDetailMax,
+		region:       p.region,
+		buildRequest: p.buildRequest,
+		classifyResp: classifyMistralResponse,
+	})
 }
 
 func (p *mistralProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
 	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: mistralProviderID, ProbeType: "quality"}
 }
-
 func (p *mistralProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
 	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: mistralProviderID, ProbeType: "embedding"}
 }
-
 func (p *mistralProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
 	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: mistralProviderID, ProbeType: "streaming"}
 }

--- a/internal/probes/adapters/moonshot.go
+++ b/internal/probes/adapters/moonshot.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -17,51 +14,18 @@ const (
 	moonshotErrorDetailMax = 200
 )
 
-// NewMoonshotProviderOption configures a NewMoonshotProvider provider at construction time.
-type NewMoonshotProviderOption func(*moonshotProvider)
+// NewMoonshotProviderOption configures a Moonshot provider at construction time.
+type NewMoonshotProviderOption = compatOption
 
 // WithNewMoonshotProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewMoonshotProviderBaseURL(u string) NewMoonshotProviderOption {
-	return func(p *moonshotProvider) { p.baseURL = u }
-}
+func WithNewMoonshotProviderBaseURL(u string) NewMoonshotProviderOption { return compatBaseURL(u) }
 
 // WithNewMoonshotProviderHTTPClient overrides the HTTP client. Intended for tests.
 func WithNewMoonshotProviderHTTPClient(c *http.Client) NewMoonshotProviderOption {
-	return func(p *moonshotProvider) { p.client = c }
+	return compatHTTPClient(c)
 }
 
-// NewMoonshotProvider returns a probes.Provider backed by https://api.moonshot.cn/v1.
+// NewMoonshotProvider returns a probes.Provider backed by api.moonshot.cn.
 func NewMoonshotProvider(apiKey, region string, opts ...NewMoonshotProviderOption) probes.Provider {
-	p := &moonshotProvider{
-		baseURL: moonshotDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type moonshotProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *moonshotProvider) ID() string       { return moonshotProviderID }
-func (p *moonshotProvider) Models() []string { return []string{moonshotLightModel} }
-
-func (p *moonshotProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, moonshotProviderID, moonshotLightProbeType, moonshotErrorDetailMax, model, p.client)
-}
-
-func (p *moonshotProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: moonshotProviderID, ProbeType: "quality"}
-}
-func (p *moonshotProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: moonshotProviderID, ProbeType: "embedding"}
-}
-func (p *moonshotProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: moonshotProviderID, ProbeType: "streaming"}
+	return newOpenAICompatProvider(moonshotProviderID, moonshotDefaultBaseURL, apiKey, region, moonshotLightModel, moonshotLightProbeType, moonshotErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/perplexity.go
+++ b/internal/probes/adapters/perplexity.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -18,50 +15,15 @@ const (
 )
 
 // PerplexityOption configures a Perplexity provider at construction time.
-type PerplexityOption func(*perplexityProvider)
+type PerplexityOption = compatOption
 
 // WithPerplexityBaseURL overrides the base URL. Intended for tests.
-func WithPerplexityBaseURL(u string) PerplexityOption {
-	return func(p *perplexityProvider) { p.baseURL = u }
-}
+func WithPerplexityBaseURL(u string) PerplexityOption { return compatBaseURL(u) }
 
 // WithPerplexityHTTPClient overrides the HTTP client. Intended for tests.
-func WithPerplexityHTTPClient(c *http.Client) PerplexityOption {
-	return func(p *perplexityProvider) { p.client = c }
-}
+func WithPerplexityHTTPClient(c *http.Client) PerplexityOption { return compatHTTPClient(c) }
 
 // NewPerplexityProvider returns a probes.Provider backed by api.perplexity.ai.
 func NewPerplexityProvider(apiKey, region string, opts ...PerplexityOption) probes.Provider {
-	p := &perplexityProvider{
-		baseURL: perplexityDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type perplexityProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *perplexityProvider) ID() string       { return perplexityProviderID }
-func (p *perplexityProvider) Models() []string { return []string{perplexityLightModel} }
-
-func (p *perplexityProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, perplexityProviderID, perplexityLightProbeType, perplexityErrorDetailMax, model, p.client)
-}
-
-func (p *perplexityProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: perplexityProviderID, ProbeType: "quality"}
-}
-func (p *perplexityProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: perplexityProviderID, ProbeType: "embedding"}
-}
-func (p *perplexityProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: perplexityProviderID, ProbeType: "streaming"}
+	return newOpenAICompatProvider(perplexityProviderID, perplexityDefaultBaseURL, apiKey, region, perplexityLightModel, perplexityLightProbeType, perplexityErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/probe_exec.go
+++ b/internal/probes/adapters/probe_exec.go
@@ -1,0 +1,55 @@
+package adapters
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/llmstatus/llmstatus/internal/probes"
+)
+
+// lightProbeConfig holds the provider-specific parameters for runLightProbe.
+type lightProbeConfig struct {
+	providerID   string
+	probeType    string
+	errorMax     int
+	region       string
+	buildRequest func(ctx context.Context, model string) (*http.Request, error)
+	classifyResp func(r *probes.ProbeResult, status int, body []byte)
+}
+
+// runLightProbe executes the standard HTTP probe flow for custom-protocol
+// adapters (those that cannot use probeOpenAICompat directly).
+func runLightProbe(ctx context.Context, client *http.Client, model string, cfg lightProbeConfig) (probes.ProbeResult, error) {
+	started := time.Now()
+	r := probes.ProbeResult{
+		ProviderID: cfg.providerID,
+		Model:      model,
+		ProbeType:  cfg.probeType,
+		StartedAt:  started.UTC(),
+		RegionID:   cfg.region,
+	}
+
+	req, err := cfg.buildRequest(ctx, model)
+	if err != nil {
+		r.DurationMs = time.Since(started).Milliseconds()
+		r.ErrorClass = probes.ErrorClassUnknown
+		r.ErrorDetail = truncate(err.Error(), cfg.errorMax)
+		return r, err
+	}
+
+	resp, err := client.Do(req)
+	r.DurationMs = time.Since(started).Milliseconds()
+	if err != nil {
+		r.ErrorClass = classifyNetError(err)
+		r.ErrorDetail = truncate(err.Error(), cfg.errorMax)
+		return r, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.HTTPStatus = resp.StatusCode
+	body, _ := io.ReadAll(resp.Body)
+	cfg.classifyResp(&r, resp.StatusCode, body)
+	return r, nil
+}

--- a/internal/probes/adapters/qwen.go
+++ b/internal/probes/adapters/qwen.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -17,51 +14,16 @@ const (
 	qwenErrorDetailMax = 200
 )
 
-// NewQwenProviderOption configures a NewQwenProvider provider at construction time.
-type NewQwenProviderOption func(*qwenProvider)
+// QwenOption configures a Qwen (Alibaba Cloud) provider at construction time.
+type QwenOption = compatOption
 
 // WithNewQwenProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewQwenProviderBaseURL(u string) NewQwenProviderOption {
-	return func(p *qwenProvider) { p.baseURL = u }
-}
+func WithNewQwenProviderBaseURL(u string) QwenOption { return compatBaseURL(u) }
 
 // WithNewQwenProviderHTTPClient overrides the HTTP client. Intended for tests.
-func WithNewQwenProviderHTTPClient(c *http.Client) NewQwenProviderOption {
-	return func(p *qwenProvider) { p.client = c }
-}
+func WithNewQwenProviderHTTPClient(c *http.Client) QwenOption { return compatHTTPClient(c) }
 
-// NewQwenProvider returns a probes.Provider backed by https://dashscope.aliyuncs.com/compatible-mode/v1.
-func NewQwenProvider(apiKey, region string, opts ...NewQwenProviderOption) probes.Provider {
-	p := &qwenProvider{
-		baseURL: qwenDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type qwenProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *qwenProvider) ID() string       { return qwenProviderID }
-func (p *qwenProvider) Models() []string { return []string{qwenLightModel} }
-
-func (p *qwenProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, qwenProviderID, qwenLightProbeType, qwenErrorDetailMax, model, p.client)
-}
-
-func (p *qwenProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: qwenProviderID, ProbeType: "quality"}
-}
-func (p *qwenProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: qwenProviderID, ProbeType: "embedding"}
-}
-func (p *qwenProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: qwenProviderID, ProbeType: "streaming"}
+// NewQwenProvider returns a probes.Provider backed by dashscope.aliyuncs.com.
+func NewQwenProvider(apiKey, region string, opts ...QwenOption) probes.Provider {
+	return newOpenAICompatProvider(qwenProviderID, qwenDefaultBaseURL, apiKey, region, qwenLightModel, qwenLightProbeType, qwenErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/together.go
+++ b/internal/probes/adapters/together.go
@@ -1,65 +1,29 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
 const (
 	togetherDefaultBaseURL = "https://api.together.xyz/v1"
 	togetherProviderID     = "together_ai"
-	togetherLightModel     = "meta-llama/Llama-3-8b-chat-hf"
+	togetherLightModel     = "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
 	togetherLightProbeType = "light_inference"
 	togetherErrorDetailMax = 200
 )
 
 // TogetherOption configures a Together AI provider at construction time.
-type TogetherOption func(*togetherProvider)
+type TogetherOption = compatOption
 
 // WithTogetherBaseURL overrides the base URL. Intended for tests.
-func WithTogetherBaseURL(u string) TogetherOption { return func(p *togetherProvider) { p.baseURL = u } }
+func WithTogetherBaseURL(u string) TogetherOption { return compatBaseURL(u) }
 
 // WithTogetherHTTPClient overrides the HTTP client. Intended for tests.
-func WithTogetherHTTPClient(c *http.Client) TogetherOption {
-	return func(p *togetherProvider) { p.client = c }
-}
+func WithTogetherHTTPClient(c *http.Client) TogetherOption { return compatHTTPClient(c) }
 
 // NewTogetherProvider returns a probes.Provider backed by api.together.xyz.
 func NewTogetherProvider(apiKey, region string, opts ...TogetherOption) probes.Provider {
-	p := &togetherProvider{
-		baseURL: togetherDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type togetherProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *togetherProvider) ID() string       { return togetherProviderID }
-func (p *togetherProvider) Models() []string { return []string{togetherLightModel} }
-
-func (p *togetherProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, togetherProviderID, togetherLightProbeType, togetherErrorDetailMax, model, p.client)
-}
-
-func (p *togetherProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: togetherProviderID, ProbeType: "quality"}
-}
-func (p *togetherProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: togetherProviderID, ProbeType: "embedding"}
-}
-func (p *togetherProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: togetherProviderID, ProbeType: "streaming"}
+	return newOpenAICompatProvider(togetherProviderID, togetherDefaultBaseURL, apiKey, region, togetherLightModel, togetherLightProbeType, togetherErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/xai.go
+++ b/internal/probes/adapters/xai.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -17,47 +14,16 @@ const (
 	xaiErrorDetailMax = 200
 )
 
-// XAIOption configures an xAI provider at construction time.
-type XAIOption func(*xaiProvider)
+// XAIOption configures an xAI (Grok) provider at construction time.
+type XAIOption = compatOption
 
 // WithXAIBaseURL overrides the base URL. Intended for tests.
-func WithXAIBaseURL(u string) XAIOption { return func(p *xaiProvider) { p.baseURL = u } }
+func WithXAIBaseURL(u string) XAIOption { return compatBaseURL(u) }
 
 // WithXAIHTTPClient overrides the HTTP client. Intended for tests.
-func WithXAIHTTPClient(c *http.Client) XAIOption { return func(p *xaiProvider) { p.client = c } }
+func WithXAIHTTPClient(c *http.Client) XAIOption { return compatHTTPClient(c) }
 
-// NewXAIProvider returns a probes.Provider backed by api.x.ai (Grok).
+// NewXAIProvider returns a probes.Provider backed by api.x.ai.
 func NewXAIProvider(apiKey, region string, opts ...XAIOption) probes.Provider {
-	p := &xaiProvider{
-		baseURL: xaiDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type xaiProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *xaiProvider) ID() string       { return xaiProviderID }
-func (p *xaiProvider) Models() []string { return []string{xaiLightModel} }
-
-func (p *xaiProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, xaiProviderID, xaiLightProbeType, xaiErrorDetailMax, model, p.client)
-}
-
-func (p *xaiProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: xaiProviderID, ProbeType: "quality"}
-}
-func (p *xaiProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: xaiProviderID, ProbeType: "embedding"}
-}
-func (p *xaiProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: xaiProviderID, ProbeType: "streaming"}
+	return newOpenAICompatProvider(xaiProviderID, xaiDefaultBaseURL, apiKey, region, xaiLightModel, xaiLightProbeType, xaiErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/zeroone.go
+++ b/internal/probes/adapters/zeroone.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -17,51 +14,16 @@ const (
 	zerooneErrorDetailMax = 200
 )
 
-// NewZeroOneProviderOption configures a NewZeroOneProvider provider at construction time.
-type NewZeroOneProviderOption func(*zerooneProvider)
+// ZeroOneOption configures a 01.AI provider at construction time.
+type ZeroOneOption = compatOption
 
 // WithNewZeroOneProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewZeroOneProviderBaseURL(u string) NewZeroOneProviderOption {
-	return func(p *zerooneProvider) { p.baseURL = u }
-}
+func WithNewZeroOneProviderBaseURL(u string) ZeroOneOption { return compatBaseURL(u) }
 
 // WithNewZeroOneProviderHTTPClient overrides the HTTP client. Intended for tests.
-func WithNewZeroOneProviderHTTPClient(c *http.Client) NewZeroOneProviderOption {
-	return func(p *zerooneProvider) { p.client = c }
-}
+func WithNewZeroOneProviderHTTPClient(c *http.Client) ZeroOneOption { return compatHTTPClient(c) }
 
-// NewZeroOneProvider returns a probes.Provider backed by https://api.01.ai/v1.
-func NewZeroOneProvider(apiKey, region string, opts ...NewZeroOneProviderOption) probes.Provider {
-	p := &zerooneProvider{
-		baseURL: zerooneDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type zerooneProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *zerooneProvider) ID() string       { return zerooneProviderID }
-func (p *zerooneProvider) Models() []string { return []string{zerooneLightModel} }
-
-func (p *zerooneProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, zerooneProviderID, zerooneLightProbeType, zerooneErrorDetailMax, model, p.client)
-}
-
-func (p *zerooneProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: zerooneProviderID, ProbeType: "quality"}
-}
-func (p *zerooneProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: zerooneProviderID, ProbeType: "embedding"}
-}
-func (p *zerooneProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: zerooneProviderID, ProbeType: "streaming"}
+// NewZeroOneProvider returns a probes.Provider backed by api.01.ai.
+func NewZeroOneProvider(apiKey, region string, opts ...ZeroOneOption) probes.Provider {
+	return newOpenAICompatProvider(zerooneProviderID, zerooneDefaultBaseURL, apiKey, region, zerooneLightModel, zerooneLightProbeType, zerooneErrorDetailMax, opts...)
 }

--- a/internal/probes/adapters/zhipu.go
+++ b/internal/probes/adapters/zhipu.go
@@ -1,11 +1,8 @@
 package adapters
 
 import (
-	"context"
 	"net/http"
-	"time"
 
-	"github.com/llmstatus/llmstatus/internal/httpclient"
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
@@ -17,51 +14,16 @@ const (
 	zhipuErrorDetailMax = 200
 )
 
-// NewZhipuProviderOption configures a NewZhipuProvider provider at construction time.
-type NewZhipuProviderOption func(*zhipuProvider)
+// ZhipuOption configures a Zhipu AI provider at construction time.
+type ZhipuOption = compatOption
 
 // WithNewZhipuProviderBaseURL overrides the base URL. Intended for tests.
-func WithNewZhipuProviderBaseURL(u string) NewZhipuProviderOption {
-	return func(p *zhipuProvider) { p.baseURL = u }
-}
+func WithNewZhipuProviderBaseURL(u string) ZhipuOption { return compatBaseURL(u) }
 
 // WithNewZhipuProviderHTTPClient overrides the HTTP client. Intended for tests.
-func WithNewZhipuProviderHTTPClient(c *http.Client) NewZhipuProviderOption {
-	return func(p *zhipuProvider) { p.client = c }
-}
+func WithNewZhipuProviderHTTPClient(c *http.Client) ZhipuOption { return compatHTTPClient(c) }
 
-// NewZhipuProvider returns a probes.Provider backed by https://open.bigmodel.cn/api/paas/v4.
-func NewZhipuProvider(apiKey, region string, opts ...NewZhipuProviderOption) probes.Provider {
-	p := &zhipuProvider{
-		baseURL: zhipuDefaultBaseURL,
-		apiKey:  apiKey,
-		region:  region,
-		client:  httpclient.New(httpclient.Options{Timeout: 30 * time.Second}),
-	}
-	for _, o := range opts {
-		o(p)
-	}
-	return p
-}
-
-type zhipuProvider struct {
-	baseURL, apiKey, region string
-	client                  *http.Client
-}
-
-func (p *zhipuProvider) ID() string       { return zhipuProviderID }
-func (p *zhipuProvider) Models() []string { return []string{zhipuLightModel} }
-
-func (p *zhipuProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
-	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, zhipuProviderID, zhipuLightProbeType, zhipuErrorDetailMax, model, p.client)
-}
-
-func (p *zhipuProvider) ProbeQuality(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: zhipuProviderID, ProbeType: "quality"}
-}
-func (p *zhipuProvider) ProbeEmbedding(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: zhipuProviderID, ProbeType: "embedding"}
-}
-func (p *zhipuProvider) ProbeStreaming(_ context.Context, _ string) (probes.ProbeResult, error) {
-	return probes.ProbeResult{}, &probes.ErrNotSupported{ProviderID: zhipuProviderID, ProbeType: "streaming"}
+// NewZhipuProvider returns a probes.Provider backed by open.bigmodel.cn.
+func NewZhipuProvider(apiKey, region string, opts ...ZhipuOption) probes.Provider {
+	return newOpenAICompatProvider(zhipuProviderID, zhipuDefaultBaseURL, apiKey, region, zhipuLightModel, zhipuLightProbeType, zhipuErrorDetailMax, opts...)
 }


### PR DESCRIPTION
## Summary

- Extract `openAICompatProvider` + `newOpenAICompatProvider` into `compat_provider.go`: 13 pure OpenAI-compatible provider files (ai21, doubao, fireworks, groq, huggingface, minimax, moonshot, perplexity, qwen, together, xai, zeroone, zhipu) reduced from ~67 lines to ~28 lines each via type aliases for exported option types
- Extract `runLightProbe` into `probe_exec.go`: the identical 30-line `ProbeLightInference` skeleton (allocate result, buildRequest, Do, classify) is now a single shared executor; Anthropic, Cohere, Gemini, Mistral adapters delegate to it
- Convert DeepSeek to pure-compat adapter (it uses the OpenAI `/chat/completions` endpoint and `classifyOpenAIResponse` — no custom protocol needed)
- Fix `goimports` separator in `internal/api/reports.go` (pre-existing lint violation from main)

## Test plan

- [ ] `go test ./internal/probes/adapters/... -short -count=1` passes
- [ ] `~/go/bin/golangci-lint run ./internal/... ./cmd/...` reports 0 issues
- [ ] `go test ./... -short` — only pre-existing `TestListProviders_*` failures (unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.ai/code)