### PR TITLE
fix: write influx retention sentinel to app_dir not data_dir

### DIFF
--- a/deploy/ansible/roles/main-server/tasks/main.yml
+++ b/deploy/ansible/roles/main-server/tasks/main.yml
@@ -240,7 +240,7 @@
       "http://localhost:8181/api/v3/configure/database" \
       -H "Content-Type: application/json" \
       -d '{"db":"probes","retention_period":"35d"}'
-    touch {{ data_dir }}/.influx-retention-configured
+    touch {{ app_dir }}/.influx-retention-configured
   args:
-    creates: "{{ data_dir }}/.influx-retention-configured"
+    creates: "{{ app_dir }}/.influx-retention-configured"
   become_user: ubuntu


### PR DESCRIPTION
## Summary
- Sentinel file `/data/.influx-retention-configured` failed with Permission denied — `/data/` is root-owned
- Changed sentinel path to `{{ app_dir }}/.influx-retention-configured` which is ubuntu-owned

## Test plan
- [ ] Re-run playbook — configure-probes-database task should succeed