### PR TITLE
fix: set influx data dir to 0777 so container user can write

### DIFF
--- a/deploy/ansible/roles/main-server/tasks/main.yml
+++ b/deploy/ansible/roles/main-server/tasks/main.yml
@@ -90,6 +90,15 @@
     - influx
     - redis
 
+# InfluxDB 3 Core runs as an unprivileged user inside the container; the
+# bind-mounted host directory must be world-writable so it can create the
+# catalog and WAL subdirectories on first boot.
+- name: allow influxdb container user to write data directory
+  file:
+    path: "{{ data_dir }}/influx"
+    state: directory
+    mode: "0777"
+
 # ── App directory ─────────────────────────────────────────────────────────
 - name: create app directory
   file:


### PR DESCRIPTION
## Summary
- InfluxDB 3 Core runs as an unprivileged `influxdb3` user inside the container
- The bind-mounted `/data/influx/` directory was `root:root 0755`, blocking writes
- This caused the container to fail to start with `Permission denied` on catalog init
- Adds a dedicated Ansible task to set mode `0777` on the influx data directory

## Test plan
- [ ] Re-run `deploy-main-server.yml` playbook
- [ ] Confirm InfluxDB container becomes healthy
- [ ] Confirm 7D/30D charts return data after probes accumulate