### PR TITLE
fix: persist InfluxDB data across container recreations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     image: influxdb:3-core
     container_name: llmstatus-influx
     restart: unless-stopped
-    command: serve --without-auth --query-file-limit 5000
+    command: serve --without-auth --object-store file --data-dir /var/lib/influxdb3 --query-file-limit 5000
     environment:
       INFLUXDB3_NODE_IDENTIFIER_PREFIX: ${REGION_ID:-local-dev}
     volumes:


### PR DESCRIPTION
## Problem
InfluxDB 3 Core, when started without `--object-store` and `--data-dir`, writes to `~/.influxdb` inside the container (not the bind-mounted volume at `/var/lib/influxdb3`). Every container recreation silently wipes all probe history.

This explains why 7d/30d charts have no data: the history was never persisted.

## Fix
Add `--object-store file --data-dir /var/lib/influxdb3` to the InfluxDB serve command. Data now lands in the bind-mounted directory and survives container recreations.

Also keeps `--query-file-limit 5000` from PR #199 which is needed for 7d/30d queries to run.

## Test Plan
- [ ] After deploy: verify `/data/influx/` on server is no longer empty
- [ ] After 24h: verify 7d history shows yesterday's data