### PR TITLE
fix: eliminate unused/gosec/gofmt lint violations

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -123,11 +123,11 @@ func (s *Server) adminTestEmail(w http.ResponseWriter, r *http.Request) {
 		Subject: "[llmstatus] Test email — integration check",
 		Text:    "If you received this, the Resend integration is working correctly.",
 	}); err != nil {
-		slog.Error("admin: test email failed", "to", to, "err", err)
+		slog.Error("admin: test email failed", "to", to, "err", err) //nolint:gosec // to is a db-stored email address
 		writeError(w, http.StatusInternalServerError, "send failed: "+err.Error())
 		return
 	}
-	slog.Info("admin: test email sent", "to", to)
+	slog.Info("admin: test email sent", "to", to) //nolint:gosec // to is a db-stored email address
 	writeJSON(w, http.StatusOK, map[string]string{"status": "sent", "to": to})
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -158,7 +158,7 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 // ---- response helpers -------------------------------------------------------
 
 const (
-	cacheTTL    = 30
+	cacheTTL     = 30
 	jsonKeyError = "error"
 )
 

--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -309,7 +309,7 @@ func (c *Client) handleSubscribe(msg map[string]interface{}) {
 
 		// Send subscription confirmation
 		confirmMsg := map[string]interface{}{
-			wsKeyType:   "subscribed",
+			wsKeyType: "subscribed",
 			"channel": channel,
 		}
 		data, err := json.Marshal(confirmMsg)
@@ -331,7 +331,7 @@ func (c *Client) handleUnsubscribe(msg map[string]interface{}) {
 
 		// Send unsubscription confirmation
 		confirmMsg := map[string]interface{}{
-			wsKeyType:   "unsubscribed",
+			wsKeyType: "unsubscribed",
 			"channel": channel,
 		}
 		data, err := json.Marshal(confirmMsg)

--- a/internal/detector/rules.go
+++ b/internal/detector/rules.go
@@ -2,11 +2,11 @@ package detector
 
 // Detection rule identifiers.
 const (
-	RuleProviderDown        = "provider_down"
-	RuleElevatedErrors      = "elevated_errors"
-	RuleLatencyDegradation  = "latency_degradation"
-	RuleRegionalOutage      = "regional_outage"
-	RuleQualityDegradation  = "quality_degradation"
+	RuleProviderDown       = "provider_down"
+	RuleElevatedErrors     = "elevated_errors"
+	RuleLatencyDegradation = "latency_degradation"
+	RuleRegionalOutage     = "regional_outage"
+	RuleQualityDegradation = "quality_degradation"
 
 	downThreshold     = 0.50
 	elevatedThreshold = 0.05
@@ -22,9 +22,9 @@ const (
 
 	// Rule 6.5: fire when quality error rate in current window > qualityDegradationFactor
 	// times the baseline rate, or exceeds qualityAbsoluteThreshold when baseline is zero.
-	qualityDegradationFactor    = 3.0
-	qualityAbsoluteThreshold    = 0.30
-	minQualityProbeCount        = int64(2)
+	qualityDegradationFactor = 3.0
+	qualityAbsoluteThreshold = 0.30
+	minQualityProbeCount     = int64(2)
 )
 
 // Detection is a rule match for a single provider.

--- a/internal/detector/rules_test.go
+++ b/internal/detector/rules_test.go
@@ -461,7 +461,7 @@ func TestRunner_QualityDegradation_CreatesIncident(t *testing.T) {
 	store := &fakeIncidentStore{}
 	r := New(&qualityFakeReader{
 		current:  []ProbeStats{{ProviderID: "openai", Total: 5, Errors: 3}}, // 60% failure
-		baseline: []ProbeStats{},                                             // no baseline → absolute threshold applies
+		baseline: []ProbeStats{},                                            // no baseline → absolute threshold applies
 	}, store, time.Hour)
 	r.runOnce(context.Background())
 

--- a/internal/probes/adapters/compat_provider.go
+++ b/internal/probes/adapters/compat_provider.go
@@ -12,6 +12,12 @@ import (
 	"github.com/llmstatus/llmstatus/internal/probes"
 )
 
+// Shared string constants used across multiple adapter implementations.
+const (
+	chatRoleUser     = "user"
+	probePingContent = "ping"
+)
+
 // compatOption configures an openAICompatProvider at construction time.
 type compatOption func(*openAICompatProvider)
 
@@ -106,7 +112,7 @@ func probeOpenAICompat(ctx context.Context, baseURL, apiKey, region, providerID,
 
 	payload, err := json.Marshal(openaiChatRequest{
 		Model:     model,
-		Messages:  []openaiChatMessage{{Role: "user", Content: "ping"}},
+		Messages:  []openaiChatMessage{{Role: chatRoleUser, Content: probePingContent}},
 		MaxTokens: 1,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add and use `chatRoleUser`/`probePingContent` constants in `compat_provider.go` (fixes `unused` linter)
- Suppress G706 gosec warning in `admin.go` for db-stored email address values
- Fix gofmt alignment in `detector/rules.go`, `server.go`, and `websocket.go`

## Test Plan
- [x] `golangci-lint run ./internal/... ./cmd/... ./pkg/...` → 0 issues
- [x] `go test ./internal/probes/adapters/...` → pass