### PR TITLE
fix: add influxdb gen1-duration and 35d database retention

### DIFF
--- a/deploy/ansible/roles/main-server/tasks/main.yml
+++ b/deploy/ansible/roles/main-server/tasks/main.yml
@@ -216,3 +216,31 @@
   args:
     chdir: "{{ app_dir }}"
   become_user: ubuntu
+
+# ── InfluxDB database retention ───────────────────────────────────────────
+- name: wait for influxdb to be healthy
+  shell: docker inspect --format="{{ '{{' }}.State.Health.Status{{ '}}' }}" llmstatus-influx
+  register: influx_health
+  until: influx_health.stdout == "healthy"
+  retries: 20
+  delay: 5
+  become_user: ubuntu
+  changed_when: false
+
+# Retention is immutable after DB creation. The sentinel file prevents
+# subsequent deploys from dropping the DB once data has accumulated.
+- name: configure probes database with 35-day retention (first run only)
+  shell: |
+    set -e
+    docker exec llmstatus-influx \
+      curl -sf -X DELETE \
+      "http://localhost:8181/api/v3/configure/database?db=probes" || true
+    docker exec llmstatus-influx \
+      curl -sf -X POST \
+      "http://localhost:8181/api/v3/configure/database" \
+      -H "Content-Type: application/json" \
+      -d '{"db":"probes","retention_period":"35d"}'
+    touch {{ data_dir }}/.influx-retention-configured
+  args:
+    creates: "{{ data_dir }}/.influx-retention-configured"
+  become_user: ubuntu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     image: influxdb:3-core
     container_name: llmstatus-influx
     restart: unless-stopped
-    command: serve --without-auth --object-store file --data-dir /var/lib/influxdb3 --query-file-limit 5000
+    command: serve --without-auth --object-store file --data-dir /var/lib/influxdb3 --query-file-limit 5000 --gen1-duration 10m
     environment:
       INFLUXDB3_NODE_IDENTIFIER_PREFIX: ${REGION_ID:-local-dev}
     volumes:


### PR DESCRIPTION
## Summary
- Add `--gen1-duration 10m` to InfluxDB serve command: batches WAL flushes into 10-minute parquet files instead of per-second flushes, reducing file count ~10× (from ~1440/day to ~144/day)
- Add Ansible task to drop and recreate `probes` database with 35-day retention period on first deploy — InfluxDB Core automatically expires and removes old parquet files beyond the retention window
- Sentinel file `{{ data_dir }}/.influx-retention-configured` prevents future deploys from dropping the database once data has accumulated

## Why
- Without compaction (Enterprise-only), parquet files accumulate indefinitely
- With 5-minute probe interval × 4 probe nodes, the 5000-file query limit would be hit again within weeks for 30D queries
- Setting retention at the database level is the correct InfluxDB 3 Core approach

## Test plan
- [ ] Re-run `deploy-main-server.yml` playbook — should show "changed" for the new Ansible tasks
- [ ] Confirm `probes` database exists with `retention_period: 35d`
- [ ] Confirm sentinel file `/data/.influx-retention-configured` exists on server