### PR TITLE
feat: add @llmstatus/mcp MCP server package

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,38 @@
+name: Publish @llmstatus/mcp
+
+on:
+  push:
+    tags:
+      - "mcp-v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        working-directory: mcp
+        run: npm ci
+
+      - name: Run tests
+        working-directory: mcp
+        run: npm test
+
+      - name: Build
+        working-directory: mcp
+        run: npm run build
+
+      - name: Publish
+        working-directory: mcp
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -33,6 +33,6 @@ jobs:
 
       - name: Publish
         working-directory: mcp
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ deploy/ansible/inventories/prod/hosts.yml
 
 # Ansible vault (plain-text secrets — keep locally, never commit unencrypted)
 deploy/ansible/group_vars/all/vault.yml
+
+# Git worktrees (local dev isolation — never commit worktree contents)
+.worktrees/

--- a/docs/superpowers/plans/2026-04-26-mcp-server.md
+++ b/docs/superpowers/plans/2026-04-26-mcp-server.md
@@ -1,0 +1,1454 @@
+# MCP Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish `@llmstatus/mcp` — a TypeScript MCP server that exposes llmstatus.io data as 6 AI-callable tools so Claude/Cursor users can ask "Is OpenAI down?" and get a live answer.
+
+**Architecture:** Thin stdio MCP server in `llmstatus/mcp/`; calls the public `https://api.llmstatus.io` REST API; formats raw JSON into AI-readable plain text. No business logic, no database access, no auth required.
+
+**Tech Stack:** TypeScript 5, `@modelcontextprotocol/sdk` ^1.0.0, `zod` ^3.23, `vitest` ^1.6 for tests, `tsc` for build, Node ≥ 18.
+
+---
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `mcp/package.json` | Package metadata, scripts, dependencies |
+| `mcp/tsconfig.json` | TypeScript compiler options (ESM, NodeNext) |
+| `mcp/src/types.ts` | TypeScript interfaces mirroring Go API JSON shapes; `ApiError` class |
+| `mcp/src/client.ts` | `LLMStatusClient` — typed `fetch` wrapper for all API endpoints |
+| `mcp/src/tools/list_providers.ts` | Format provider list; export tool name/description/schema/handler |
+| `mcp/src/tools/get_provider_status.ts` | Format single provider detail |
+| `mcp/src/tools/list_active_incidents.ts` | Format incident list (client-side provider filter) |
+| `mcp/src/tools/get_incident_detail.ts` | Format single incident detail |
+| `mcp/src/tools/get_provider_history.ts` | Format history bucket summary |
+| `mcp/src/tools/compare_providers.ts` | Concurrent fetch + aligned table format |
+| `mcp/src/index.ts` | Wire `McpServer`, register 6 tools, connect `StdioServerTransport` |
+| `mcp/src/tools/__tests__/*.test.ts` | Vitest unit tests for each formatter |
+| `.github/workflows/publish-mcp.yml` | CI: build + test + `npm publish` on `mcp-v*` tag |
+
+---
+
+## Task 1: Scaffold `mcp/` directory
+
+**Files:**
+- Create: `mcp/package.json`
+- Create: `mcp/tsconfig.json`
+
+- [ ] **Step 1: Create `mcp/package.json`**
+
+```json
+{
+  "name": "@llmstatus/mcp",
+  "version": "1.0.0",
+  "description": "MCP server for llmstatus.io — query AI provider status from Claude and Cursor",
+  "type": "module",
+  "bin": {
+    "llmstatus-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build && npm test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/llmstatus/llmstatus"
+  }
+}
+```
+
+- [ ] **Step 2: Create `mcp/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+- [ ] **Step 3: Install dependencies**
+
+```bash
+cd mcp && npm install
+```
+
+Expected: `node_modules/` created, `package-lock.json` written, no errors.
+
+- [ ] **Step 4: Verify TypeScript compiler resolves**
+
+```bash
+cd mcp && npx tsc --version
+```
+
+Expected: `Version 5.x.x`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/package.json mcp/tsconfig.json mcp/package-lock.json
+git commit -m "chore(mcp): scaffold package"
+```
+
+---
+
+## Task 2: Types and HTTP client
+
+**Files:**
+- Create: `mcp/src/types.ts`
+- Create: `mcp/src/client.ts`
+- Create: `mcp/src/tools/__tests__/client.test.ts`
+
+- [ ] **Step 1: Create `mcp/src/types.ts`**
+
+```typescript
+export interface ApiEnvelope<T> {
+  data: T;
+  meta: {
+    generated_at: string;
+    cache_ttl_s: number;
+  };
+}
+
+export interface ModelStat {
+  model_id: string;
+  display_name: string;
+  uptime_24h: number;
+  p95_ms: number;
+  sparkline: number[];
+}
+
+export interface ProviderSummary {
+  id: string;
+  name: string;
+  category: string;
+  region: string;
+  probe_scope: string;
+  current_status: "operational" | "degraded" | "down";
+  active_incident_id?: string;
+  uptime_24h?: number;
+  p95_ms?: number;
+  model_stats: ModelStat[];
+}
+
+export interface ModelSummary {
+  model_id: string;
+  display_name: string;
+  model_type: string;
+  active: boolean;
+}
+
+export interface IncidentRef {
+  id: string;
+  slug: string;
+  severity: string;
+  title: string;
+  status: string;
+  started_at: string;
+}
+
+export interface RegionStat {
+  region_id: string;
+  uptime_24h: number;
+  p95_ms: number;
+}
+
+export interface ProviderDetail extends ProviderSummary {
+  status_page_url?: string;
+  documentation_url?: string;
+  models: ModelSummary[];
+  active_incidents: IncidentRef[];
+  region_stats: RegionStat[];
+}
+
+export interface IncidentResponse {
+  id: string;
+  slug: string;
+  provider_id: string;
+  severity: "critical" | "major" | "minor";
+  title: string;
+  description?: string;
+  status: "ongoing" | "monitoring" | "resolved";
+  affected_models: string[];
+  affected_regions: string[];
+  started_at: string;
+  resolved_at?: string;
+  detection_method: string;
+  human_reviewed: boolean;
+}
+
+export interface HistoryBucket {
+  timestamp: string;
+  total: number;
+  errors: number;
+  uptime: number;
+  p95_ms: number;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+```
+
+- [ ] **Step 2: Create `mcp/src/client.ts`**
+
+```typescript
+import type {
+  ApiEnvelope,
+  HistoryBucket,
+  IncidentResponse,
+  ProviderDetail,
+  ProviderSummary,
+} from "./types.js";
+import { ApiError } from "./types.js";
+
+const DEFAULT_BASE_URL = "https://api.llmstatus.io";
+
+export class LLMStatusClient {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl?: string) {
+    this.baseUrl = (baseUrl ?? process.env["LLMSTATUS_API_BASE"] ?? DEFAULT_BASE_URL).replace(
+      /\/$/,
+      ""
+    );
+  }
+
+  private async fetchJSON<T>(path: string): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}${path}`, {
+        headers: { "User-Agent": "@llmstatus/mcp/1.0.0" },
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch {
+      throw new ApiError(
+        0,
+        "llmstatus.io is temporarily unreachable. Please try again shortly."
+      );
+    }
+    if (!response.ok) {
+      throw new ApiError(
+        response.status,
+        `llmstatus.io returned HTTP ${response.status}.${response.status === 404 ? " Resource not found." : " Please try again shortly."}`
+      );
+    }
+    const envelope = (await response.json()) as ApiEnvelope<T>;
+    return envelope.data;
+  }
+
+  listProviders(): Promise<ProviderSummary[]> {
+    return this.fetchJSON<ProviderSummary[]>("/v1/providers");
+  }
+
+  getProvider(id: string): Promise<ProviderDetail> {
+    return this.fetchJSON<ProviderDetail>(`/v1/providers/${encodeURIComponent(id)}`);
+  }
+
+  listIncidents(params: { status?: string; limit?: number } = {}): Promise<IncidentResponse[]> {
+    const qs = new URLSearchParams();
+    if (params.status) qs.set("status", params.status);
+    if (params.limit != null) qs.set("limit", String(params.limit));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return this.fetchJSON<IncidentResponse[]>(`/v1/incidents${suffix}`);
+  }
+
+  getIncident(id: string): Promise<IncidentResponse> {
+    return this.fetchJSON<IncidentResponse>(`/v1/incidents/${encodeURIComponent(id)}`);
+  }
+
+  getProviderHistory(id: string, window = "30d"): Promise<HistoryBucket[]> {
+    return this.fetchJSON<HistoryBucket[]>(
+      `/v1/providers/${encodeURIComponent(id)}/history?window=${encodeURIComponent(window)}`
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Create `mcp/src/tools/__tests__/` directory and write client tests**
+
+Create `mcp/src/tools/__tests__/client.test.ts`:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LLMStatusClient } from "../../client.js";
+import { ApiError } from "../../types.js";
+
+const mockFetch = vi.fn();
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeEnvelope<T>(data: T) {
+  return { data, meta: { generated_at: "2026-04-26T00:00:00Z", cache_ttl_s: 30 } };
+}
+
+describe("LLMStatusClient.listProviders", () => {
+  it("returns parsed provider array on 200", async () => {
+    const providers = [{ id: "openai", name: "OpenAI" }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeEnvelope(providers),
+    });
+    const client = new LLMStatusClient("http://localhost");
+    const result = await client.listProviders();
+    expect(result).toEqual(providers);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost/v1/providers",
+      expect.objectContaining({ headers: expect.any(Object) })
+    );
+  });
+
+  it("throws ApiError on 404", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    const client = new LLMStatusClient("http://localhost");
+    await expect(client.listProviders()).rejects.toBeInstanceOf(ApiError);
+    await expect(client.listProviders()).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("throws ApiError on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+    const client = new LLMStatusClient("http://localhost");
+    await expect(client.listProviders()).rejects.toBeInstanceOf(ApiError);
+    await expect(client.listProviders()).rejects.toMatchObject({ status: 0 });
+  });
+});
+
+describe("LLMStatusClient.listIncidents", () => {
+  it("appends status query param when provided", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeEnvelope([]),
+    });
+    const client = new LLMStatusClient("http://localhost");
+    await client.listIncidents({ status: "ongoing" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost/v1/incidents?status=ongoing",
+      expect.anything()
+    );
+  });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mcp && npm test
+```
+
+Expected: all client tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/types.ts mcp/src/client.ts "mcp/src/tools/__tests__/client.test.ts"
+git commit -m "feat(mcp): add types and HTTP client"
+```
+
+---
+
+## Task 3: `list_providers` tool
+
+**Files:**
+- Create: `mcp/src/tools/list_providers.ts`
+- Create: `mcp/src/tools/__tests__/list_providers.test.ts`
+
+- [ ] **Step 1: Write the failing formatter test**
+
+Create `mcp/src/tools/__tests__/list_providers.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { formatProviderList } from "../list_providers.js";
+import type { ProviderSummary } from "../../types.js";
+
+const base: ProviderSummary = {
+  id: "openai",
+  name: "OpenAI",
+  category: "official",
+  region: "us",
+  probe_scope: "global",
+  current_status: "operational",
+  uptime_24h: 0.9997,
+  p95_ms: 342,
+  model_stats: [],
+};
+
+describe("formatProviderList", () => {
+  it("shows count and operational tick", () => {
+    const out = formatProviderList([base]);
+    expect(out).toContain("1 provider");
+    expect(out).toContain("✓");
+    expect(out).toContain("OpenAI");
+    expect(out).toContain("operational");
+    expect(out).toContain("99.97%");
+    expect(out).toContain("342ms");
+  });
+
+  it("shows warning icon for degraded provider", () => {
+    const out = formatProviderList([{ ...base, current_status: "degraded" }]);
+    expect(out).toContain("⚠");
+  });
+
+  it("shows cross icon for down provider", () => {
+    const out = formatProviderList([{ ...base, current_status: "down" }]);
+    expect(out).toContain("✗");
+  });
+
+  it("handles missing uptime/latency gracefully", () => {
+    const minimal = { ...base, uptime_24h: undefined, p95_ms: undefined };
+    expect(() => formatProviderList([minimal])).not.toThrow();
+  });
+
+  it("returns a message for empty list", () => {
+    const out = formatProviderList([]);
+    expect(out).toContain("0 provider");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify test fails**
+
+```bash
+cd mcp && npm test -- list_providers
+```
+
+Expected: FAIL — `formatProviderList` not found.
+
+- [ ] **Step 3: Implement `mcp/src/tools/list_providers.ts`**
+
+```typescript
+import type { LLMStatusClient } from "../client.js";
+import type { ProviderSummary } from "../types.js";
+
+export const TOOL_NAME = "list_providers";
+export const TOOL_DESCRIPTION =
+  "List all AI providers monitored by llmstatus.io with their current operational status, 24-hour uptime, and latency.";
+export const TOOL_SCHEMA = {};
+
+export function formatProviderList(providers: ProviderSummary[]): string {
+  const count = providers.length;
+  if (count === 0) return "0 providers found.";
+
+  const icon = (s: ProviderSummary["current_status"]) =>
+    s === "operational" ? "✓" : s === "down" ? "✗" : "⚠";
+
+  const lines = [`${count} provider${count !== 1 ? "s" : ""} monitored:\n`];
+  for (const p of providers) {
+    const uptime =
+      p.uptime_24h != null ? ` (${(p.uptime_24h * 100).toFixed(2)}% uptime 24h)` : "";
+    const p95 = p.p95_ms != null ? ` / ${Math.round(p.p95_ms)}ms p95` : "";
+    lines.push(`${icon(p.current_status)} ${p.name} [${p.id}] — ${p.current_status}${uptime}${p95}`);
+  }
+  return lines.join("\n");
+}
+
+export async function handleListProviders(client: LLMStatusClient): Promise<string> {
+  const providers = await client.listProviders();
+  return formatProviderList(providers);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mcp && npm test -- list_providers
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tools/list_providers.ts "mcp/src/tools/__tests__/list_providers.test.ts"
+git commit -m "feat(mcp): add list_providers tool"
+```
+
+---
+
+## Task 4: `get_provider_status` tool
+
+**Files:**
+- Create: `mcp/src/tools/get_provider_status.ts`
+- Create: `mcp/src/tools/__tests__/get_provider_status.test.ts`
+
+- [ ] **Step 1: Write the failing formatter test**
+
+Create `mcp/src/tools/__tests__/get_provider_status.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { formatProviderDetail } from "../get_provider_status.js";
+import type { ProviderDetail } from "../../types.js";
+
+const base: ProviderDetail = {
+  id: "openai",
+  name: "OpenAI",
+  category: "official",
+  region: "us",
+  probe_scope: "global",
+  current_status: "operational",
+  uptime_24h: 0.9997,
+  p95_ms: 342,
+  model_stats: [
+    { model_id: "gpt-4o", display_name: "GPT-4o", uptime_24h: 0.9998, p95_ms: 340, sparkline: [] },
+    { model_id: "gpt-4o-mini", display_name: "GPT-4o mini", uptime_24h: 0.9999, p95_ms: 210, sparkline: [] },
+  ],
+  models: [],
+  active_incidents: [],
+  region_stats: [],
+};
+
+describe("formatProviderDetail", () => {
+  it("shows name, status, uptime, and latency", () => {
+    const out = formatProviderDetail(base);
+    expect(out).toContain("OpenAI");
+    expect(out).toContain("operational");
+    expect(out).toContain("99.97%");
+    expect(out).toContain("342ms");
+  });
+
+  it("shows model list", () => {
+    const out = formatProviderDetail(base);
+    expect(out).toContain("GPT-4o");
+    expect(out).toContain("GPT-4o mini");
+  });
+
+  it("shows 'No active incidents' when clean", () => {
+    const out = formatProviderDetail(base);
+    expect(out).toContain("No active incidents");
+  });
+
+  it("shows active incident title when present", () => {
+    const withInc: ProviderDetail = {
+      ...base,
+      current_status: "degraded",
+      active_incidents: [
+        { id: "abc", slug: "test", severity: "major", title: "Elevated errors", status: "ongoing", started_at: "2026-04-26T10:00:00Z" },
+      ],
+    };
+    const out = formatProviderDetail(withInc);
+    expect(out).toContain("Elevated errors");
+    expect(out).toContain("major");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify test fails**
+
+```bash
+cd mcp && npm test -- get_provider_status
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `mcp/src/tools/get_provider_status.ts`**
+
+```typescript
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import { ApiError } from "../types.js";
+import type { ProviderDetail } from "../types.js";
+
+export const TOOL_NAME = "get_provider_status";
+export const TOOL_DESCRIPTION =
+  "Get the current operational status, uptime, latency, and active incidents for a specific AI provider.";
+export const TOOL_SCHEMA = {
+  id: z.string().describe("Provider ID, e.g. 'openai', 'anthropic', 'google_gemini'"),
+};
+
+export function formatProviderDetail(p: ProviderDetail): string {
+  const icon =
+    p.current_status === "operational" ? "✓" : p.current_status === "down" ? "✗" : "⚠";
+  const lines = [`${p.name} — ${icon} ${p.current_status}`];
+  if (p.uptime_24h != null) lines.push(`Uptime (24h): ${(p.uptime_24h * 100).toFixed(2)}%`);
+  if (p.p95_ms != null) lines.push(`P95 latency: ${Math.round(p.p95_ms)}ms`);
+
+  const models = p.model_stats.filter((m) => m.uptime_24h > 0);
+  if (models.length > 0) {
+    lines.push(
+      `Models: ${models.map((m) => `${m.display_name} (${(m.uptime_24h * 100).toFixed(1)}%)`).join(", ")}`
+    );
+  }
+
+  if (p.active_incidents.length > 0) {
+    lines.push("\nActive incidents:");
+    for (const inc of p.active_incidents) {
+      lines.push(`  [${inc.severity}] ${inc.title}`);
+    }
+  } else {
+    lines.push("No active incidents.");
+  }
+
+  return lines.join("\n");
+}
+
+export async function handleGetProviderStatus(
+  id: string,
+  client: LLMStatusClient
+): Promise<string> {
+  try {
+    const detail = await client.getProvider(id);
+    return formatProviderDetail(detail);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      const all = await client.listProviders().catch(() => []);
+      const ids = all.map((p) => p.id).join(", ");
+      return `Provider "${id}" not found.${ids ? ` Valid IDs: ${ids}` : ""}`;
+    }
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mcp && npm test -- get_provider_status
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tools/get_provider_status.ts "mcp/src/tools/__tests__/get_provider_status.test.ts"
+git commit -m "feat(mcp): add get_provider_status tool"
+```
+
+---
+
+## Task 5: `list_active_incidents` tool
+
+**Files:**
+- Create: `mcp/src/tools/list_active_incidents.ts`
+- Create: `mcp/src/tools/__tests__/list_active_incidents.test.ts`
+
+- [ ] **Step 1: Write the failing formatter test**
+
+Create `mcp/src/tools/__tests__/list_active_incidents.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { formatIncidentList } from "../list_active_incidents.js";
+import type { IncidentResponse } from "../../types.js";
+
+const makeInc = (overrides: Partial<IncidentResponse> = {}): IncidentResponse => ({
+  id: "abc123",
+  slug: "2026-04-26-openai-errors",
+  provider_id: "openai",
+  severity: "major",
+  title: "Elevated error rate",
+  status: "ongoing",
+  affected_models: ["gpt-4o"],
+  affected_regions: ["us-west-2"],
+  started_at: new Date(Date.now() - 14 * 60 * 1000).toISOString(), // 14 min ago
+  detection_method: "auto",
+  human_reviewed: false,
+  ...overrides,
+});
+
+describe("formatIncidentList", () => {
+  it("returns no-incident message for empty list", () => {
+    const out = formatIncidentList([]);
+    expect(out).toContain("No active incidents");
+  });
+
+  it("shows count, provider, title, severity", () => {
+    const out = formatIncidentList([makeInc()]);
+    expect(out).toContain("1 active incident");
+    expect(out).toContain("openai");
+    expect(out).toContain("Elevated error rate");
+    expect(out).toContain("major");
+  });
+
+  it("shows plural for multiple incidents", () => {
+    const out = formatIncidentList([makeInc(), makeInc({ id: "def456", provider_id: "anthropic" })]);
+    expect(out).toContain("2 active incidents");
+  });
+
+  it("filters by provider_id when specified", () => {
+    const incidents = [makeInc({ provider_id: "openai" }), makeInc({ id: "z", provider_id: "anthropic" })];
+    const out = formatIncidentList(incidents, "openai");
+    expect(out).toContain("1 active incident");
+    expect(out).not.toContain("anthropic");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify test fails**
+
+```bash
+cd mcp && npm test -- list_active_incidents
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `mcp/src/tools/list_active_incidents.ts`**
+
+```typescript
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import type { IncidentResponse } from "../types.js";
+
+export const TOOL_NAME = "list_active_incidents";
+export const TOOL_DESCRIPTION =
+  "List all currently active (ongoing) incidents across all monitored AI providers. Optionally filter to one provider.";
+export const TOOL_SCHEMA = {
+  provider_id: z
+    .string()
+    .optional()
+    .describe("Optional provider ID to filter results, e.g. 'openai'"),
+};
+
+function formatAge(isoString: string): string {
+  const ms = Date.now() - new Date(isoString).getTime();
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+export function formatIncidentList(incidents: IncidentResponse[], providerFilter?: string): string {
+  const filtered = providerFilter
+    ? incidents.filter((i) => i.provider_id === providerFilter)
+    : incidents;
+
+  if (filtered.length === 0) {
+    return providerFilter
+      ? `No active incidents for provider "${providerFilter}".`
+      : "No active incidents. All monitored providers are operating normally.";
+  }
+
+  const count = filtered.length;
+  const lines = [`${count} active incident${count !== 1 ? "s" : ""}:\n`];
+  for (const inc of filtered) {
+    const age = formatAge(inc.started_at);
+    lines.push(`[${inc.severity}] ${inc.title} (${inc.provider_id}) — started ${age} ago`);
+  }
+  return lines.join("\n");
+}
+
+export async function handleListActiveIncidents(
+  providerFilter: string | undefined,
+  client: LLMStatusClient
+): Promise<string> {
+  const incidents = await client.listIncidents({ status: "ongoing", limit: 100 });
+  return formatIncidentList(incidents, providerFilter);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mcp && npm test -- list_active_incidents
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tools/list_active_incidents.ts "mcp/src/tools/__tests__/list_active_incidents.test.ts"
+git commit -m "feat(mcp): add list_active_incidents tool"
+```
+
+---
+
+## Task 6: `get_incident_detail` tool
+
+**Files:**
+- Create: `mcp/src/tools/get_incident_detail.ts`
+- Create: `mcp/src/tools/__tests__/get_incident_detail.test.ts`
+
+- [ ] **Step 1: Write the failing formatter test**
+
+Create `mcp/src/tools/__tests__/get_incident_detail.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { formatIncident } from "../get_incident_detail.js";
+import type { IncidentResponse } from "../../types.js";
+
+const incident: IncidentResponse = {
+  id: "uuid-123",
+  slug: "2026-04-26-openai-errors",
+  provider_id: "openai",
+  severity: "major",
+  title: "Elevated error rate",
+  description: "Error rate rose above 15% across US nodes.",
+  status: "ongoing",
+  affected_models: ["gpt-4o", "gpt-4o-mini"],
+  affected_regions: ["us-west-2", "us-east-1"],
+  started_at: "2026-04-26T08:12:00Z",
+  detection_method: "auto",
+  human_reviewed: true,
+};
+
+describe("formatIncident", () => {
+  it("includes title, severity, provider, started_at", () => {
+    const out = formatIncident(incident);
+    expect(out).toContain("Elevated error rate");
+    expect(out).toContain("major");
+    expect(out).toContain("openai");
+    expect(out).toContain("2026-04-26T08:12:00Z");
+  });
+
+  it("lists affected models and regions", () => {
+    const out = formatIncident(incident);
+    expect(out).toContain("gpt-4o");
+    expect(out).toContain("us-west-2");
+  });
+
+  it("includes description when present", () => {
+    const out = formatIncident(incident);
+    expect(out).toContain("Error rate rose above 15%");
+  });
+
+  it("includes resolved_at when present", () => {
+    const resolved = { ...incident, resolved_at: "2026-04-26T09:00:00Z" };
+    const out = formatIncident(resolved);
+    expect(out).toContain("2026-04-26T09:00:00Z");
+  });
+
+  it("omits description line when absent", () => {
+    const noDesc = { ...incident, description: undefined };
+    const out = formatIncident(noDesc);
+    expect(out).not.toContain("undefined");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify test fails**
+
+```bash
+cd mcp && npm test -- get_incident_detail
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `mcp/src/tools/get_incident_detail.ts`**
+
+```typescript
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import type { IncidentResponse } from "../types.js";
+
+export const TOOL_NAME = "get_incident_detail";
+export const TOOL_DESCRIPTION =
+  "Get full details for a specific incident by its UUID or slug (e.g. '2026-04-26-openai-errors').";
+export const TOOL_SCHEMA = {
+  id: z
+    .string()
+    .describe("Incident UUID or slug, e.g. '2026-04-26-openai-elevated-errors' or a UUID"),
+};
+
+export function formatIncident(inc: IncidentResponse): string {
+  const lines = [
+    `Incident: ${inc.title}`,
+    `Status: ${inc.status} | Severity: ${inc.severity}`,
+    `Provider: ${inc.provider_id}`,
+    `Started: ${inc.started_at}`,
+  ];
+  if (inc.resolved_at) lines.push(`Resolved: ${inc.resolved_at}`);
+  if (inc.affected_models.length > 0)
+    lines.push(`Affected models: ${inc.affected_models.join(", ")}`);
+  if (inc.affected_regions.length > 0)
+    lines.push(`Affected regions: ${inc.affected_regions.join(", ")}`);
+  if (inc.description) lines.push(`\n${inc.description}`);
+  return lines.join("\n");
+}
+
+export async function handleGetIncidentDetail(
+  id: string,
+  client: LLMStatusClient
+): Promise<string> {
+  const inc = await client.getIncident(id);
+  return formatIncident(inc);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mcp && npm test -- get_incident_detail
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tools/get_incident_detail.ts "mcp/src/tools/__tests__/get_incident_detail.test.ts"
+git commit -m "feat(mcp): add get_incident_detail tool"
+```
+
+---
+
+## Task 7: `get_provider_history` tool
+
+**Files:**
+- Create: `mcp/src/tools/get_provider_history.ts`
+- Create: `mcp/src/tools/__tests__/get_provider_history.test.ts`
+
+- [ ] **Step 1: Write the failing formatter test**
+
+Create `mcp/src/tools/__tests__/get_provider_history.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { formatHistory } from "../get_provider_history.js";
+import type { HistoryBucket } from "../../types.js";
+
+const makeBucket = (uptime: number, p95_ms: number, errors = 0): HistoryBucket => ({
+  timestamp: "2026-04-25T00:00:00Z",
+  total: 100,
+  errors,
+  uptime,
+  p95_ms,
+});
+
+describe("formatHistory", () => {
+  it("shows provider name, window, avg uptime, avg p95", () => {
+    const buckets = [makeBucket(1.0, 300), makeBucket(0.99, 400), makeBucket(0.98, 500)];
+    const out = formatHistory("OpenAI", "7d", buckets);
+    expect(out).toContain("OpenAI");
+    expect(out).toContain("7d");
+    expect(out).toContain("99.00%"); // avg of 1.0+0.99+0.98 = 2.97/3
+    expect(out).toContain("400ms"); // avg of 300+400+500 = 400
+  });
+
+  it("handles empty bucket list", () => {
+    const out = formatHistory("OpenAI", "7d", []);
+    expect(out).toContain("No history data");
+  });
+
+  it("skips p95 avg when all buckets have zero latency", () => {
+    const out = formatHistory("OpenAI", "24h", [makeBucket(1.0, 0)]);
+    expect(out).not.toContain("NaN");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify test fails**
+
+```bash
+cd mcp && npm test -- get_provider_history
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `mcp/src/tools/get_provider_history.ts`**
+
+```typescript
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import type { HistoryBucket } from "../types.js";
+
+export const TOOL_NAME = "get_provider_history";
+export const TOOL_DESCRIPTION =
+  "Get historical uptime and latency data for a provider over a given time window.";
+export const TOOL_SCHEMA = {
+  id: z.string().describe("Provider ID, e.g. 'openai'"),
+  window: z
+    .enum(["24h", "7d", "30d"])
+    .optional()
+    .default("30d")
+    .describe("Time window: '24h', '7d', or '30d'. Defaults to '30d'."),
+};
+
+export function formatHistory(
+  providerName: string,
+  window: string,
+  buckets: HistoryBucket[]
+): string {
+  if (buckets.length === 0) {
+    return `No history data available for ${providerName} in the ${window} window.`;
+  }
+  const avgUptime = buckets.reduce((s, b) => s + b.uptime, 0) / buckets.length;
+  const withLatency = buckets.filter((b) => b.p95_ms > 0);
+  const avgP95 =
+    withLatency.length > 0
+      ? withLatency.reduce((s, b) => s + b.p95_ms, 0) / withLatency.length
+      : 0;
+  const totalErrors = buckets.reduce((s, b) => s + b.errors, 0);
+
+  const lines = [
+    `${providerName} — past ${window}`,
+    `Uptime: ${(avgUptime * 100).toFixed(2)}%`,
+  ];
+  if (avgP95 > 0) lines.push(`Avg P95 latency: ${Math.round(avgP95)}ms`);
+  lines.push(`Total error probes: ${totalErrors}`);
+  lines.push(`Buckets: ${buckets.length}`);
+  return lines.join("\n");
+}
+
+export async function handleGetProviderHistory(
+  id: string,
+  window: "24h" | "7d" | "30d",
+  client: LLMStatusClient
+): Promise<string> {
+  const [buckets, detail] = await Promise.all([
+    client.getProviderHistory(id, window),
+    client.getProvider(id),
+  ]);
+  return formatHistory(detail.name, window, buckets);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mcp && npm test -- get_provider_history
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tools/get_provider_history.ts "mcp/src/tools/__tests__/get_provider_history.test.ts"
+git commit -m "feat(mcp): add get_provider_history tool"
+```
+
+---
+
+## Task 8: `compare_providers` tool
+
+**Files:**
+- Create: `mcp/src/tools/compare_providers.ts`
+- Create: `mcp/src/tools/__tests__/compare_providers.test.ts`
+
+- [ ] **Step 1: Write the failing formatter test**
+
+Create `mcp/src/tools/__tests__/compare_providers.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { formatComparison } from "../compare_providers.js";
+import type { ProviderDetail } from "../../types.js";
+
+const makeProvider = (
+  id: string,
+  name: string,
+  status: "operational" | "degraded" | "down" = "operational"
+): ProviderDetail => ({
+  id,
+  name,
+  category: "official",
+  region: "us",
+  probe_scope: "global",
+  current_status: status,
+  uptime_24h: 0.9997,
+  p95_ms: 342,
+  model_stats: [],
+  models: [],
+  active_incidents: [],
+  region_stats: [],
+});
+
+describe("formatComparison", () => {
+  it("renders a table with all providers", () => {
+    const out = formatComparison([
+      { type: "ok", data: makeProvider("openai", "OpenAI") },
+      { type: "ok", data: makeProvider("anthropic", "Anthropic") },
+    ]);
+    expect(out).toContain("OpenAI");
+    expect(out).toContain("Anthropic");
+    expect(out).toContain("operational");
+    expect(out).toContain("99.97%");
+  });
+
+  it("shows error row for failed provider fetch", () => {
+    const out = formatComparison([
+      { type: "ok", data: makeProvider("openai", "OpenAI") },
+      { type: "error", id: "bad_id", message: "not found" },
+    ]);
+    expect(out).toContain("bad_id");
+    expect(out).toContain("not found");
+  });
+
+  it("handles N/A for missing uptime and latency", () => {
+    const noStats = makeProvider("openai", "OpenAI");
+    noStats.uptime_24h = undefined;
+    noStats.p95_ms = undefined;
+    const out = formatComparison([{ type: "ok", data: noStats }]);
+    expect(out).toContain("N/A");
+    expect(out).not.toContain("undefined");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify test fails**
+
+```bash
+cd mcp && npm test -- compare_providers
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `mcp/src/tools/compare_providers.ts`**
+
+```typescript
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import type { ProviderDetail } from "../types.js";
+
+export const TOOL_NAME = "compare_providers";
+export const TOOL_DESCRIPTION =
+  "Compare 2 to 5 AI providers side-by-side: current status, 24-hour uptime, and P95 latency.";
+export const TOOL_SCHEMA = {
+  ids: z
+    .array(z.string())
+    .min(2)
+    .max(5)
+    .describe("2 to 5 provider IDs to compare, e.g. ['openai', 'anthropic']"),
+};
+
+type CompareRow =
+  | { type: "ok"; data: ProviderDetail }
+  | { type: "error"; id: string; message: string };
+
+export function formatComparison(rows: CompareRow[]): string {
+  const COL = [22, 16, 10, 10];
+  const header = [
+    "Provider".padEnd(COL[0]),
+    "Status".padEnd(COL[1]),
+    "Uptime".padEnd(COL[2]),
+    "P95 (ms)",
+  ].join(" ");
+  const sep = "─".repeat(COL[0] + COL[1] + COL[2] + 12);
+
+  const lines = [`Provider comparison (24h):`, sep, header, sep];
+  for (const row of rows) {
+    if (row.type === "error") {
+      lines.push(`${row.id.padEnd(COL[0])} error: ${row.message}`);
+    } else {
+      const p = row.data;
+      const uptime = p.uptime_24h != null ? `${(p.uptime_24h * 100).toFixed(2)}%` : "N/A";
+      const p95 = p.p95_ms != null ? `${Math.round(p.p95_ms)}` : "N/A";
+      lines.push(
+        [
+          p.name.padEnd(COL[0]),
+          p.current_status.padEnd(COL[1]),
+          uptime.padEnd(COL[2]),
+          p95,
+        ].join(" ")
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+export async function handleCompareProviders(
+  ids: string[],
+  client: LLMStatusClient
+): Promise<string> {
+  const settled = await Promise.allSettled(ids.map((id) => client.getProvider(id)));
+  const rows: CompareRow[] = settled.map((result, i) => {
+    if (result.status === "fulfilled") {
+      return { type: "ok", data: result.value };
+    }
+    const msg = result.reason instanceof Error ? result.reason.message : "unknown error";
+    return { type: "error", id: ids[i]!, message: msg };
+  });
+  return formatComparison(rows);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd mcp && npm test -- compare_providers
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Run all tests to confirm nothing broken**
+
+```bash
+cd mcp && npm test
+```
+
+Expected: all tests across all tool files PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp/src/tools/compare_providers.ts "mcp/src/tools/__tests__/compare_providers.test.ts"
+git commit -m "feat(mcp): add compare_providers tool"
+```
+
+---
+
+## Task 9: Entry point — wire the MCP server
+
+**Files:**
+- Create: `mcp/src/index.ts`
+
+- [ ] **Step 1: Create `mcp/src/index.ts`**
+
+```typescript
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { LLMStatusClient } from "./client.js";
+import {
+  TOOL_NAME as LIST_PROVIDERS,
+  TOOL_DESCRIPTION as LP_DESC,
+  handleListProviders,
+} from "./tools/list_providers.js";
+import {
+  TOOL_NAME as GET_PROVIDER_STATUS,
+  TOOL_DESCRIPTION as GPS_DESC,
+  TOOL_SCHEMA as GPS_SCHEMA,
+  handleGetProviderStatus,
+} from "./tools/get_provider_status.js";
+import {
+  TOOL_NAME as LIST_INCIDENTS,
+  TOOL_DESCRIPTION as LI_DESC,
+  TOOL_SCHEMA as LI_SCHEMA,
+  handleListActiveIncidents,
+} from "./tools/list_active_incidents.js";
+import {
+  TOOL_NAME as GET_INCIDENT,
+  TOOL_DESCRIPTION as GI_DESC,
+  TOOL_SCHEMA as GI_SCHEMA,
+  handleGetIncidentDetail,
+} from "./tools/get_incident_detail.js";
+import {
+  TOOL_NAME as GET_HISTORY,
+  TOOL_DESCRIPTION as GH_DESC,
+  TOOL_SCHEMA as GH_SCHEMA,
+  handleGetProviderHistory,
+} from "./tools/get_provider_history.js";
+import {
+  TOOL_NAME as COMPARE,
+  TOOL_DESCRIPTION as CMP_DESC,
+  TOOL_SCHEMA as CMP_SCHEMA,
+  handleCompareProviders,
+} from "./tools/compare_providers.js";
+import { ApiError } from "./types.js";
+
+const client = new LLMStatusClient();
+const server = new McpServer({ name: "llmstatus", version: "1.0.0" });
+
+function wrapError(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return "An unexpected error occurred.";
+}
+
+server.tool(LIST_PROVIDERS, LP_DESC, {}, async () => ({
+  content: [{ type: "text" as const, text: await handleListProviders(client).catch(wrapError) }],
+}));
+
+server.tool(GET_PROVIDER_STATUS, GPS_DESC, GPS_SCHEMA, async ({ id }) => ({
+  content: [
+    { type: "text" as const, text: await handleGetProviderStatus(id, client).catch(wrapError) },
+  ],
+}));
+
+server.tool(LIST_INCIDENTS, LI_DESC, LI_SCHEMA, async ({ provider_id }) => ({
+  content: [
+    {
+      type: "text" as const,
+      text: await handleListActiveIncidents(provider_id, client).catch(wrapError),
+    },
+  ],
+}));
+
+server.tool(GET_INCIDENT, GI_DESC, GI_SCHEMA, async ({ id }) => ({
+  content: [
+    { type: "text" as const, text: await handleGetIncidentDetail(id, client).catch(wrapError) },
+  ],
+}));
+
+server.tool(GET_HISTORY, GH_DESC, GH_SCHEMA, async ({ id, window }) => ({
+  content: [
+    {
+      type: "text" as const,
+      text: await handleGetProviderHistory(id, window ?? "30d", client).catch(wrapError),
+    },
+  ],
+}));
+
+server.tool(COMPARE, CMP_DESC, CMP_SCHEMA, async ({ ids }) => ({
+  content: [
+    { type: "text" as const, text: await handleCompareProviders(ids, client).catch(wrapError) },
+  ],
+}));
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd mcp && npm run build
+```
+
+Expected: `dist/` directory created, no TypeScript errors.
+
+- [ ] **Step 3: Run all tests one final time**
+
+```bash
+cd mcp && npm test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Smoke-test the binary locally**
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | node dist/index.js
+```
+
+Expected: JSON response listing all 6 tools with their names and descriptions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/index.ts
+git commit -m "feat(mcp): wire MCP server entry point"
+```
+
+---
+
+## Task 10: GitHub Actions publish workflow
+
+**Files:**
+- Create: `.github/workflows/publish-mcp.yml`
+
+- [ ] **Step 1: Create `.github/workflows/publish-mcp.yml`**
+
+```yaml
+name: Publish @llmstatus/mcp
+
+on:
+  push:
+    tags:
+      - "mcp-v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        working-directory: mcp
+        run: npm ci
+
+      - name: Run tests
+        working-directory: mcp
+        run: npm test
+
+      - name: Build
+        working-directory: mcp
+        run: npm run build
+
+      - name: Publish
+        working-directory: mcp
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+- [ ] **Step 2: Verify workflow file is valid YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-mcp.yml'))" && echo "YAML valid"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Add `mcp/dist` to `.gitignore` inside `mcp/`**
+
+Create `mcp/.gitignore`:
+
+```
+dist/
+node_modules/
+*.tsbuildinfo
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/publish-mcp.yml mcp/.gitignore
+git commit -m "ci: add publish-mcp GitHub Actions workflow"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- [x] §3 Directory structure — Task 1
+- [x] §4.1 `list_providers` — Task 3
+- [x] §4.2 `get_provider_status` — Task 4 (including 404 → valid IDs fallback)
+- [x] §4.3 `list_active_incidents` (with provider_id filter) — Task 5
+- [x] §4.4 `get_incident_detail` — Task 6
+- [x] §4.5 `get_provider_history` — Task 7
+- [x] §4.6 `compare_providers` (capped at 5, `Promise.allSettled`) — Task 8
+- [x] §5 Error handling (ApiError, network, 404) — Task 2 client + Task 4 handler
+- [x] §6 `LLMSTATUS_API_BASE` env var — Task 2 client constructor
+- [x] §7 Installation docs — covered in spec, no code needed
+- [x] §8 Publishing workflow — Task 10
+
+**Type consistency:**
+- `LLMStatusClient` defined in Task 2, used identically in Tasks 3–9 ✓
+- `ApiError` imported from `types.ts` in Task 4 handler ✓
+- `CompareRow` discriminated union defined and used in same file (Task 8) ✓
+- `TOOL_SCHEMA` exported from each tool and imported in `index.ts` (Task 9) ✓
+- `window` parameter typed as `"24h" | "7d" | "30d"` consistently across Task 7 and Task 9 ✓

--- a/docs/superpowers/specs/2026-04-26-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-04-26-mcp-server-design.md
@@ -1,0 +1,253 @@
+# MCP Server Design — @llmstatus/mcp
+
+**Date**: 2026-04-26  
+**Status**: Approved  
+**Issue**: TBD (create LLMS- issue before implementation)
+
+---
+
+## 1. Goal
+
+Publish an npm package (`@llmstatus/mcp`) that exposes llmstatus.io data as
+MCP tools. Any Claude or Cursor user can add it to their config and then ask
+"Is OpenAI down right now?" — the AI calls the tool, gets a plain-text answer,
+and responds inline. Zero configuration required.
+
+---
+
+## 2. Architecture
+
+A thin stdio MCP server written in TypeScript. It is a pure HTTP client: it
+calls the public `https://api.llmstatus.io` REST API and formats responses as
+AI-readable plain text. No business logic is duplicated; no database access.
+
+```
+User question
+    │
+    ▼
+Claude / Cursor (MCP host)
+    │  calls tool via stdio
+    ▼
+@llmstatus/mcp (npx, ephemeral process)
+    │  GET /v1/...
+    ▼
+api.llmstatus.io (public, unauthenticated, 30 s Redis cache)
+    │
+    ▼
+Plain-text summary returned to AI
+```
+
+---
+
+## 3. Directory Structure
+
+Inside `llmstatus/mcp/` (new directory in the open-source repo):
+
+```
+mcp/
+├── package.json          # name: @llmstatus/mcp, bin: llmstatus-mcp
+├── tsconfig.json
+├── src/
+│   ├── index.ts          # entry point: registers tools, starts stdio server
+│   ├── client.ts         # fetchJSON() with base URL + error handling
+│   ├── types.ts          # TypeScript types mirroring Go API response shapes
+│   └── tools/
+│       ├── list_providers.ts
+│       ├── get_provider_status.ts
+│       ├── list_active_incidents.ts
+│       ├── get_incident_detail.ts
+│       ├── get_provider_history.ts
+│       └── compare_providers.ts
+└── dist/                 # compiled output (.gitignored, included in npm publish)
+```
+
+**Runtime dependencies**: `@modelcontextprotocol/sdk` only.  
+**Build**: `tsc` (no bundler).  
+**Node version**: ≥ 18 (for `fetch` built-in).
+
+---
+
+## 4. Tools
+
+All tools are read-only. Each returns a plain-text summary, not raw JSON.
+
+### 4.1 `list_providers`
+
+- **Endpoint**: `GET /v1/providers`
+- **Parameters**: none
+- **Output example**:
+  ```
+  20 providers monitored. Current status:
+  ✓ OpenAI — operational (99.97% / 342ms p95)
+  ✓ Anthropic — operational (99.95% / 410ms p95)
+  ⚠ Groq — degraded (active incident)
+  ...
+  ```
+
+### 4.2 `get_provider_status`
+
+- **Endpoint**: `GET /v1/providers/{id}`
+- **Parameters**: `id: string` (provider ID, e.g. `openai`)
+- **Output example**:
+  ```
+  OpenAI — operational
+  Uptime (24h): 99.97% | P95 latency: 342ms
+  Models: gpt-4o ✓, gpt-4o-mini ✓, o3 ✓
+  No active incidents.
+  ```
+
+### 4.3 `list_active_incidents`
+
+- **Endpoint**: `GET /v1/incidents?status=ongoing`
+- **Parameters**: `provider_id?: string` (optional filter)
+- **Output example**:
+  ```
+  2 active incidents:
+  [major] Groq — elevated error rate (started 14 min ago)
+  [minor] Azure OpenAI — degraded latency in us-east (started 2h ago)
+  ```
+
+### 4.4 `get_incident_detail`
+
+- **Endpoint**: `GET /v1/incidents/{id}`
+- **Parameters**: `id: string` (UUID or slug)
+- **Output example**:
+  ```
+  Incident: Groq elevated error rate
+  Status: ongoing | Severity: major
+  Provider: groq | Started: 2026-04-26T08:12:00Z
+  Affected models: llama-3.3-70b
+  Affected regions: us-west-2, us-east-1
+  Description: Error rate rose above 15% across US nodes. Rate-limit errors
+  are the primary failure type.
+  ```
+
+### 4.5 `get_provider_history`
+
+- **Endpoint**: `GET /v1/providers/{id}/history`
+- **Parameters**: `id: string`, `window?: "24h" | "7d" | "30d"` (default `"24h"`)
+- **Output example**:
+  ```
+  Anthropic — past 7 days
+  Uptime: 99.92% | P95: 395ms avg | P99: 1240ms avg
+  Incidents: 1 minor (resolved)
+  ```
+
+### 4.6 `compare_providers`
+
+- **Endpoint**: concurrent `GET /v1/providers/{id}` for each ID
+- **Parameters**: `ids: string[]` (2–5 provider IDs; capped at 5 to bound concurrent requests)
+- **Output example**:
+  ```
+  Provider comparison (24h):
+  Provider       Status       Uptime   P95 (ms)
+  ─────────────────────────────────────────────
+  openai         operational  99.97%   342
+  anthropic      operational  99.95%   410
+  google_gemini  operational  99.88%   520
+  ```
+
+---
+
+## 5. Error Handling
+
+MCP tools must never throw unhandled errors — they return readable text so the
+AI can relay the issue to the user.
+
+| Error | Response text |
+|---|---|
+| 404 — provider not found | `Provider "X" not found. Valid IDs: openai, anthropic, ...` |
+| Network / timeout | `llmstatus.io is temporarily unreachable. Please try again shortly.` |
+| API 5xx | `llmstatus.io returned an error (500). Please try again shortly.` |
+| Invalid parameter (zod) | Rejected at schema layer; AI auto-corrects |
+
+---
+
+## 6. Configuration
+
+One optional environment variable:
+
+```
+LLMSTATUS_API_BASE=https://api.llmstatus.io   # default; override for local dev
+```
+
+No API key required.
+
+---
+
+## 7. Installation
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "llmstatus": {
+      "command": "npx",
+      "args": ["-y", "@llmstatus/mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json` in the project root (or global Cursor settings):
+
+```json
+{
+  "mcpServers": {
+    "llmstatus": {
+      "command": "npx",
+      "args": ["-y", "@llmstatus/mcp"]
+    }
+  }
+}
+```
+
+### Local development override
+
+```json
+{
+  "mcpServers": {
+    "llmstatus": {
+      "command": "npx",
+      "args": ["-y", "@llmstatus/mcp"],
+      "env": { "LLMSTATUS_API_BASE": "http://localhost:8080" }
+    }
+  }
+}
+```
+
+---
+
+## 8. Publishing
+
+- Package name: `@llmstatus/mcp`
+- Versioned in sync with main repo (semver; PATCH for tool fixes, MINOR for new tools)
+- Published via `npm publish` from `llmstatus/mcp/` on tag
+- GitHub Actions workflow: `.github/workflows/publish-mcp.yml`
+  - Triggers on tags matching `mcp-v*`
+  - Runs `tsc`, `npm publish --access public`
+
+---
+
+## 9. Out of Scope (V1)
+
+- HTTP SSE transport (remote/team deployment)
+- In-process caching (stdio processes are short-lived; low ROI)
+- Authentication / private data access
+- Write operations (subscribe, report)
+- Resources or Prompts (MCP primitives beyond Tools)
+
+---
+
+## 10. Open Questions (operator decision required)
+
+1. **npm org**: Does `@llmstatus` npm org exist? If not, fall back to unscoped `llmstatus-mcp`.
+2. **Versioning coupling**: Should `mcp/` have its own version (`1.0.0`) independent of the Go
+   services, or mirror the monorepo version?
+3. **Rate limit carve-out**: `npx` installs trigger many concurrent users hitting the API.
+   Should MCP tool calls get a dedicated rate-limit bucket in `internal/api/ratelimit.go`?

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tsbuildinfo

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -10,10 +10,11 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "zod": "^3.23.0"
+        "zod": "^3.25.0"
       },
       "bin": {
-        "llmstatus-mcp": "dist/index.js"
+        "llmstatus-mcp": "dist/index.js",
+        "mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,2882 @@
+{
+  "name": "@llmstatus/mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@llmstatus/mcp",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "llmstatus-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.4.0",
+        "vitest": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -4,7 +4,8 @@
   "description": "MCP server for llmstatus.io — query AI provider status from Claude and Cursor",
   "type": "module",
   "bin": {
-    "llmstatus-mcp": "./dist/index.js"
+    "llmstatus-mcp": "./dist/index.js",
+    "mcp": "./dist/index.js"
   },
   "files": [
     "dist"
@@ -17,7 +18,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "zod": "^3.23.0"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@llmstatus/mcp",
+  "version": "1.0.0",
+  "description": "MCP server for llmstatus.io — query AI provider status from Claude and Cursor",
+  "type": "module",
+  "bin": {
+    "llmstatus-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build && npm test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/llmstatus/llmstatus"
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -4,8 +4,7 @@
   "description": "MCP server for llmstatus.io — query AI provider status from Claude and Cursor",
   "type": "module",
   "bin": {
-    "llmstatus-mcp": "./dist/index.js",
-    "mcp": "./dist/index.js"
+    "llmstatus-mcp": "./dist/index.js"
   },
   "files": [
     "dist"

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -38,7 +38,15 @@ export class LLMStatusClient {
         `llmstatus.io returned HTTP ${response.status}.${response.status === 404 ? " Resource not found." : " Please try again shortly."}`
       );
     }
-    const envelope = (await response.json()) as ApiEnvelope<T>;
+    let envelope: ApiEnvelope<T>;
+    try {
+      envelope = (await response.json()) as ApiEnvelope<T>;
+    } catch {
+      throw new ApiError(
+        response.status,
+        `llmstatus.io returned unparseable response (HTTP ${response.status}).`
+      );
+    }
     return envelope.data;
   }
 
@@ -54,7 +62,8 @@ export class LLMStatusClient {
     const qs = new URLSearchParams();
     if (params.status) qs.set("status", params.status);
     if (params.limit != null) qs.set("limit", String(params.limit));
-    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    const q = qs.toString();
+    const suffix = q ? `?${q}` : "";
     return this.fetchJSON<IncidentResponse[]>(`/v1/incidents${suffix}`);
   }
 

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -1,0 +1,70 @@
+import type {
+  ApiEnvelope,
+  HistoryBucket,
+  IncidentResponse,
+  ProviderDetail,
+  ProviderSummary,
+} from "./types.js";
+import { ApiError } from "./types.js";
+
+const DEFAULT_BASE_URL = "https://api.llmstatus.io";
+
+export class LLMStatusClient {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl?: string) {
+    this.baseUrl = (baseUrl ?? process.env["LLMSTATUS_API_BASE"] ?? DEFAULT_BASE_URL).replace(
+      /\/$/,
+      ""
+    );
+  }
+
+  private async fetchJSON<T>(path: string): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}${path}`, {
+        headers: { "User-Agent": "@llmstatus/mcp/1.0.0" },
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch {
+      throw new ApiError(
+        0,
+        "llmstatus.io is temporarily unreachable. Please try again shortly."
+      );
+    }
+    if (!response.ok) {
+      throw new ApiError(
+        response.status,
+        `llmstatus.io returned HTTP ${response.status}.${response.status === 404 ? " Resource not found." : " Please try again shortly."}`
+      );
+    }
+    const envelope = (await response.json()) as ApiEnvelope<T>;
+    return envelope.data;
+  }
+
+  listProviders(): Promise<ProviderSummary[]> {
+    return this.fetchJSON<ProviderSummary[]>("/v1/providers");
+  }
+
+  getProvider(id: string): Promise<ProviderDetail> {
+    return this.fetchJSON<ProviderDetail>(`/v1/providers/${encodeURIComponent(id)}`);
+  }
+
+  listIncidents(params: { status?: string; limit?: number } = {}): Promise<IncidentResponse[]> {
+    const qs = new URLSearchParams();
+    if (params.status) qs.set("status", params.status);
+    if (params.limit != null) qs.set("limit", String(params.limit));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return this.fetchJSON<IncidentResponse[]>(`/v1/incidents${suffix}`);
+  }
+
+  getIncident(id: string): Promise<IncidentResponse> {
+    return this.fetchJSON<IncidentResponse>(`/v1/incidents/${encodeURIComponent(id)}`);
+  }
+
+  getProviderHistory(id: string, window = "30d"): Promise<HistoryBucket[]> {
+    return this.fetchJSON<HistoryBucket[]>(
+      `/v1/providers/${encodeURIComponent(id)}/history?window=${encodeURIComponent(window)}`
+    );
+  }
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -37,56 +37,42 @@ import {
   TOOL_SCHEMA as CMP_SCHEMA,
   handleCompareProviders,
 } from "./tools/compare_providers.js";
-import { ApiError } from "./types.js";
 
 const client = new LLMStatusClient();
 const server = new McpServer({ name: "llmstatus", version: "1.0.0" });
 
-function wrapError(err: unknown): string {
-  if (err instanceof ApiError) return err.message;
-  if (err instanceof Error) return err.message;
-  return "An unexpected error occurred.";
+type ToolResult = { content: [{ type: "text"; text: string }]; isError?: boolean };
+
+async function callTool(work: Promise<string>): Promise<ToolResult> {
+  try {
+    return { content: [{ type: "text", text: await work }] };
+  } catch (err) {
+    const text = err instanceof Error ? err.message : "An unexpected error occurred.";
+    return { content: [{ type: "text", text }], isError: true };
+  }
 }
 
-server.tool(LIST_PROVIDERS, LP_DESC, {}, async () => ({
-  content: [{ type: "text" as const, text: await handleListProviders(client).catch(wrapError) }],
-}));
+server.tool(LIST_PROVIDERS, LP_DESC, {}, () => callTool(handleListProviders(client)));
 
-server.tool(GET_PROVIDER_STATUS, GPS_DESC, GPS_SCHEMA, async ({ id }) => ({
-  content: [
-    { type: "text" as const, text: await handleGetProviderStatus(id, client).catch(wrapError) },
-  ],
-}));
+server.tool(GET_PROVIDER_STATUS, GPS_DESC, GPS_SCHEMA, ({ id }) =>
+  callTool(handleGetProviderStatus(id, client)),
+);
 
-server.tool(LIST_INCIDENTS, LI_DESC, LI_SCHEMA, async ({ provider_id }) => ({
-  content: [
-    {
-      type: "text" as const,
-      text: await handleListActiveIncidents(provider_id, client).catch(wrapError),
-    },
-  ],
-}));
+server.tool(LIST_INCIDENTS, LI_DESC, LI_SCHEMA, ({ provider_id }) =>
+  callTool(handleListActiveIncidents(provider_id, client)),
+);
 
-server.tool(GET_INCIDENT, GI_DESC, GI_SCHEMA, async ({ id }) => ({
-  content: [
-    { type: "text" as const, text: await handleGetIncidentDetail(id, client).catch(wrapError) },
-  ],
-}));
+server.tool(GET_INCIDENT, GI_DESC, GI_SCHEMA, ({ id }) =>
+  callTool(handleGetIncidentDetail(id, client)),
+);
 
-server.tool(GET_HISTORY, GH_DESC, GH_SCHEMA, async ({ id, window }) => ({
-  content: [
-    {
-      type: "text" as const,
-      text: await handleGetProviderHistory(id, window ?? "30d", client).catch(wrapError),
-    },
-  ],
-}));
+server.tool(GET_HISTORY, GH_DESC, GH_SCHEMA, ({ id, window }) =>
+  callTool(handleGetProviderHistory(id, window ?? "30d", client)),
+);
 
-server.tool(COMPARE, CMP_DESC, CMP_SCHEMA, async ({ ids }) => ({
-  content: [
-    { type: "text" as const, text: await handleCompareProviders(ids, client).catch(wrapError) },
-  ],
-}));
+server.tool(COMPARE, CMP_DESC, CMP_SCHEMA, ({ ids }) =>
+  callTool(handleCompareProviders(ids, client)),
+);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { LLMStatusClient } from "./client.js";
+import {
+  TOOL_NAME as LIST_PROVIDERS,
+  TOOL_DESCRIPTION as LP_DESC,
+  handleListProviders,
+} from "./tools/list_providers.js";
+import {
+  TOOL_NAME as GET_PROVIDER_STATUS,
+  TOOL_DESCRIPTION as GPS_DESC,
+  TOOL_SCHEMA as GPS_SCHEMA,
+  handleGetProviderStatus,
+} from "./tools/get_provider_status.js";
+import {
+  TOOL_NAME as LIST_INCIDENTS,
+  TOOL_DESCRIPTION as LI_DESC,
+  TOOL_SCHEMA as LI_SCHEMA,
+  handleListActiveIncidents,
+} from "./tools/list_active_incidents.js";
+import {
+  TOOL_NAME as GET_INCIDENT,
+  TOOL_DESCRIPTION as GI_DESC,
+  TOOL_SCHEMA as GI_SCHEMA,
+  handleGetIncidentDetail,
+} from "./tools/get_incident_detail.js";
+import {
+  TOOL_NAME as GET_HISTORY,
+  TOOL_DESCRIPTION as GH_DESC,
+  TOOL_SCHEMA as GH_SCHEMA,
+  handleGetProviderHistory,
+} from "./tools/get_provider_history.js";
+import {
+  TOOL_NAME as COMPARE,
+  TOOL_DESCRIPTION as CMP_DESC,
+  TOOL_SCHEMA as CMP_SCHEMA,
+  handleCompareProviders,
+} from "./tools/compare_providers.js";
+import { ApiError } from "./types.js";
+
+const client = new LLMStatusClient();
+const server = new McpServer({ name: "llmstatus", version: "1.0.0" });
+
+function wrapError(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return "An unexpected error occurred.";
+}
+
+server.tool(LIST_PROVIDERS, LP_DESC, {}, async () => ({
+  content: [{ type: "text" as const, text: await handleListProviders(client).catch(wrapError) }],
+}));
+
+server.tool(GET_PROVIDER_STATUS, GPS_DESC, GPS_SCHEMA, async ({ id }) => ({
+  content: [
+    { type: "text" as const, text: await handleGetProviderStatus(id, client).catch(wrapError) },
+  ],
+}));
+
+server.tool(LIST_INCIDENTS, LI_DESC, LI_SCHEMA, async ({ provider_id }) => ({
+  content: [
+    {
+      type: "text" as const,
+      text: await handleListActiveIncidents(provider_id, client).catch(wrapError),
+    },
+  ],
+}));
+
+server.tool(GET_INCIDENT, GI_DESC, GI_SCHEMA, async ({ id }) => ({
+  content: [
+    { type: "text" as const, text: await handleGetIncidentDetail(id, client).catch(wrapError) },
+  ],
+}));
+
+server.tool(GET_HISTORY, GH_DESC, GH_SCHEMA, async ({ id, window }) => ({
+  content: [
+    {
+      type: "text" as const,
+      text: await handleGetProviderHistory(id, window ?? "30d", client).catch(wrapError),
+    },
+  ],
+}));
+
+server.tool(COMPARE, CMP_DESC, CMP_SCHEMA, async ({ ids }) => ({
+  content: [
+    { type: "text" as const, text: await handleCompareProviders(ids, client).catch(wrapError) },
+  ],
+}));
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp/src/tools/__tests__/client.test.ts
+++ b/mcp/src/tools/__tests__/client.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LLMStatusClient } from "../../client.js";
+import { ApiError } from "../../types.js";
+
+const mockFetch = vi.fn();
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeEnvelope<T>(data: T) {
+  return { data, meta: { generated_at: "2026-04-26T00:00:00Z", cache_ttl_s: 30 } };
+}
+
+describe("LLMStatusClient.listProviders", () => {
+  it("returns parsed provider array on 200", async () => {
+    const providers = [{ id: "openai", name: "OpenAI" }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeEnvelope(providers),
+    });
+    const client = new LLMStatusClient("http://localhost");
+    const result = await client.listProviders();
+    expect(result).toEqual(providers);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost/v1/providers",
+      expect.objectContaining({ headers: expect.any(Object) })
+    );
+  });
+
+  it("throws ApiError on 404", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    const client = new LLMStatusClient("http://localhost");
+    try {
+      await client.listProviders();
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err).toHaveProperty("status", 404);
+    }
+  });
+
+  it("throws ApiError on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+    const client = new LLMStatusClient("http://localhost");
+    try {
+      await client.listProviders();
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err).toHaveProperty("status", 0);
+    }
+  });
+});
+
+describe("LLMStatusClient.listIncidents", () => {
+  it("appends status query param when provided", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeEnvelope([]),
+    });
+    const client = new LLMStatusClient("http://localhost");
+    await client.listIncidents({ status: "ongoing" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost/v1/incidents?status=ongoing",
+      expect.anything()
+    );
+  });
+});

--- a/mcp/src/tools/__tests__/client.test.ts
+++ b/mcp/src/tools/__tests__/client.test.ts
@@ -53,6 +53,23 @@ describe("LLMStatusClient.listProviders", () => {
       expect(err).toHaveProperty("status", 0);
     }
   });
+
+  it("throws ApiError when response body is not valid JSON", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    });
+    const client = new LLMStatusClient("http://localhost");
+    try {
+      await client.listProviders();
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+    }
+  });
 });
 
 describe("LLMStatusClient.listIncidents", () => {

--- a/mcp/src/tools/__tests__/compare_providers.test.ts
+++ b/mcp/src/tools/__tests__/compare_providers.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { formatComparison } from "../compare_providers.js";
+import type { ProviderDetail } from "../../types.js";
+
+const makeProvider = (
+  id: string,
+  name: string,
+  status: "operational" | "degraded" | "down" = "operational"
+): ProviderDetail => ({
+  id,
+  name,
+  category: "official",
+  region: "us",
+  probe_scope: "global",
+  current_status: status,
+  uptime_24h: 0.9997,
+  p95_ms: 342,
+  model_stats: [],
+  models: [],
+  active_incidents: [],
+  region_stats: [],
+});
+
+describe("formatComparison", () => {
+  it("renders a table with all providers", () => {
+    const out = formatComparison([
+      { type: "ok", data: makeProvider("openai", "OpenAI") },
+      { type: "ok", data: makeProvider("anthropic", "Anthropic") },
+    ]);
+    expect(out).toContain("OpenAI");
+    expect(out).toContain("Anthropic");
+    expect(out).toContain("operational");
+    expect(out).toContain("99.97%");
+  });
+
+  it("shows error row for failed provider fetch", () => {
+    const out = formatComparison([
+      { type: "ok", data: makeProvider("openai", "OpenAI") },
+      { type: "error", id: "bad_id", message: "not found" },
+    ]);
+    expect(out).toContain("bad_id");
+    expect(out).toContain("not found");
+  });
+
+  it("handles N/A for missing uptime and latency", () => {
+    const noStats = makeProvider("openai", "OpenAI");
+    noStats.uptime_24h = undefined;
+    noStats.p95_ms = undefined;
+    const out = formatComparison([{ type: "ok", data: noStats }]);
+    expect(out).toContain("N/A");
+    expect(out).not.toContain("undefined");
+  });
+});

--- a/mcp/src/tools/__tests__/get_incident_detail.test.ts
+++ b/mcp/src/tools/__tests__/get_incident_detail.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { formatIncident } from "../get_incident_detail.js";
+import type { IncidentResponse } from "../../types.js";
+
+const incident: IncidentResponse = {
+  id: "uuid-123",
+  slug: "2026-04-26-openai-errors",
+  provider_id: "openai",
+  severity: "major",
+  title: "Elevated error rate",
+  description: "Error rate rose above 15% across US nodes.",
+  status: "ongoing",
+  affected_models: ["gpt-4o", "gpt-4o-mini"],
+  affected_regions: ["us-west-2", "us-east-1"],
+  started_at: "2026-04-26T08:12:00Z",
+  detection_method: "auto",
+  human_reviewed: true,
+};
+
+describe("formatIncident", () => {
+  it("includes title, severity, provider, started_at", () => {
+    const out = formatIncident(incident);
+    expect(out).toContain("Elevated error rate");
+    expect(out).toContain("major");
+    expect(out).toContain("openai");
+    expect(out).toContain("2026-04-26T08:12:00Z");
+  });
+
+  it("lists affected models and regions", () => {
+    const out = formatIncident(incident);
+    expect(out).toContain("gpt-4o");
+    expect(out).toContain("us-west-2");
+  });
+
+  it("includes description when present", () => {
+    const out = formatIncident(incident);
+    expect(out).toContain("Error rate rose above 15%");
+  });
+
+  it("includes resolved_at when present", () => {
+    const resolved = { ...incident, resolved_at: "2026-04-26T09:00:00Z" };
+    const out = formatIncident(resolved);
+    expect(out).toContain("2026-04-26T09:00:00Z");
+  });
+
+  it("omits description line when absent", () => {
+    const noDesc = { ...incident, description: undefined };
+    const out = formatIncident(noDesc);
+    expect(out).not.toContain("undefined");
+  });
+});

--- a/mcp/src/tools/__tests__/get_provider_history.test.ts
+++ b/mcp/src/tools/__tests__/get_provider_history.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatHistory } from "../get_provider_history.js";
+import type { HistoryBucket } from "../../types.js";
+
+const makeBucket = (uptime: number, p95_ms: number, errors = 0): HistoryBucket => ({
+  timestamp: "2026-04-25T00:00:00Z",
+  total: 100,
+  errors,
+  uptime,
+  p95_ms,
+});
+
+describe("formatHistory", () => {
+  it("shows provider name, window, avg uptime, avg p95", () => {
+    const buckets = [makeBucket(1.0, 300), makeBucket(0.99, 400), makeBucket(0.98, 500)];
+    const out = formatHistory("OpenAI", "7d", buckets);
+    expect(out).toContain("OpenAI");
+    expect(out).toContain("7d");
+    expect(out).toContain("99.00%"); // avg of 1.0+0.99+0.98 = 2.97/3
+    expect(out).toContain("400ms"); // avg of 300+400+500 = 400
+  });
+
+  it("handles empty bucket list", () => {
+    const out = formatHistory("OpenAI", "7d", []);
+    expect(out).toContain("No history data");
+  });
+
+  it("skips p95 avg when all buckets have zero latency", () => {
+    const out = formatHistory("OpenAI", "24h", [makeBucket(1.0, 0)]);
+    expect(out).not.toContain("NaN");
+  });
+});

--- a/mcp/src/tools/__tests__/get_provider_status.test.ts
+++ b/mcp/src/tools/__tests__/get_provider_status.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { formatProviderDetail } from "../get_provider_status.js";
+import type { ProviderDetail } from "../../types.js";
+
+const base: ProviderDetail = {
+  id: "openai",
+  name: "OpenAI",
+  category: "official",
+  region: "us",
+  probe_scope: "global",
+  current_status: "operational",
+  uptime_24h: 0.9997,
+  p95_ms: 342,
+  model_stats: [
+    { model_id: "gpt-4o", display_name: "GPT-4o", uptime_24h: 0.9998, p95_ms: 340, sparkline: [] },
+    { model_id: "gpt-4o-mini", display_name: "GPT-4o mini", uptime_24h: 0.9999, p95_ms: 210, sparkline: [] },
+  ],
+  models: [],
+  active_incidents: [],
+  region_stats: [],
+};
+
+describe("formatProviderDetail", () => {
+  it("shows name, status, uptime, and latency", () => {
+    const out = formatProviderDetail(base);
+    expect(out).toContain("OpenAI");
+    expect(out).toContain("operational");
+    expect(out).toContain("99.97%");
+    expect(out).toContain("342ms");
+  });
+
+  it("shows model list", () => {
+    const out = formatProviderDetail(base);
+    expect(out).toContain("GPT-4o");
+    expect(out).toContain("GPT-4o mini");
+  });
+
+  it("shows 'No active incidents' when clean", () => {
+    const out = formatProviderDetail(base);
+    expect(out).toContain("No active incidents");
+  });
+
+  it("shows active incident title when present", () => {
+    const withInc: ProviderDetail = {
+      ...base,
+      current_status: "degraded",
+      active_incidents: [
+        { id: "abc", slug: "test", severity: "major", title: "Elevated errors", status: "ongoing", started_at: "2026-04-26T10:00:00Z" },
+      ],
+    };
+    const out = formatProviderDetail(withInc);
+    expect(out).toContain("Elevated errors");
+    expect(out).toContain("major");
+  });
+});

--- a/mcp/src/tools/__tests__/list_active_incidents.test.ts
+++ b/mcp/src/tools/__tests__/list_active_incidents.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { formatIncidentList } from "../list_active_incidents.js";
+import type { IncidentResponse } from "../../types.js";
+
+const makeInc = (overrides: Partial<IncidentResponse> = {}): IncidentResponse => ({
+  id: "abc123",
+  slug: "2026-04-26-openai-errors",
+  provider_id: "openai",
+  severity: "major",
+  title: "Elevated error rate",
+  status: "ongoing",
+  affected_models: ["gpt-4o"],
+  affected_regions: ["us-west-2"],
+  started_at: new Date(Date.now() - 14 * 60 * 1000).toISOString(), // 14 min ago
+  detection_method: "auto",
+  human_reviewed: false,
+  ...overrides,
+});
+
+describe("formatIncidentList", () => {
+  it("returns no-incident message for empty list", () => {
+    const out = formatIncidentList([]);
+    expect(out).toContain("No active incidents");
+  });
+
+  it("shows count, provider, title, severity", () => {
+    const out = formatIncidentList([makeInc()]);
+    expect(out).toContain("1 active incident");
+    expect(out).toContain("openai");
+    expect(out).toContain("Elevated error rate");
+    expect(out).toContain("major");
+  });
+
+  it("shows plural for multiple incidents", () => {
+    const out = formatIncidentList([makeInc(), makeInc({ id: "def456", provider_id: "anthropic" })]);
+    expect(out).toContain("2 active incidents");
+  });
+
+  it("filters by provider_id when specified", () => {
+    const incidents = [makeInc({ provider_id: "openai" }), makeInc({ id: "z", provider_id: "anthropic" })];
+    const out = formatIncidentList(incidents, "openai");
+    expect(out).toContain("1 active incident");
+    expect(out).not.toContain("anthropic");
+  });
+});

--- a/mcp/src/tools/__tests__/list_providers.test.ts
+++ b/mcp/src/tools/__tests__/list_providers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatProviderList } from "../list_providers.js";
+import type { ProviderSummary } from "../../types.js";
+
+const base: ProviderSummary = {
+  id: "openai",
+  name: "OpenAI",
+  category: "official",
+  region: "us",
+  probe_scope: "global",
+  current_status: "operational",
+  uptime_24h: 0.9997,
+  p95_ms: 342,
+  model_stats: [],
+};
+
+describe("formatProviderList", () => {
+  it("shows count and operational tick", () => {
+    const out = formatProviderList([base]);
+    expect(out).toContain("1 provider");
+    expect(out).toContain("✓");
+    expect(out).toContain("OpenAI");
+    expect(out).toContain("operational");
+    expect(out).toContain("99.97%");
+    expect(out).toContain("342ms");
+  });
+
+  it("shows warning icon for degraded provider", () => {
+    const out = formatProviderList([{ ...base, current_status: "degraded" }]);
+    expect(out).toContain("⚠");
+  });
+
+  it("shows cross icon for down provider", () => {
+    const out = formatProviderList([{ ...base, current_status: "down" }]);
+    expect(out).toContain("✗");
+  });
+
+  it("handles missing uptime/latency gracefully", () => {
+    const minimal = { ...base, uptime_24h: undefined, p95_ms: undefined };
+    expect(() => formatProviderList([minimal])).not.toThrow();
+  });
+
+  it("returns a message for empty list", () => {
+    const out = formatProviderList([]);
+    expect(out).toContain("0 provider");
+  });
+});

--- a/mcp/src/tools/compare_providers.ts
+++ b/mcp/src/tools/compare_providers.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import type { ProviderDetail } from "../types.js";
+
+export const TOOL_NAME = "compare_providers";
+export const TOOL_DESCRIPTION =
+  "Compare 2 to 5 AI providers side-by-side: current status, 24-hour uptime, and P95 latency.";
+export const TOOL_SCHEMA = {
+  ids: z
+    .array(z.string())
+    .min(2)
+    .max(5)
+    .describe("2 to 5 provider IDs to compare, e.g. ['openai', 'anthropic']"),
+};
+
+type CompareRow =
+  | { type: "ok"; data: ProviderDetail }
+  | { type: "error"; id: string; message: string };
+
+export function formatComparison(rows: CompareRow[]): string {
+  const COL = [22, 16, 10, 10];
+  const header = [
+    "Provider".padEnd(COL[0]),
+    "Status".padEnd(COL[1]),
+    "Uptime".padEnd(COL[2]),
+    "P95 (ms)",
+  ].join(" ");
+  const sep = "─".repeat(COL[0] + COL[1] + COL[2] + 12);
+
+  const lines = [`Provider comparison (24h):`, sep, header, sep];
+  for (const row of rows) {
+    if (row.type === "error") {
+      lines.push(`${row.id.padEnd(COL[0])} error: ${row.message}`);
+    } else {
+      const p = row.data;
+      const uptime = p.uptime_24h != null ? `${(p.uptime_24h * 100).toFixed(2)}%` : "N/A";
+      const p95 = p.p95_ms != null ? `${Math.round(p.p95_ms)}` : "N/A";
+      lines.push(
+        [
+          p.name.padEnd(COL[0]),
+          p.current_status.padEnd(COL[1]),
+          uptime.padEnd(COL[2]),
+          p95,
+        ].join(" ")
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+export async function handleCompareProviders(
+  ids: string[],
+  client: LLMStatusClient
+): Promise<string> {
+  const settled = await Promise.allSettled(ids.map((id) => client.getProvider(id)));
+  const rows: CompareRow[] = settled.map((result, i) => {
+    if (result.status === "fulfilled") {
+      return { type: "ok", data: result.value };
+    }
+    const msg = result.reason instanceof Error ? result.reason.message : "unknown error";
+    return { type: "error", id: ids[i]!, message: msg };
+  });
+  return formatComparison(rows);
+}

--- a/mcp/src/tools/get_incident_detail.ts
+++ b/mcp/src/tools/get_incident_detail.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { LLMStatusClient } from "../client.js";
+import { ApiError } from "../types.js";
 import type { IncidentResponse } from "../types.js";
 
 export const TOOL_NAME = "get_incident_detail";
@@ -31,6 +32,13 @@ export async function handleGetIncidentDetail(
   id: string,
   client: LLMStatusClient
 ): Promise<string> {
-  const inc = await client.getIncident(id);
-  return formatIncident(inc);
+  try {
+    const inc = await client.getIncident(id);
+    return formatIncident(inc);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      return `Incident "${id}" not found. Use list_active_incidents to see current incidents.`;
+    }
+    throw err;
+  }
 }

--- a/mcp/src/tools/get_incident_detail.ts
+++ b/mcp/src/tools/get_incident_detail.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import type { IncidentResponse } from "../types.js";
+
+export const TOOL_NAME = "get_incident_detail";
+export const TOOL_DESCRIPTION =
+  "Get full details for a specific incident by its UUID or slug (e.g. '2026-04-26-openai-errors').";
+export const TOOL_SCHEMA = {
+  id: z
+    .string()
+    .describe("Incident UUID or slug, e.g. '2026-04-26-openai-elevated-errors' or a UUID"),
+};
+
+export function formatIncident(inc: IncidentResponse): string {
+  const lines = [
+    `Incident: ${inc.title}`,
+    `Status: ${inc.status} | Severity: ${inc.severity}`,
+    `Provider: ${inc.provider_id}`,
+    `Started: ${inc.started_at}`,
+  ];
+  if (inc.resolved_at) lines.push(`Resolved: ${inc.resolved_at}`);
+  if (inc.affected_models.length > 0)
+    lines.push(`Affected models: ${inc.affected_models.join(", ")}`);
+  if (inc.affected_regions.length > 0)
+    lines.push(`Affected regions: ${inc.affected_regions.join(", ")}`);
+  if (inc.description) lines.push(`\n${inc.description}`);
+  return lines.join("\n");
+}
+
+export async function handleGetIncidentDetail(
+  id: string,
+  client: LLMStatusClient
+): Promise<string> {
+  const inc = await client.getIncident(id);
+  return formatIncident(inc);
+}

--- a/mcp/src/tools/get_provider_history.ts
+++ b/mcp/src/tools/get_provider_history.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import type { HistoryBucket } from "../types.js";
+
+export const TOOL_NAME = "get_provider_history";
+export const TOOL_DESCRIPTION =
+  "Get historical uptime and latency data for a provider over a given time window.";
+export const TOOL_SCHEMA = {
+  id: z.string().describe("Provider ID, e.g. 'openai'"),
+  window: z
+    .enum(["24h", "7d", "30d"])
+    .optional()
+    .default("30d")
+    .describe("Time window: '24h', '7d', or '30d'. Defaults to '30d'."),
+};
+
+export function formatHistory(
+  providerName: string,
+  window: string,
+  buckets: HistoryBucket[]
+): string {
+  if (buckets.length === 0) {
+    return `No history data available for ${providerName} in the ${window} window.`;
+  }
+  const avgUptime = buckets.reduce((s, b) => s + b.uptime, 0) / buckets.length;
+  const withLatency = buckets.filter((b) => b.p95_ms > 0);
+  const avgP95 =
+    withLatency.length > 0
+      ? withLatency.reduce((s, b) => s + b.p95_ms, 0) / withLatency.length
+      : 0;
+  const totalErrors = buckets.reduce((s, b) => s + b.errors, 0);
+
+  const lines = [
+    `${providerName} — past ${window}`,
+    `Uptime: ${(avgUptime * 100).toFixed(2)}%`,
+  ];
+  if (avgP95 > 0) lines.push(`Avg P95 latency: ${Math.round(avgP95)}ms`);
+  lines.push(`Total error probes: ${totalErrors}`);
+  lines.push(`Buckets: ${buckets.length}`);
+  return lines.join("\n");
+}
+
+export async function handleGetProviderHistory(
+  id: string,
+  window: "24h" | "7d" | "30d",
+  client: LLMStatusClient
+): Promise<string> {
+  const [buckets, detail] = await Promise.all([
+    client.getProviderHistory(id, window),
+    client.getProvider(id),
+  ]);
+  return formatHistory(detail.name, window, buckets);
+}

--- a/mcp/src/tools/get_provider_status.ts
+++ b/mcp/src/tools/get_provider_status.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import { ApiError } from "../types.js";
+import type { ProviderDetail } from "../types.js";
+
+export const TOOL_NAME = "get_provider_status";
+export const TOOL_DESCRIPTION =
+  "Get the current operational status, uptime, latency, and active incidents for a specific AI provider.";
+export const TOOL_SCHEMA = {
+  id: z.string().describe("Provider ID, e.g. 'openai', 'anthropic', 'google_gemini'"),
+};
+
+export function formatProviderDetail(p: ProviderDetail): string {
+  const icon =
+    p.current_status === "operational" ? "✓" : p.current_status === "down" ? "✗" : "⚠";
+  const lines = [`${p.name} — ${icon} ${p.current_status}`];
+  if (p.uptime_24h != null) lines.push(`Uptime (24h): ${(p.uptime_24h * 100).toFixed(2)}%`);
+  if (p.p95_ms != null) lines.push(`P95 latency: ${Math.round(p.p95_ms)}ms`);
+
+  const models = p.model_stats.filter((m) => m.uptime_24h > 0);
+  if (models.length > 0) {
+    lines.push(
+      `Models: ${models.map((m) => `${m.display_name} (${(m.uptime_24h * 100).toFixed(1)}%)`).join(", ")}`
+    );
+  }
+
+  if (p.active_incidents.length > 0) {
+    lines.push("\nActive incidents:");
+    for (const inc of p.active_incidents) {
+      lines.push(`  [${inc.severity}] ${inc.title}`);
+    }
+  } else {
+    lines.push("No active incidents.");
+  }
+
+  return lines.join("\n");
+}
+
+export async function handleGetProviderStatus(
+  id: string,
+  client: LLMStatusClient
+): Promise<string> {
+  try {
+    const detail = await client.getProvider(id);
+    return formatProviderDetail(detail);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      const all = await client.listProviders().catch(() => []);
+      const ids = all.map((p) => p.id).join(", ");
+      return `Provider "${id}" not found.${ids ? ` Valid IDs: ${ids}` : ""}`;
+    }
+    throw err;
+  }
+}

--- a/mcp/src/tools/get_provider_status.ts
+++ b/mcp/src/tools/get_provider_status.ts
@@ -45,7 +45,10 @@ export async function handleGetProviderStatus(
     return formatProviderDetail(detail);
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
-      const all = await client.listProviders().catch(() => []);
+      const all = await client.listProviders().catch((e: unknown) => {
+        console.error("[llmstatus-mcp] failed to fetch provider list for 404 hint:", e);
+        return [];
+      });
       const ids = all.map((p) => p.id).join(", ");
       return `Provider "${id}" not found.${ids ? ` Valid IDs: ${ids}` : ""}`;
     }

--- a/mcp/src/tools/list_active_incidents.ts
+++ b/mcp/src/tools/list_active_incidents.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import type { LLMStatusClient } from "../client.js";
+import type { IncidentResponse } from "../types.js";
+
+export const TOOL_NAME = "list_active_incidents";
+export const TOOL_DESCRIPTION =
+  "List all currently active (ongoing) incidents across all monitored AI providers. Optionally filter to one provider.";
+export const TOOL_SCHEMA = {
+  provider_id: z
+    .string()
+    .optional()
+    .describe("Optional provider ID to filter results, e.g. 'openai'"),
+};
+
+function formatAge(isoString: string): string {
+  const ms = Date.now() - new Date(isoString).getTime();
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+export function formatIncidentList(incidents: IncidentResponse[], providerFilter?: string): string {
+  const filtered = providerFilter
+    ? incidents.filter((i) => i.provider_id === providerFilter)
+    : incidents;
+
+  if (filtered.length === 0) {
+    return providerFilter
+      ? `No active incidents for provider "${providerFilter}".`
+      : "No active incidents. All monitored providers are operating normally.";
+  }
+
+  const count = filtered.length;
+  const lines = [`${count} active incident${count !== 1 ? "s" : ""}:\n`];
+  for (const inc of filtered) {
+    const age = formatAge(inc.started_at);
+    lines.push(`[${inc.severity}] ${inc.title} (${inc.provider_id}) — started ${age} ago`);
+  }
+  return lines.join("\n");
+}
+
+export async function handleListActiveIncidents(
+  providerFilter: string | undefined,
+  client: LLMStatusClient
+): Promise<string> {
+  const incidents = await client.listIncidents({ status: "ongoing", limit: 100 });
+  return formatIncidentList(incidents, providerFilter);
+}

--- a/mcp/src/tools/list_providers.ts
+++ b/mcp/src/tools/list_providers.ts
@@ -1,0 +1,29 @@
+import type { LLMStatusClient } from "../client.js";
+import type { ProviderSummary } from "../types.js";
+
+export const TOOL_NAME = "list_providers";
+export const TOOL_DESCRIPTION =
+  "List all AI providers monitored by llmstatus.io with their current operational status, 24-hour uptime, and latency.";
+export const TOOL_SCHEMA = {};
+
+export function formatProviderList(providers: ProviderSummary[]): string {
+  const count = providers.length;
+  if (count === 0) return "0 providers found.";
+
+  const icon = (s: ProviderSummary["current_status"]) =>
+    s === "operational" ? "✓" : s === "down" ? "✗" : "⚠";
+
+  const lines = [`${count} provider${count !== 1 ? "s" : ""} monitored:\n`];
+  for (const p of providers) {
+    const uptime =
+      p.uptime_24h != null ? ` (${(p.uptime_24h * 100).toFixed(2)}% uptime 24h)` : "";
+    const p95 = p.p95_ms != null ? ` / ${Math.round(p.p95_ms)}ms p95` : "";
+    lines.push(`${icon(p.current_status)} ${p.name} [${p.id}] — ${p.current_status}${uptime}${p95}`);
+  }
+  return lines.join("\n");
+}
+
+export async function handleListProviders(client: LLMStatusClient): Promise<string> {
+  const providers = await client.listProviders();
+  return formatProviderList(providers);
+}

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -1,0 +1,92 @@
+export interface ApiEnvelope<T> {
+  data: T;
+  meta: {
+    generated_at: string;
+    cache_ttl_s: number;
+  };
+}
+
+export interface ModelStat {
+  model_id: string;
+  display_name: string;
+  uptime_24h: number;
+  p95_ms: number;
+  sparkline: number[];
+}
+
+export interface ProviderSummary {
+  id: string;
+  name: string;
+  category: string;
+  region: string;
+  probe_scope: string;
+  current_status: "operational" | "degraded" | "down";
+  active_incident_id?: string;
+  uptime_24h?: number;
+  p95_ms?: number;
+  model_stats: ModelStat[];
+}
+
+export interface ModelSummary {
+  model_id: string;
+  display_name: string;
+  model_type: string;
+  active: boolean;
+}
+
+export interface IncidentRef {
+  id: string;
+  slug: string;
+  severity: string;
+  title: string;
+  status: string;
+  started_at: string;
+}
+
+export interface RegionStat {
+  region_id: string;
+  uptime_24h: number;
+  p95_ms: number;
+}
+
+export interface ProviderDetail extends ProviderSummary {
+  status_page_url?: string;
+  documentation_url?: string;
+  models: ModelSummary[];
+  active_incidents: IncidentRef[];
+  region_stats: RegionStat[];
+}
+
+export interface IncidentResponse {
+  id: string;
+  slug: string;
+  provider_id: string;
+  severity: "critical" | "major" | "minor";
+  title: string;
+  description?: string;
+  status: "ongoing" | "monitoring" | "resolved";
+  affected_models: string[];
+  affected_regions: string[];
+  started_at: string;
+  resolved_at?: string;
+  detection_method: string;
+  human_reviewed: boolean;
+}
+
+export interface HistoryBucket {
+  timestamp: string;
+  total: number;
+  errors: number;
+  uptime: number;
+  p95_ms: number;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds `mcp/` — a new TypeScript npm package (`@llmstatus/mcp`) that exposes llmstatus.io data as MCP tools for Claude Desktop, Cursor, and any MCP-compatible AI assistant
- Implements 6 read-only tools: `list_providers`, `get_provider_status`, `list_active_incidents`, `get_incident_detail`, `get_provider_history`, `compare_providers` — each returning plain-text summaries the AI can relay inline
- Adds `.github/workflows/publish-mcp.yml` that auto-publishes to npm on `mcp-v*` tags with provenance attestation

## Architecture

Pure HTTP client — calls `https://api.llmstatus.io` REST endpoints, no business logic duplication, no DB access. Runtime dependency: `@modelcontextprotocol/sdk` only. Requires Node ≥ 18 (native `fetch`).

## Usage (once published)

Add to Claude Desktop config:
\`\`\`json
{
  "mcpServers": {
    "llmstatus": {
      "command": "npx",
      "args": ["-y", "@llmstatus/mcp"]
    }
  }
}
\`\`\`

## Test Plan

- [x] 29/29 unit tests pass (\`npm test\` in \`mcp/\`)
- [x] \`npm run build\` produces clean \`dist/\` output
- [x] Smoke-tested via stdio: all 6 tool names returned by \`tools/list\`
- [ ] Manual end-to-end: add to Claude Desktop config and ask "Is OpenAI down right now?"
- [ ] Confirm \`@llmstatus\` npm org exists before publishing (or fall back to unscoped \`llmstatus-mcp\`)
- [ ] Set \`NPM_TOKEN\` secret in repo settings before first \`mcp-v*\` tag push