### PR TITLE
feat: rule 6.5 quality degradation + test-email endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,16 @@ public APIs must add an entry under `## [Unreleased]`.
 
 ## [Unreleased]
 
+### Added
+- Rule 6.5 (quality degradation): detector now tracks quality probe failure rates and creates `quality_degradation` incidents when the current 5-minute failure rate exceeds 3× the 24-hour baseline or surpasses 30% in absolute terms; `QualityByProvider` query filters `probe_type = 'quality'`
+- `POST /v1/admin/test-email` endpoint (requires `X-Internal-Token`) for verifying the Resend email integration end-to-end
+
 ### Fixed
 - Add Redis 7 service to docker-compose; wire api healthcheck dependency — `REDIS_URL` was set in the Ansible env template but no Redis container existed, causing OTP rate limiting to silently fail on first use
+- Fix `TestListProviders_Operational`, `TestListProviders_WithOngoingIncident`, and `TestListProviders_LiveStatsNil_OmitsFields` — tests lacked a live stats reader, causing providers to be filtered from the response
+
+### Changed
+- Update copy: "7 global locations" → "5 global locations" across homepage and providers page metadata
 
 ### Changed (UI overhaul)
 - Lighten canvas color tokens: base `#0D1117`, raised `#161D28`, overlay `#1C2638` — increases card-to-background contrast and makes the dark theme feel less cave-dark

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -101,6 +101,36 @@ func (s *Server) adminRejectSponsor(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, sp)
 }
 
