### PR TITLE
feat: add Discord and GitHub icons to site footer

### DIFF
--- a/web/components/SiteFooter.tsx
+++ b/web/components/SiteFooter.tsx
@@ -7,6 +7,32 @@ interface Props {
 const DEFAULT_MESSAGE =
   "Data sourced from real API calls, not status pages. Updated every 30 s.";
 
+function GitHubIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill="currentColor"
+      className="w-4 h-4"
+    >
+      <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
+
+function DiscordIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill="currentColor"
+      className="w-4 h-4"
+    >
+      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.1 18.08.114 18.1.132 18.11a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+    </svg>
+  );
+}
+
 export function SiteFooter({ message = DEFAULT_MESSAGE }: Props) {
   return (
     <footer className="border-t border-[var(--ink-600)] px-6 py-4">
@@ -18,6 +44,25 @@ export function SiteFooter({ message = DEFAULT_MESSAGE }: Props) {
           <Link href="/privacy" className="hover:text-[var(--ink-200)] transition-colors">Privacy</Link>
           <Link href="/tos" className="hover:text-[var(--ink-200)] transition-colors">Terms</Link>
           <Link href="/api/feed" className="hover:text-[var(--ink-200)] transition-colors" aria-label="RSS feed">RSS</Link>
+          <span className="text-[var(--ink-600)]">|</span>
+          <a
+            href="https://discord.gg/jVesHFy7"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Join our Discord"
+            className="hover:text-[var(--ink-200)] transition-colors"
+          >
+            <DiscordIcon />
+          </a>
+          <a
+            href="https://github.com/llmstatus/llmstatus"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub repository"
+            className="hover:text-[var(--ink-200)] transition-colors"
+          >
+            <GitHubIcon />
+          </a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

- Adds Discord (https://discord.gg/jVesHFy7) and GitHub icons to the right side of the site footer
- Icons are inlined SVGs (official brand paths) — no new dependency
- Separated from nav links with a `|` divider
- Both links open in a new tab with `noopener noreferrer`; `aria-label` provided for accessibility

## Test Plan

- [x] `tsc --noEmit` passes
- [x] Icons render correctly in footer alongside existing nav links