### PR TITLE
feat: probe deepseek-v4-flash and deepseek-v4-pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ public APIs must add an entry under `## [Unreleased]`.
 ## [Unreleased]
 
 ### Added
+- DeepSeek adapter now probes two models: `deepseek-v4-flash` and `deepseek-v4-pro`; migration 0019 deactivates the old `deepseek-chat`/`deepseek-reasoner` rows and adds the V4 rows; `openAICompatProvider` gains a `compatModels` option for multi-model support
 - Rule 6.5 (quality degradation): detector now tracks quality probe failure rates and creates `quality_degradation` incidents when the current 5-minute failure rate exceeds 3× the 24-hour baseline or surpasses 30% in absolute terms; `QualityByProvider` query filters `probe_type = 'quality'`
 - `POST /v1/admin/test-email` endpoint (requires `X-Internal-Token`) for verifying the Resend email integration end-to-end
 - Published `@llmstatus/mcp@1.0.0` to npm — MCP server with 6 tools (list_providers, get_provider_status, list_active_incidents, get_incident_detail, get_provider_history, compare_providers)

--- a/internal/probes/adapters/compat_provider.go
+++ b/internal/probes/adapters/compat_provider.go
@@ -22,7 +22,8 @@ type openAICompatProvider struct {
 	baseURL    string
 	apiKey     string
 	region     string
-	lightModel string
+	lightModel string   // primary/default model; also the first element when models is empty
+	models     []string // if non-empty, overrides [lightModel] in Models()
 	probeType  string
 	errorMax   int
 	client     *http.Client
@@ -58,8 +59,20 @@ func compatHTTPClient(c *http.Client) compatOption {
 	return func(p *openAICompatProvider) { p.client = c }
 }
 
-func (p *openAICompatProvider) ID() string       { return p.providerID }
-func (p *openAICompatProvider) Models() []string { return []string{p.lightModel} }
+// compatModels overrides the model list returned by Models(). The first entry
+// is also used as the default model for ProbeLightInference.
+func compatModels(models ...string) compatOption {
+	return func(p *openAICompatProvider) { p.models = models }
+}
+
+func (p *openAICompatProvider) ID() string { return p.providerID }
+
+func (p *openAICompatProvider) Models() []string {
+	if len(p.models) > 0 {
+		return p.models
+	}
+	return []string{p.lightModel}
+}
 
 func (p *openAICompatProvider) ProbeLightInference(ctx context.Context, model string) (probes.ProbeResult, error) {
 	return probeOpenAICompat(ctx, p.baseURL, p.apiKey, p.region, p.providerID, p.probeType, p.errorMax, model, p.client)

--- a/internal/probes/adapters/deepseek.go
+++ b/internal/probes/adapters/deepseek.go
@@ -9,7 +9,8 @@ import (
 const (
 	deepseekDefaultBaseURL = "https://api.deepseek.com/v1"
 	deepseekProviderID     = "deepseek"
-	deepseekLightModel     = "deepseek-chat"
+	deepseekFlashModel     = "deepseek-v4-flash"
+	deepseekProModel       = "deepseek-v4-pro"
 	deepseekLightProbeType = "light_inference"
 	deepseekErrorDetailMax = 200
 )
@@ -26,5 +27,10 @@ func WithDeepSeekHTTPClient(c *http.Client) DeepSeekOption { return compatHTTPCl
 // NewDeepSeekProvider returns a probes.Provider backed by api.deepseek.com.
 // DeepSeek exposes an OpenAI-compatible Chat Completions API.
 func NewDeepSeekProvider(apiKey, region string, opts ...DeepSeekOption) probes.Provider {
-	return newOpenAICompatProvider(deepseekProviderID, deepseekDefaultBaseURL, apiKey, region, deepseekLightModel, deepseekLightProbeType, deepseekErrorDetailMax, opts...)
+	baseOpts := []DeepSeekOption{compatModels(deepseekFlashModel, deepseekProModel)}
+	return newOpenAICompatProvider(
+		deepseekProviderID, deepseekDefaultBaseURL, apiKey, region,
+		deepseekFlashModel, deepseekLightProbeType, deepseekErrorDetailMax,
+		append(baseOpts, opts...)...,
+	)
 }

--- a/internal/probes/adapters/deepseek_test.go
+++ b/internal/probes/adapters/deepseek_test.go
@@ -27,8 +27,9 @@ func TestDeepSeek_Identity(t *testing.T) {
 	if got := p.ID(); got != "deepseek" {
 		t.Errorf("ID: got %q, want deepseek", got)
 	}
-	if got := p.Models(); len(got) == 0 || got[0] != "deepseek-chat" {
-		t.Errorf("Models: got %v", got)
+	got := p.Models()
+	if len(got) != 2 || got[0] != "deepseek-v4-flash" || got[1] != "deepseek-v4-pro" {
+		t.Errorf("Models: got %v, want [deepseek-v4-flash deepseek-v4-pro]", got)
 	}
 }
 
@@ -59,7 +60,7 @@ func TestDeepSeek_ProbeLightInference(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			p := NewDeepSeekProvider("sk-fake", "node-1", WithDeepSeekBaseURL(srv.URL))
-			r, err := p.ProbeLightInference(context.Background(), "deepseek-chat")
+			r, err := p.ProbeLightInference(context.Background(), "deepseek-v4-flash")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -90,7 +91,7 @@ func TestDeepSeek_Timeout(t *testing.T) {
 		WithDeepSeekBaseURL(srv.URL),
 		WithDeepSeekHTTPClient(&http.Client{Timeout: 30 * time.Millisecond}),
 	)
-	r, err := p.ProbeLightInference(context.Background(), "deepseek-chat")
+	r, err := p.ProbeLightInference(context.Background(), "deepseek-v4-flash")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/store/migrations/0019_deepseek_v4_models.down.sql
+++ b/store/migrations/0019_deepseek_v4_models.down.sql
@@ -1,0 +1,14 @@
+-- 0019_deepseek_v4_models.down.sql
+
+BEGIN;
+
+DELETE FROM models
+WHERE provider_id = 'deepseek'
+  AND model_id IN ('deepseek-v4-flash', 'deepseek-v4-pro');
+
+UPDATE models
+SET active = TRUE
+WHERE provider_id = 'deepseek'
+  AND model_id IN ('deepseek-chat', 'deepseek-reasoner');
+
+COMMIT;

--- a/store/migrations/0019_deepseek_v4_models.up.sql
+++ b/store/migrations/0019_deepseek_v4_models.up.sql
@@ -1,0 +1,18 @@
+-- 0019_deepseek_v4_models.up.sql — switch DeepSeek probed models to V4 (flash + pro)
+
+BEGIN;
+
+-- Retire the old aliases that are no longer probed.
+UPDATE models
+SET active = FALSE
+WHERE provider_id = 'deepseek'
+  AND model_id IN ('deepseek-chat', 'deepseek-reasoner');
+
+-- Add V4 models.
+INSERT INTO models (provider_id, model_id, display_name, model_type, active)
+VALUES
+    ('deepseek', 'deepseek-v4-flash', 'DeepSeek V4 Flash', 'chat', TRUE),
+    ('deepseek', 'deepseek-v4-pro',   'DeepSeek V4 Pro',   'chat', TRUE)
+ON CONFLICT (provider_id, model_id) DO UPDATE SET active = TRUE;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Add `compatModels` option to `openAICompatProvider` so any OpenAI-compat adapter can declare multiple probe models (previously hard-coded to one)
- Update DeepSeek adapter to probe `deepseek-v4-flash` + `deepseek-v4-pro` instead of the old `deepseek-chat` alias
- Migration 0019 deactivates `deepseek-chat`/`deepseek-reasoner` rows and inserts V4 model rows

## Test plan
- [ ] `go test ./internal/probes/adapters/... -run DeepSeek` — all pass
- [ ] `go test ./... -short` — all pass
- [ ] After API key is available: `go run ./scripts/test_provider deepseek` with real key confirms both models probe successfully
- [ ] Run migration 0019 on staging; verify `SELECT model_id, active FROM models WHERE provider_id = 'deepseek'` shows flash+pro active, chat+reasoner inactive