### PR TITLE
fix: resolve CI lint failures (Go dupl + Web unescaped-entities/setState)

### DIFF
--- a/internal/detector/reader.go
+++ b/internal/detector/reader.go
@@ -71,39 +71,7 @@ func (r *influxReader) ErrorRateByProvider(ctx context.Context, window time.Dura
 		 GROUP BY provider_id`,
 		int(window.Seconds()),
 	)
-
-	resp, err := r.querySQLRaw(ctx, sql)
-	if err != nil {
-		return nil, fmt.Errorf("detector: query influx: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, fmt.Errorf("detector: influx status %d: %s", resp.StatusCode, detail)
-	}
-
-	var rows []struct {
-		ProviderID string  `json:"provider_id"`
-		Total      float64 `json:"total"`
-		Errors     float64 `json:"errors"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
-		return nil, fmt.Errorf("detector: decode response: %w", err)
-	}
-
-	stats := make([]ProbeStats, 0, len(rows))
-	for _, row := range rows {
-		if row.ProviderID == "" {
-			continue
-		}
-		stats = append(stats, ProbeStats{
-			ProviderID: row.ProviderID,
-			Total:      int64(row.Total),
-			Errors:     int64(row.Errors),
-		})
-	}
-	return stats, nil
+	return r.queryProbeStats(ctx, sql, "detector")
 }
 
 func (r *influxReader) LatencyByProvider(ctx context.Context, window time.Duration) ([]LatencyStats, error) {
@@ -211,16 +179,21 @@ func (r *influxReader) QualityByProvider(ctx context.Context, window time.Durati
 		 GROUP BY provider_id`,
 		int(window.Seconds()),
 	)
+	return r.queryProbeStats(ctx, sql, "detector quality")
+}
 
+// queryProbeStats executes sql against InfluxDB and decodes the result into
+// a []ProbeStats slice. errPrefix is prepended to all returned errors.
+func (r *influxReader) queryProbeStats(ctx context.Context, sql, errPrefix string) ([]ProbeStats, error) {
 	resp, err := r.querySQLRaw(ctx, sql)
 	if err != nil {
-		return nil, fmt.Errorf("detector quality: %w", err)
+		return nil, fmt.Errorf("%s: query influx: %w", errPrefix, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, fmt.Errorf("detector quality: influx status %d: %s", resp.StatusCode, detail)
+		return nil, fmt.Errorf("%s: influx status %d: %s", errPrefix, resp.StatusCode, detail)
 	}
 
 	var rows []struct {
@@ -229,7 +202,7 @@ func (r *influxReader) QualityByProvider(ctx context.Context, window time.Durati
 		Errors     float64 `json:"errors"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
-		return nil, fmt.Errorf("detector quality: decode: %w", err)
+		return nil, fmt.Errorf("%s: decode: %w", errPrefix, err)
 	}
 
 	stats := make([]ProbeStats, 0, len(rows))

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -140,7 +140,7 @@ export default function PrivacyPage() {
                 rel="noopener noreferrer"
                 className="text-[var(--ink-300)] hover:text-[var(--ink-100)] transition-colors underline underline-offset-2"
               >
-                Google's Privacy Policy
+                Google&apos;s Privacy Policy
               </a>.
             </span>
           </div>
@@ -153,7 +153,7 @@ export default function PrivacyPage() {
                 rel="noopener noreferrer"
                 className="text-[var(--ink-300)] hover:text-[var(--ink-100)] transition-colors underline underline-offset-2"
               >
-                GitHub's Privacy Statement
+                GitHub&apos;s Privacy Statement
               </a>.
             </span>
           </div>

--- a/web/app/tos/page.tsx
+++ b/web/app/tos/page.tsx
@@ -150,13 +150,13 @@ export default function TosPage() {
       <Section title="Disclaimers">
         <p>
           <strong className="text-[var(--ink-100)]">No warranty.</strong> llmstatus.io is provided
-          "as is" and "as available." We make no warranties, express or implied, regarding accuracy,
+          &ldquo;as is&rdquo; and &ldquo;as available.&rdquo; We make no warranties, express or implied, regarding accuracy,
           completeness, availability, or fitness for a particular purpose.
         </p>
         <p>
           <strong className="text-[var(--ink-100)]">Data is observational.</strong> Probe results
           reflect what our infrastructure observed from specific locations at specific times. They
-          may not reflect all users' experience and should not be used as the sole basis for legal
+          may not reflect all users&apos; experience and should not be used as the sole basis for legal
           or contractual claims against a provider.
         </p>
         <p>

--- a/web/components/ReportButton.tsx
+++ b/web/components/ReportButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { postReport } from "@/app/providers/[id]/actions";
 
 const COOLDOWN_MS = 5 * 60 * 1000;
@@ -22,12 +22,8 @@ interface Props {
 }
 
 export function ReportButton({ providerId, providerName }: Props) {
-  const [reported, setReported] = useState(false);
+  const [reported, setReported] = useState(() => isCoolingDown(providerId));
   const [pending, startTransition] = useTransition();
-
-  useEffect(() => {
-    setReported(isCoolingDown(providerId));
-  }, [providerId]);
 
   function handleClick() {
     if (reported || pending) return;


### PR DESCRIPTION
## Summary
- **Go `dupl`**: Extract `queryProbeStats` helper in `internal/detector/reader.go`; `ErrorRateByProvider` and `QualityByProvider` were 44-line clones differing only in the SQL WHERE clause
- **Web `react/no-unescaped-entities`** (7 errors): Escape apostrophes in `privacy/page.tsx` (`Google's`, `GitHub's`) and tos/page.tsx (`users'`); escape double-quotes in `tos/page.tsx` (`"as is"`, `"as available."`)
- **Web `react-hooks/set-state-in-effect`** (1 error): Replace `useEffect(() => setReported(...), [providerId])` with lazy `useState` initializer in `ReportButton.tsx`

## Why these failed
These were pre-existing errors on `main` that blocked the dependabot PRs (#194 jose patch, #195 eslint bump) from merging — both branches inherit main's lint state.

## Test plan
- [ ] `go test ./internal/detector/... -short` — all pass
- [ ] `npm run lint` in web/ — 0 errors (15 warnings only)
- [ ] CI green on this PR → rebase/merge dependabot PRs #194 and #195