### PR TITLE
fix: use SITE_URL env var for RSS feed links

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -76,6 +76,7 @@ func main() {
 		api.WithHistoryReader(historyReader),
 		api.WithLiveStatsReader(historyReader),
 		api.WithRateLimiter(limiter),
+		api.WithSiteURL(envOr("SITE_URL", "https://llmstatus.io")),
 	}
 
 	if authCfg, ok := buildAuthConfig(store); ok {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,7 @@ services:
       INFLUX_TOKEN: ${INFLUX_TOKEN:-dev-token}
       INFLUX_DATABASE: ${INFLUX_DATABASE:-probes}
       API_ADDR: ":8081"
+      SITE_URL: ${SITE_URL:-https://llmstatus.io}
       API_RATE_LIMIT: ${API_RATE_LIMIT:-60}
       JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret-change-in-prod}
       INTERNAL_SECRET: ${INTERNAL_SECRET:-dev-internal-secret}

--- a/internal/api/feed.go
+++ b/internal/api/feed.go
@@ -80,7 +80,7 @@ func (s *Server) getGlobalFeed(w http.ResponseWriter, r *http.Request) {
 	providers, _ := s.store.ListActiveProviders(r.Context())
 	names := providerNameMap(providers)
 
-	base := siteBase(r)
+	base := s.siteBase(r)
 	writeFeed(w, feedData{
 		Title:         "llmstatus.io — All Incidents",
 		Link:          base,
@@ -116,7 +116,7 @@ func (s *Server) getProviderFeed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	base := siteBase(r)
+	base := s.siteBase(r)
 	writeFeed(w, feedData{
 		Title:         p.Name + " — Incidents | llmstatus.io",
 		Link:          base + "/providers/" + p.ID,
@@ -171,9 +171,13 @@ func providerNameMap(providers []pgstore.Provider) map[string]string {
 	return m
 }
 
-// siteBase constructs the scheme+host base URL, honouring X-Forwarded-Proto
-// set by nginx in production.
-func siteBase(r *http.Request) string {
+// siteBase returns the canonical scheme+host base URL for use in feed links.
+// When s.siteURL is configured it is returned directly; otherwise the URL is
+// reconstructed from X-Forwarded-Proto and Host headers (nginx sets both in prod).
+func (s *Server) siteBase(r *http.Request) string {
+	if s.siteURL != "" {
+		return s.siteURL
+	}
 	scheme := r.Header.Get("X-Forwarded-Proto")
 	if scheme == "" {
 		if r.TLS != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	keyEnc    *keyenc.Encrypter // optional; nil → sponsor key endpoints return 503
 	mailer    email.Sender      // optional; nil → admin approval emails skipped
 	hub       *Hub              // WebSocket hub for real-time updates
+	siteURL   string            // optional; overrides header-derived base URL in feed/badge links
 	mux       *http.ServeMux
 	handler   http.Handler // mux optionally wrapped with limiter middleware
 }
@@ -60,6 +61,12 @@ func WithKeyEncrypter(enc *keyenc.Encrypter) func(*Server) {
 // WithEmailSender enables transactional emails (sponsor approval notifications).
 func WithEmailSender(m email.Sender) func(*Server) {
 	return func(s *Server) { s.mailer = m }
+}
+
+// WithSiteURL sets the canonical public base URL used in feed and badge links.
+// When set it takes precedence over Host/X-Forwarded-* header reconstruction.
+func WithSiteURL(u string) func(*Server) {
+	return func(s *Server) { s.siteURL = u }
 }
 
 // New creates a Server and registers all routes. Pass functional options


### PR DESCRIPTION
## Root cause

The Next.js feed proxy routes (`/api/feed`, `/api/feed/[id]`) call the Go API
internally via `http://api:8081` — no `Host` or `X-Forwarded-Proto` headers are
forwarded. So `siteBase()` reconstructed the URL as `http://api:8081`, which
leaked into all `<link>` and `<guid>` elements in the RSS XML.

## Fix

- Add `siteURL string` field to `Server` and a `WithSiteURL()` option
- `siteBase()` returns `s.siteURL` when set; falls back to header reconstruction
- `cmd/api/main.go` wires `SITE_URL` env var (default `https://llmstatus.io`)
- `docker-compose.yml` passes `SITE_URL` to the `api` service

`SITE_URL` was already documented in the `cmd/api` godoc but was never actually
wired — this closes that gap.

## Test plan

- [x] All 9 feed tests pass (`go test ./internal/api/ -run Feed`)
- [x] `go build ./...` clean