### PR TITLE
fix: raise InfluxDB query-file-limit to 5000 for 7d/30d history

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     image: influxdb:3-core
     container_name: llmstatus-influx
     restart: unless-stopped
-    command: serve --without-auth
+    command: serve --without-auth --query-file-limit 5000
     environment:
       INFLUXDB3_NODE_IDENTIFIER_PREFIX: ${REGION_ID:-local-dev}
     volumes:


### PR DESCRIPTION
## Problem
Provider detail pages return `{"error":"failed to query history"}` for the 7d and 30d windows. The 24h window works fine.

**Root cause:** InfluxDB 3 Core has a default per-query parquet file scan limit. A 7-day window currently requires scanning 432+ files (Core does not compact files automatically), which exceeds the default cap.

InfluxDB error:
> Query would scan 432 Parquet files, exceeding the file limit. InfluxDB 3 Core caps file access to prevent performance degradation and memory issues. Use a narrower time range, or increase the limit with --query-file-limit

## Fix
Add `--query-file-limit 5000` to the InfluxDB `serve` command. At current write rates (~4-5 files/hour), this covers ~45 days of queries.

## Test Plan
- [x] Identified root cause from InfluxDB container logs
- [ ] After deploy: verify `GET /v1/providers/openai/history?window=7d` returns data
- [ ] After deploy: verify `GET /v1/providers/openai/history?window=30d` returns data