### PR TITLE
fix: goconst violations in api package

### DIFF
--- a/internal/api/badge.go
+++ b/internal/api/badge.go
@@ -78,7 +78,7 @@ func writeBadge(w http.ResponseWriter, label, message, color string) {
 
 func statusColor(status string) string {
 	switch status {
-	case "operational":
+	case statusOperational:
 		return "#4CAF50"
 	case "degraded":
 		return "#FF9800"

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -14,7 +14,9 @@ const (
 	statusOperational = "operational"
 	statusDown        = "down"
 	statusDegraded    = "degraded"
+	severityMinor     = "minor"
 	severityMajor     = "major"
+	severityCritical  = "critical"
 )
 
 // ---- response types ---------------------------------------------------------
@@ -220,7 +222,7 @@ func deriveStatus(providerID string, incMap map[string]pgstore.Incident) (string
 	}
 	id := inc.ID.String()
 	switch inc.Severity {
-	case "critical":
+	case severityCritical:
 		return statusDown, &id
 	case severityMajor:
 		return statusDegraded, &id
@@ -231,11 +233,11 @@ func deriveStatus(providerID string, incMap map[string]pgstore.Incident) (string
 
 func severityRank(s string) int {
 	switch s {
-	case "critical":
+	case severityCritical:
 		return 3
 	case severityMajor:
 		return 2
-	case "minor":
+	case severityMinor:
 		return 1
 	default:
 		return 0

--- a/internal/api/realtime.go
+++ b/internal/api/realtime.go
@@ -155,10 +155,10 @@ func (rm *RealtimeManager) SubscriberCount(channel string) int {
 // handleSubscription processes subscription and unsubscription requests.
 func handleSubscription(client *Client, msg SubscriptionMessage) {
 	switch msg.Type {
-	case "subscribe":
+	case wsTypeSubscribe:
 		client.subscriptions[msg.Topic] = true
 		slog.Info("client subscribed", "topic", msg.Topic)
-	case "unsubscribe":
+	case wsTypeUnsubscribe:
 		delete(client.subscriptions, msg.Topic)
 		slog.Info("client unsubscribed", "topic", msg.Topic)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -157,7 +157,10 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 
 // ---- response helpers -------------------------------------------------------
 
-const cacheTTL = 30
+const (
+	cacheTTL    = 30
+	jsonKeyError = "error"
+)
 
 type meta struct {
 	GeneratedAt time.Time `json:"generated_at"`
@@ -180,7 +183,7 @@ func writeEnvelope(w http.ResponseWriter, data any) {
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {
-	writeJSON(w, status, map[string]string{"error": msg})
+	writeJSON(w, status, map[string]string{jsonKeyError: msg})
 }
 
 // coalesceSlice ensures nil slices become [] in JSON (never null).

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -46,7 +46,7 @@ func (s *Server) getStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	counts := statusCounts{Total: len(providers)}
-	worst := "operational"
+	worst := statusOperational
 	for _, p := range providers {
 		st, _ := deriveStatus(p.ID, incidentByProvider)
 		switch st {

--- a/internal/api/subscriptions.go
+++ b/internal/api/subscriptions.go
@@ -14,7 +14,7 @@ import (
 	pgstore "github.com/llmstatus/llmstatus/internal/store/postgres/gen"
 )
 
-var validSeverities = map[string]bool{"minor": true, "major": true, "critical": true}
+var validSeverities = map[string]bool{severityMinor: true, severityMajor: true, severityCritical: true}
 
 // subUpdateBody is shared between create/update decoders.
 type subUpdateBody struct {

--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -12,6 +12,13 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// WebSocket message type and key constants.
+const (
+	wsKeyType         = "type"
+	wsTypeSubscribe   = "subscribe"
+	wsTypeUnsubscribe = "unsubscribe"
+)
+
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		// Validate origin to prevent CSRF attacks
@@ -192,7 +199,7 @@ func HandleWebSocketWithHub(w http.ResponseWriter, r *http.Request, hub *Hub) {
 	hub.register <- client
 
 	// Send connection confirmation
-	confirmMsg := map[string]string{"type": "connected"}
+	confirmMsg := map[string]string{wsKeyType: "connected"}
 	if err := conn.WriteJSON(confirmMsg); err != nil {
 		slog.Error("websocket: failed to send connection confirmation", "err", err)
 		_ = conn.Close()
@@ -228,15 +235,15 @@ func (c *Client) readPump() {
 		}
 
 		// Process message based on type
-		if msgType, ok := msg["type"].(string); ok {
+		if msgType, ok := msg[wsKeyType].(string); ok {
 			switch msgType {
-			case "subscribe":
+			case wsTypeSubscribe:
 				c.handleSubscribe(msg)
-			case "unsubscribe":
+			case wsTypeUnsubscribe:
 				c.handleUnsubscribe(msg)
 			case "ping":
 				// Send pong response using proper JSON marshaling
-				pongMsg := map[string]string{"type": "pong"}
+				pongMsg := map[string]string{wsKeyType: "pong"}
 				data, err := json.Marshal(pongMsg)
 				if err != nil {
 					slog.Error("websocket: failed to marshal pong message", "err", err)
@@ -244,7 +251,7 @@ func (c *Client) readPump() {
 				}
 				c.send <- data
 			default:
-				slog.Debug("websocket: unknown message type", "type", msgType)
+				slog.Debug("websocket: unknown message type", wsKeyType, msgType)
 			}
 		}
 	}
@@ -287,8 +294,8 @@ func (c *Client) handleSubscribe(msg map[string]interface{}) {
 		if !isValidChannelName(channel) {
 			slog.Warn("websocket: invalid channel name", "channel", channel)
 			errMsg := map[string]interface{}{
-				"type":  "error",
-				"error": "invalid channel name",
+				wsKeyType:    jsonKeyError,
+				jsonKeyError: "invalid channel name",
 			}
 			data, _ := json.Marshal(errMsg)
 			c.send <- data
@@ -302,7 +309,7 @@ func (c *Client) handleSubscribe(msg map[string]interface{}) {
 
 		// Send subscription confirmation
 		confirmMsg := map[string]interface{}{
-			"type":    "subscribed",
+			wsKeyType:   "subscribed",
 			"channel": channel,
 		}
 		data, err := json.Marshal(confirmMsg)
@@ -324,7 +331,7 @@ func (c *Client) handleUnsubscribe(msg map[string]interface{}) {
 
 		// Send unsubscription confirmation
 		confirmMsg := map[string]interface{}{
-			"type":    "unsubscribed",
+			wsKeyType:   "unsubscribed",
 			"channel": channel,
 		}
 		data, err := json.Marshal(confirmMsg)


### PR DESCRIPTION
## Summary
- Add `severityMinor`, `severityCritical` to existing const block in `providers.go`; use in `providers.go`, `subscriptions.go`
- Use existing `statusOperational` constant in `badge.go` and `status.go` (were using raw strings)
- Add `jsonKeyError = "error"` to `server.go`; use in `writeError` and `websocket.go` error messages
- Add `wsKeyType`, `wsTypeSubscribe`, `wsTypeUnsubscribe` to `websocket.go`; use across `websocket.go` and `realtime.go`

These strings each appeared 3+ times, triggering `goconst` in golangci-lint v2.12.1.

## Test plan
- [ ] `go test ./... -short` — all pass
- [ ] CI green → dependabot PRs #194 and #195 can be merged