### PR TITLE
fix: add Redis 7 service to docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Fixed
+- Add Redis 7 service to docker-compose; wire api healthcheck dependency — `REDIS_URL` was set in the Ansible env template but no Redis container existed, causing OTP rate limiting to silently fail on first use
+
 ### Changed (UI overhaul)
 - Lighten canvas color tokens: base `#0D1117`, raised `#161D28`, overlay `#1C2638` — increases card-to-background contrast and makes the dark theme feel less cave-dark
 - Raise ink-400 (`#7B8899`) and ink-500 (`#4D5B6C`) for readable secondary text; ink-600 borders now `#2D3A4A`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@
 # FIXED HOST PORTS (do not change — chosen to avoid conflicts on this host):
 #   db       — PostgreSQL 17        host:15432 → container:5432
 #   influx   — InfluxDB 3 Core      host:18086 → container:8181
+#   redis    — Redis 7               host:16379 → container:6379
 #   ingest   — probe ingest API     host:18080 → container:8080
 #   api      — public read API      host:18081 → container:8081
 #   web      — Next.js frontend     host:13000 → container:3000
@@ -63,6 +64,20 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+
+  redis:
+    image: redis:7-alpine
+    container_name: llmstatus-redis
+    restart: unless-stopped
+    volumes:
+      - ${REDIS_DATA_DIR:-./data/redis}:/data
+    ports:
+      - "16379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # ── one-shot migration runner ───────────────────────────────────────────────
 
@@ -145,10 +160,13 @@ services:
       INTERNAL_SECRET: ${INTERNAL_SECRET:-dev-internal-secret}
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       EMAIL_FROM: ${EMAIL_FROM:-noreply@llmstatus.io}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
     depends_on:
       db:
         condition: service_healthy
       influx:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     ports:
       - "18081:8081"


### PR DESCRIPTION
## Summary
- Add `redis:7-alpine` service with healthcheck and persistent volume
- Wire `api` service to depend on `redis: condition: service_healthy`
- Add `REDIS_URL: redis://redis:6379` to api environment in docker-compose
- Redis data dir already provisioned by Ansible; env.j2 already sets `REDIS_URL`

## Root cause
`REDIS_URL=redis://redis:6379` was templated into the production `.env` via Ansible, but no Redis container was defined in `docker-compose.yml`. The API starts fine (lazy connection), but OTP rate limiting silently fails on first use since there's nothing listening on `redis:6379`.

## Test plan
- [ ] `docker compose up -d redis` — container starts, healthcheck passes
- [ ] `docker compose up -d api` — api depends_on redis healthy, starts after
- [ ] `docker compose exec redis redis-cli ping` → `PONG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)