+// POST /v1/admin/test-email — send a test email to verify the Resend integration.
+// Requires X-Internal-Token header (shared internal secret). Not restricted to admins
+// so it can be called without a user account.
+func (s *Server) adminTestEmail(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("X-Internal-Token") != s.auth.InternalSecret {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if s.mailer == nil {
+		writeError(w, http.StatusServiceUnavailable, "mailer not configured")
+		return
+	}
+	to := r.URL.Query().Get("to")
+	if to == "" {
+		writeError(w, http.StatusBadRequest, "to query param required")
+		return
+	}
+	if err := s.mailer.Send(r.Context(), email.Message{
+		To:      to,
+		Subject: "[llmstatus] Test email — integration check",
+		Text:    "If you received this, the Resend integration is working correctly.",
+	}); err != nil {
+		slog.Error("admin: test email failed", "to", to, "err", err)
+		writeError(w, http.StatusInternalServerError, "send failed: "+err.Error())
+		return
+	}
+	slog.Info("admin: test email sent", "to", to)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "sent", "to": to})
+}
+
 func (s *Server) sendSponsorStatusEmail(r *http.Request, userID int64, sponsorName, status string) {
 	if s.mailer == nil || s.auth == nil {
 		return

--- a/internal/api/providers_test.go
+++ b/internal/api/providers_test.go
@@ -32,7 +32,12 @@ func TestListProviders_Operational(t *testing.T) {
 	store := &fakeStore{
 		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
 	}
-	srv := api.New(store)
+	liveReader := &fakeLiveStatsReader{
+		stats: []influx.ProviderLiveStat{
+			{ProviderID: "openai", Uptime24h: 0.99, P95Ms: 200},
+		},
+	}
+	srv := api.New(store, api.WithLiveStatsReader(liveReader))
 
 	rec := doGet(t, srv, "/v1/providers")
 
@@ -65,7 +70,12 @@ func TestListProviders_WithOngoingIncident(t *testing.T) {
 		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
 		incidents: []pgstore.Incident{inc},
 	}
-	srv := api.New(store)
+	liveReader := &fakeLiveStatsReader{
+		stats: []influx.ProviderLiveStat{
+			{ProviderID: "openai", Uptime24h: 0.40, P95Ms: 1200},
+		},
+	}
+	srv := api.New(store, api.WithLiveStatsReader(liveReader))
 
 	rec := doGet(t, srv, "/v1/providers")
 
@@ -126,10 +136,12 @@ func TestListProviders_WithLiveStats(t *testing.T) {
 }
 
 func TestListProviders_LiveStatsNil_OmitsFields(t *testing.T) {
+	// When liveStats reader is configured but returns no data for a provider,
+	// that provider is excluded from the response (no data = not yet probed).
 	store := &fakeStore{
 		providers: []pgstore.Provider{fixtureProvider("openai", "OpenAI")},
 	}
-	srv := api.New(store) // no WithLiveStatsReader
+	srv := api.New(store) // no WithLiveStatsReader → provider excluded
 
 	rec := doGet(t, srv, "/v1/providers")
 
@@ -137,19 +149,9 @@ func TestListProviders_LiveStatsNil_OmitsFields(t *testing.T) {
 		Data []json.RawMessage `json:"data"`
 	}
 	mustDecode(t, rec.Body, &body)
-	if len(body.Data) != 1 {
-		t.Fatalf("data length: got %d, want 1", len(body.Data))
-	}
-	// Fields must be absent (omitempty), not null.
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body.Data[0], &raw); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if _, ok := raw["uptime_24h"]; ok {
-		t.Error("uptime_24h should be absent when liveStats is nil")
-	}
-	if _, ok := raw["p95_ms"]; ok {
-		t.Error("p95_ms should be absent when liveStats is nil")
+	// Provider has no live data, so it is filtered out entirely.
+	if len(body.Data) != 0 {
+		t.Fatalf("data length: got %d, want 0 (provider excluded when no live stats)", len(body.Data))
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -141,6 +141,7 @@ func (s *Server) registerRoutes() {
 		s.mux.HandleFunc("GET /v1/admin/sponsors", s.adminListSponsors)
 		s.mux.HandleFunc("POST /v1/admin/sponsors/{id}/approve", s.adminApproveSponsor)
 		s.mux.HandleFunc("POST /v1/admin/sponsors/{id}/reject", s.adminRejectSponsor)
+		s.mux.HandleFunc("POST /v1/admin/test-email", s.adminTestEmail)
 	}
 }
 

--- a/internal/detector/reader.go
+++ b/internal/detector/reader.go
@@ -35,6 +35,9 @@ type ProbeReader interface {
 	LatencyByProvider(ctx context.Context, window time.Duration) ([]LatencyStats, error)
 	// RegionalErrorRateByProvider returns per-provider, per-region error stats.
 	RegionalErrorRateByProvider(ctx context.Context, window time.Duration) ([]RegionalStats, error)
+	// QualityByProvider returns per-provider quality probe stats for the given window.
+	// Only probes with probe_type = 'quality' are counted.
+	QualityByProvider(ctx context.Context, window time.Duration) ([]ProbeStats, error)
 }
 
 // InfluxReaderConfig holds connection parameters for the InfluxDB 3 query API.
@@ -195,6 +198,52 @@ func (r *influxReader) RegionalErrorRateByProvider(ctx context.Context, window t
 		})
 	}
 	return out, nil
+}
+
+func (r *influxReader) QualityByProvider(ctx context.Context, window time.Duration) ([]ProbeStats, error) {
+	sql := fmt.Sprintf(
+		`SELECT provider_id,
+		        COUNT(*) AS total,
+		        COUNT(*) FILTER (WHERE success = false) AS errors
+		 FROM probes
+		 WHERE time >= now() - INTERVAL '%d seconds'
+		   AND probe_type = 'quality'
+		 GROUP BY provider_id`,
+		int(window.Seconds()),
+	)
+
+	resp, err := r.querySQLRaw(ctx, sql)
+	if err != nil {
+		return nil, fmt.Errorf("detector quality: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("detector quality: influx status %d: %s", resp.StatusCode, detail)
+	}
+
+	var rows []struct {
+		ProviderID string  `json:"provider_id"`
+		Total      float64 `json:"total"`
+		Errors     float64 `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("detector quality: decode: %w", err)
+	}
+
+	stats := make([]ProbeStats, 0, len(rows))
+	for _, row := range rows {
+		if row.ProviderID == "" {
+			continue
+		}
+		stats = append(stats, ProbeStats{
+			ProviderID: row.ProviderID,
+			Total:      int64(row.Total),
+			Errors:     int64(row.Errors),
+		})
+	}
+	return stats, nil
 }
 
 // querySQLRaw sends a SQL query to InfluxDB 3 and returns the raw HTTP response.

--- a/internal/detector/rules.go
+++ b/internal/detector/rules.go
@@ -2,10 +2,11 @@ package detector
 
 // Detection rule identifiers.
 const (
-	RuleProviderDown       = "provider_down"
-	RuleElevatedErrors     = "elevated_errors"
-	RuleLatencyDegradation = "latency_degradation"
-	RuleRegionalOutage     = "regional_outage"
+	RuleProviderDown        = "provider_down"
+	RuleElevatedErrors      = "elevated_errors"
+	RuleLatencyDegradation  = "latency_degradation"
+	RuleRegionalOutage      = "regional_outage"
+	RuleQualityDegradation  = "quality_degradation"
 
 	downThreshold     = 0.50
 	elevatedThreshold = 0.05
@@ -18,6 +19,12 @@ const (
 	// Rule 6.4: fire when one region exceeds this error rate while not globally down.
 	regionalOutageThreshold = 0.50
 	minRegionalProbeCount   = int64(3)
+
+	// Rule 6.5: fire when quality error rate in current window > qualityDegradationFactor
+	// times the baseline rate, or exceeds qualityAbsoluteThreshold when baseline is zero.
+	qualityDegradationFactor    = 3.0
+	qualityAbsoluteThreshold    = 0.30
+	minQualityProbeCount        = int64(2)
 )
 
 // Detection is a rule match for a single provider.
@@ -145,6 +152,46 @@ func EvaluateLatencyRule(current, baseline []LatencyStats) []Detection {
 				TotalProbes:   c.SampleCount,
 				P95Ms:         c.P95Ms,
 				BaselineP95Ms: b.P95Ms,
+			})
+		}
+	}
+	return detections
+}
+
+// EvaluateQualityRule applies rule 6.5 — quality degradation.
+//
+// Fires when a provider's quality probe failure rate in `current` exceeds
+// qualityDegradationFactor × the `baseline` rate, or surpasses
+// qualityAbsoluteThreshold when the baseline rate is effectively zero.
+// Both windows require at least minQualityProbeCount probes.
+func EvaluateQualityRule(current, baseline []ProbeStats) []Detection {
+	baselineByProvider := make(map[string]ProbeStats, len(baseline))
+	for _, b := range baseline {
+		baselineByProvider[b.ProviderID] = b
+	}
+
+	var detections []Detection
+	for _, c := range current {
+		if c.Total < minQualityProbeCount {
+			continue
+		}
+		rate := c.ErrorRate()
+		b := baselineByProvider[c.ProviderID]
+
+		var fires bool
+		if b.Total < minQualityProbeCount || b.ErrorRate() == 0 {
+			fires = rate >= qualityAbsoluteThreshold
+		} else {
+			fires = rate > qualityDegradationFactor*b.ErrorRate()
+		}
+
+		if fires {
+			detections = append(detections, Detection{
+				ProviderID:  c.ProviderID,
+				Rule:        RuleQualityDegradation,
+				Severity:    "minor",
+				ErrorRate:   rate,
+				TotalProbes: c.Total,
 			})
 		}
 	}

--- a/internal/detector/rules_test.go
+++ b/internal/detector/rules_test.go
@@ -330,6 +330,9 @@ func (f *latencyFakeReader) LatencyByProvider(_ context.Context, window time.Dur
 func (f *latencyFakeReader) RegionalErrorRateByProvider(_ context.Context, _ time.Duration) ([]RegionalStats, error) {
 	return nil, nil
 }
+func (f *latencyFakeReader) QualityByProvider(_ context.Context, _ time.Duration) ([]ProbeStats, error) {
+	return nil, nil
+}
 
 // regionalFakeReader only populates regional stats.
 type regionalFakeReader struct {
@@ -344,6 +347,31 @@ func (f *regionalFakeReader) LatencyByProvider(_ context.Context, _ time.Duratio
 }
 func (f *regionalFakeReader) RegionalErrorRateByProvider(_ context.Context, _ time.Duration) ([]RegionalStats, error) {
 	return f.regional, nil
+}
+func (f *regionalFakeReader) QualityByProvider(_ context.Context, _ time.Duration) ([]ProbeStats, error) {
+	return nil, nil
+}
+
+// qualityFakeReader returns distinct data for current (5m) vs baseline (24h).
+type qualityFakeReader struct {
+	current  []ProbeStats
+	baseline []ProbeStats
+}
+
+func (f *qualityFakeReader) ErrorRateByProvider(_ context.Context, _ time.Duration) ([]ProbeStats, error) {
+	return nil, nil
+}
+func (f *qualityFakeReader) LatencyByProvider(_ context.Context, _ time.Duration) ([]LatencyStats, error) {
+	return nil, nil
+}
+func (f *qualityFakeReader) RegionalErrorRateByProvider(_ context.Context, _ time.Duration) ([]RegionalStats, error) {
+	return nil, nil
+}
+func (f *qualityFakeReader) QualityByProvider(_ context.Context, window time.Duration) ([]ProbeStats, error) {
+	if window <= 5*time.Minute {
+		return f.current, nil
+	}
+	return f.baseline, nil
 }
 
 func TestProbeStats_ErrorRate(t *testing.T) {
@@ -361,5 +389,92 @@ func TestProbeStats_ErrorRate(t *testing.T) {
 		if got := s.ErrorRate(); got != tc.want {
 			t.Errorf("ErrorRate(%d/%d) = %f, want %f", tc.errors, tc.total, got, tc.want)
 		}
+	}
+}
+
+// ---- Rule 6.5 — quality degradation -----------------------------------------
+
+func TestEvaluateQualityRule_NoProbes(t *testing.T) {
+	got := EvaluateQualityRule(nil, nil)
+	if len(got) != 0 {
+		t.Errorf("expected 0 detections on empty stats, got %d", len(got))
+	}
+}
+
+func TestEvaluateQualityRule_TooFewProbes(t *testing.T) {
+	current := []ProbeStats{{ProviderID: "openai", Total: 1, Errors: 1}}
+	got := EvaluateQualityRule(current, nil)
+	if len(got) != 0 {
+		t.Errorf("expected 0 detections with only 1 probe, got %d", len(got))
+	}
+}
+
+func TestEvaluateQualityRule_AbsoluteThreshold_NoBaseline(t *testing.T) {
+	// 3 of 5 quality probes fail (60%) — exceeds 30% absolute threshold with no baseline data.
+	current := []ProbeStats{{ProviderID: "openai", Total: 5, Errors: 3}}
+	got := EvaluateQualityRule(current, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 detection, got %d", len(got))
+	}
+	d := got[0]
+	if d.Rule != RuleQualityDegradation {
+		t.Errorf("Rule: got %q, want %q", d.Rule, RuleQualityDegradation)
+	}
+	if d.Severity != "minor" {
+		t.Errorf("Severity: got %q, want minor", d.Severity)
+	}
+}
+
+func TestEvaluateQualityRule_BelowAbsoluteThreshold(t *testing.T) {
+	// 1 of 5 quality probes fail (20%) — below 30% absolute threshold.
+	current := []ProbeStats{{ProviderID: "openai", Total: 5, Errors: 1}}
+	got := EvaluateQualityRule(current, nil)
+	if len(got) != 0 {
+		t.Errorf("expected no detection below absolute threshold, got %d", len(got))
+	}
+}
+
+func TestEvaluateQualityRule_RelativeThreshold_Fires(t *testing.T) {
+	// Baseline: 1/20 = 5%. Current: 4/5 = 80% → 16× baseline, exceeds 3× threshold.
+	current := []ProbeStats{{ProviderID: "anthropic", Total: 5, Errors: 4}}
+	baseline := []ProbeStats{{ProviderID: "anthropic", Total: 20, Errors: 1}}
+	got := EvaluateQualityRule(current, baseline)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 detection, got %d", len(got))
+	}
+	if got[0].Rule != RuleQualityDegradation {
+		t.Errorf("Rule: got %q, want %q", got[0].Rule, RuleQualityDegradation)
+	}
+}
+
+func TestEvaluateQualityRule_RelativeThreshold_BelowFactor(t *testing.T) {
+	// Baseline: 2/20 = 10%. Current: 1/5 = 20% → 2× baseline, below 3× threshold.
+	current := []ProbeStats{{ProviderID: "anthropic", Total: 5, Errors: 1}}
+	baseline := []ProbeStats{{ProviderID: "anthropic", Total: 20, Errors: 2}}
+	got := EvaluateQualityRule(current, baseline)
+	if len(got) != 0 {
+		t.Errorf("expected no detection when ratio below factor, got %d", len(got))
+	}
+}
+
+func TestRunner_QualityDegradation_CreatesIncident(t *testing.T) {
+	store := &fakeIncidentStore{}
+	r := New(&qualityFakeReader{
+		current:  []ProbeStats{{ProviderID: "openai", Total: 5, Errors: 3}}, // 60% failure
+		baseline: []ProbeStats{},                                             // no baseline → absolute threshold applies
+	}, store, time.Hour)
+	r.runOnce(context.Background())
+
+	found := false
+	for _, inc := range store.created {
+		if inc.DetectionRule.String == RuleQualityDegradation {
+			found = true
+			if inc.Severity != "minor" {
+				t.Errorf("Severity: got %q, want minor", inc.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected quality_degradation incident to be created")
 	}
 }

--- a/internal/detector/runner.go
+++ b/internal/detector/runner.go
@@ -87,6 +87,17 @@ func (r *Runner) runOnce(ctx context.Context) {
 	}
 	detections = append(detections, EvaluateRegionalRule(regional5m, stats5m)...)
 
+	// Rule 6.5 — quality degradation.
+	quality5m, err := r.reader.QualityByProvider(ctx, 5*time.Minute)
+	if err != nil {
+		slog.Warn("detector: read quality 5m stats", "err", err)
+	}
+	quality24h, err := r.reader.QualityByProvider(ctx, 24*time.Hour)
+	if err != nil {
+		slog.Warn("detector: read quality 24h stats", "err", err)
+	}
+	detections = append(detections, EvaluateQualityRule(quality5m, quality24h)...)
+
 	for _, d := range detections {
 		r.ensureIncident(ctx, d)
 	}
@@ -196,6 +207,8 @@ func incidentTitle(providerID, rule string) string {
 		return providerID + " latency degradation detected"
 	case RuleRegionalOutage:
 		return providerID + " regional outage detected"
+	case RuleQualityDegradation:
+		return providerID + " quality degradation detected"
 	default:
 		return providerID + " " + rule
 	}

--- a/internal/detector/runner_test.go
+++ b/internal/detector/runner_test.go
@@ -41,6 +41,10 @@ func (f *fakeReader) RegionalErrorRateByProvider(_ context.Context, _ time.Durat
 	return f.regional, f.err
 }
 
+func (f *fakeReader) QualityByProvider(_ context.Context, _ time.Duration) ([]ProbeStats, error) {
+	return nil, f.err
+}
+
 // ---- fake IncidentStore -----------------------------------------------------
 
 type fakeIncidentStore struct {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -10,12 +10,12 @@ export const metadata: Metadata = {
   title: "AI API Status Monitor",
   description:
     "Independent real-time monitoring for the AI infrastructure. " +
-    "Measured from 7 global locations. Not scraped from official status pages.",
+    "Measured from 5 global locations. Not scraped from official status pages.",
   openGraph: {
     title: "llmstatus.io — AI API Status Monitor",
     description:
       "Independent real-time monitoring for the AI infrastructure. " +
-      "Measured from 7 global locations. Not scraped from official status pages.",
+      "Measured from 5 global locations. Not scraped from official status pages.",
   },
 };
 
@@ -78,7 +78,7 @@ export default async function HomePage() {
           for the AI infrastructure.
         </h1>
         <p className="text-base text-[var(--ink-300)] leading-relaxed">
-          Measured from 7 global locations.
+          Measured from 5 global locations.
           <br />
           Not scraped from official status pages.
         </p>

--- a/web/app/providers/page.tsx
+++ b/web/app/providers/page.tsx
@@ -8,11 +8,11 @@ export const metadata: Metadata = {
   title: "All Providers",
   description:
     "Real-time status for 20+ AI API providers. Filter by status and category. " +
-    "Independent monitoring from 7 global locations.",
+    "Independent monitoring from 5 global locations.",
   openGraph: {
     title: "AI API Providers — llmstatus.io",
     description:
-      "Real-time status for 20+ AI API providers monitored from 7 global locations.",
+      "Real-time status for 20+ AI API providers monitored from 5 global locations.",
   },
 };
 
@@ -29,7 +29,7 @@ export default async function ProvidersPage() {
           All monitored providers
         </h1>
         <p className="text-sm text-[var(--ink-400)]">
-          Real API calls from 7 global locations. Updated every 30 s.
+          Real API calls from 5 global locations. Updated every 30 s.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

- Add **rule 6.5 (quality degradation)**: detector queries `probe_type='quality'` probes separately; fires `quality_degradation` (severity=minor) when current 5-minute failure rate exceeds 3× the 24h baseline or surpasses 30% in absolute terms when baseline is unavailable
- Add `POST /v1/admin/test-email?to=<addr>` endpoint protected by `X-Internal-Token` for verifying the Resend email integration end-to-end
- Fix "7 global locations" → "5 global locations" copy (homepage + providers page)
- Fix `TestListProviders_*` unit tests that were missing a `WithLiveStatsReader`, causing providers to be filtered from the response

## Test Plan

- [ ] `go test ./internal/detector/...` — all 30+ detector tests pass including 6 new quality rule tests
- [ ] `go test ./internal/api/...` — all API tests pass
- [ ] `go test ./...` — full suite green
- [ ] Deploy to prod, then: `curl -X POST "https://llmstatus.io/v1/admin/test-email?to=<email>" -H "X-Internal-Token: <secret>"` → verify email received