### PR TITLE
docs: add Claude Code MCP install instructions to API page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ public APIs must add an entry under `## [Unreleased]`.
 ### Added
 - Rule 6.5 (quality degradation): detector now tracks quality probe failure rates and creates `quality_degradation` incidents when the current 5-minute failure rate exceeds 3× the 24-hour baseline or surpasses 30% in absolute terms; `QualityByProvider` query filters `probe_type = 'quality'`
 - `POST /v1/admin/test-email` endpoint (requires `X-Internal-Token`) for verifying the Resend email integration end-to-end
+- Published `@llmstatus/mcp@1.0.0` to npm — MCP server with 6 tools (list_providers, get_provider_status, list_active_incidents, get_incident_detail, get_provider_history, compare_providers)
+- API docs page now includes Claude Code one-line install instruction for the MCP server
 
 ### Fixed
 - Add Redis 7 service to docker-compose; wire api healthcheck dependency — `REDIS_URL` was set in the Ansible env template but no Redis container existed, causing OTP rate limiting to silently fail on first use

--- a/web/app/api/page.tsx
+++ b/web/app/api/page.tsx
@@ -127,10 +127,27 @@ export default function ApiPage() {
         </p>
 
         {/* Installation */}
-        <div className="rounded-lg border border-[var(--ink-600)] overflow-hidden mb-6">
+        {/* Claude Code */}
+        <div className="rounded-lg border border-[var(--ink-600)] overflow-hidden mb-4">
           <div className="px-4 py-3 border-b border-[var(--ink-600)] bg-[var(--canvas-sunken)]">
             <span className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">
-              Claude Desktop — <code className="font-mono normal-case tracking-normal text-[var(--ink-300)]">~/Library/Application Support/Claude/claude_desktop_config.json</code>
+              Claude Code — one-line install
+            </span>
+          </div>
+          <div className="px-4 py-4 space-y-3">
+            <pre className="text-xs font-mono text-[var(--ink-200)] overflow-x-auto leading-relaxed">{`claude mcp add llmstatus -- npx -y @llmstatus/mcp`}</pre>
+            <p className="text-xs text-[var(--ink-500)] leading-relaxed">
+              Adds to the current project (<code className="font-mono text-[var(--ink-400)]">.claude.json</code>).
+              Append <code className="font-mono text-[var(--ink-400)]">--scope global</code> to enable in all projects.
+            </p>
+          </div>
+        </div>
+
+        {/* Claude Desktop */}
+        <div className="rounded-lg border border-[var(--ink-600)] overflow-hidden mb-4">
+          <div className="px-4 py-3 border-b border-[var(--ink-600)] bg-[var(--canvas-sunken)]">
+            <span className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">
+              Claude Desktop — <code className="font-mono normal-case tracking-normal text-[var(--ink-300)]">claude_desktop_config.json</code>
             </span>
           </div>
           <div className="px-4 py-4">
@@ -145,6 +162,7 @@ export default function ApiPage() {
           </div>
         </div>
 
+        {/* Cursor */}
         <div className="rounded-lg border border-[var(--ink-600)] overflow-hidden mb-6">
           <div className="px-4 py-3 border-b border-[var(--ink-600)] bg-[var(--canvas-sunken)]">
             <span className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--ink-400)]">


### PR DESCRIPTION
## Summary

- Add Claude Code one-line install block to the MCP section of the API docs page
- Claude Code config is different from Claude Desktop/Cursor — uses `claude mcp add` CLI instead of manual JSON editing
- Include note about `--scope global` for machine-wide install

## Test Plan

- [ ] Visual check: llmstatus.io/api page shows all three client blocks (Claude Code, Claude Desktop, Cursor)